### PR TITLE
Fix tests/lints, add a String alias for `Regex`

### DIFF
--- a/junction-api-types/src/http.rs
+++ b/junction-api-types/src/http.rs
@@ -638,12 +638,12 @@ impl RouteTimeouts {
             backend_request = r1.per_try_timeout.clone().map(|x| x.try_into().unwrap());
         }
         if request.is_some() || backend_request.is_some() {
-            return Some(RouteTimeouts {
-                backend_request: backend_request,
-                request: request,
-            });
+            Some(RouteTimeouts {
+                backend_request,
+                request,
+            })
         } else {
-            return None;
+            None
         }
     }
 }
@@ -710,12 +710,9 @@ impl QueryParamMatch {
                     //regex or maybe just throw an error
                     StringMatch::Exact { value: s.clone() }
                 }
-                Some(MatchPattern::SafeRegex(pfx)) => {
-                    let Some(x) = parse_xds_regex(pfx) else {
-                        return None;
-                    };
-                    StringMatch::RegularExpression { value: x }
-                }
+                Some(MatchPattern::SafeRegex(pfx)) => StringMatch::RegularExpression {
+                    value: parse_xds_regex(pfx)?,
+                },
                 Some(_) | None => {
                     //fixme: raise an error that config is being thrown away
                     return None;
@@ -742,10 +739,9 @@ impl HeaderMatch {
                 StringMatch::Exact { value: s.clone() }
             }
             xds_route::header_matcher::HeaderMatchSpecifier::SafeRegexMatch(pfx) => {
-                let Some(x) = parse_xds_regex(pfx) else {
-                    return None;
-                };
-                StringMatch::RegularExpression { value: x }
+                StringMatch::RegularExpression {
+                    value: parse_xds_regex(pfx)?,
+                }
             }
             _ => {
                 // FIXME: log/record that we are throwing away config
@@ -762,7 +758,7 @@ impl HeaderMatch {
 
 impl PathMatch {
     fn from_xds(path_spec: &xds_route::route_match::PathSpecifier) -> Option<Self> {
-        return match path_spec {
+        match path_spec {
             xds_route::route_match::PathSpecifier::Prefix(p) => {
                 Some(PathMatch::Prefix { value: p.clone() })
             }
@@ -770,16 +766,15 @@ impl PathMatch {
                 Some(PathMatch::Exact { value: p.clone() })
             }
             xds_route::route_match::PathSpecifier::SafeRegex(p) => {
-                let Some(x) = parse_xds_regex(p) else {
-                    return None;
-                };
-                Some(PathMatch::RegularExpression { value: x })
+                Some(PathMatch::RegularExpression {
+                    value: parse_xds_regex(p)?,
+                })
             }
             _ => {
                 // FIXME: log/record that we are throwing away config
                 None
             }
-        };
+        }
     }
 }
 
@@ -790,8 +785,7 @@ impl RouteRetryPolicy {
         let backoff = r
             .retry_back_off
             .as_ref()
-            .map(|r2| r2.base_interval.clone().map(|x| x.try_into().unwrap()))
-            .flatten();
+            .and_then(|r2| r2.base_interval.clone().map(|x| x.try_into().unwrap()));
         Self {
             codes,
             attempts,
@@ -845,16 +839,16 @@ impl SessionAffinityHashParam {
 
 impl SessionAffinityPolicy {
     //only returns session affinity
-    pub fn from_xds(hash_policy: &Vec<xds_route::route_action::HashPolicy>) -> Option<Self> {
+    pub fn from_xds(hash_policy: &[xds_route::route_action::HashPolicy]) -> Option<Self> {
         let hash_params: Vec<_> = hash_policy
             .iter()
             .filter_map(SessionAffinityHashParam::from_xds)
             .collect();
 
-        if hash_params.len() == 0 {
-            return None;
+        if hash_params.is_empty() {
+            None
         } else {
-            return Some(SessionAffinityPolicy { hash_params });
+            Some(SessionAffinityPolicy { hash_params })
         }
     }
 }

--- a/junction-api-types/src/shared.rs
+++ b/junction-api-types/src/shared.rs
@@ -82,11 +82,11 @@ impl<'de> Visitor<'de> for RegexVisitor {
         formatter.write_str("a Regex")
     }
 
-    fn visit_string<E>(self, value: std::string::String) -> Result<Self::Value, E>
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        match Regex::from_str(&value) {
+        match Regex::from_str(value) {
             Ok(s) => Ok(s),
             Err(e) => Err(E::custom(format!("could not parse {}: {}", value, e))),
         }
@@ -413,13 +413,12 @@ impl FromStr for Duration {
         // This Lazy Regex::new should never ever fail, given that the regex is
         // a compile-time constant. But just in case.....
         static RE: Lazy<regex::Regex> = Lazy::new(|| {
-            regex::Regex::new(GEP2257_PATTERN).expect(
-                format!(
+            regex::Regex::new(GEP2257_PATTERN).unwrap_or_else(|_| {
+                panic!(
                     r#"GEP2257 regex "{}" did not compile (this is a bug!)"#,
                     GEP2257_PATTERN
                 )
-                .as_str(),
-            )
+            })
         });
 
         // If the string doesn't match the regex, it's invalid.
@@ -544,11 +543,11 @@ impl<'de> Visitor<'de> for DurationVisitor {
         formatter.write_str("a GEP-2257 Duration as a string")
     }
 
-    fn visit_string<E>(self, value: std::string::String) -> Result<Self::Value, E>
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        match Duration::from_str(&value) {
+        match Duration::from_str(value) {
             Ok(s) => Ok(s),
             Err(e) => Err(E::custom(format!("could not parse {}: {}", value, e))),
         }


### PR DESCRIPTION
Added some tests for StringMatcher and fixed clippy/rustfmt lints. I'll open a follow-up CR to fix our GHA workflows, and added aliases for the Regex string matcher so that `"type": "regex"` works.

Not wedded to the type aliases, felt worth trying.