### PR TITLE
Allow dumping junction routes and backends in addition to xds

### DIFF
--- a/crates/junction-api-types/src/backend.rs
+++ b/crates/junction-api-types/src/backend.rs
@@ -41,6 +41,15 @@ pub enum LbPolicy {
 }
 
 impl LbPolicy {
+    #[doc(hidden)]
+    pub fn is_default_policy(&self) -> bool {
+        match self {
+            // FIXME: only Unspecified should be here
+            LbPolicy::RoundRobin | LbPolicy::Unspecified => true,
+            _ => false,
+        }
+    }
+
     //FIXME: work out what XDS leads to Unspecified being returned
     pub(crate) fn from_xds(cluster: &xds_cluster::Cluster) -> Option<Self> {
         match cluster.lb_policy() {

--- a/crates/junction-api-types/src/http.rs
+++ b/crates/junction-api-types/src/http.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 #[cfg(feature = "typeinfo")]
 use junction_typeinfo::TypeInfo;
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct Route {
@@ -24,6 +24,23 @@ pub struct Route {
 
     /// The route rules that determine whether any URLs match.
     pub rules: Vec<RouteRule>,
+}
+
+impl Route {
+    // FIXME: impl Default and make sure this passes on it
+    #[doc(hidden)]
+    pub fn is_default_route(&self) -> bool {
+        self.rules.len() == 1
+            && self.rules[0].backends.len() == 1
+            && self.rules[0].matches.len() == 1
+            && self.rules[0].matches[0].method.is_none()
+            && self.rules[0].matches[0].headers.is_empty()
+            && self.rules[0].matches[0].query_params.is_empty()
+            && self.rules[0].matches[0].path
+                == Some(PathMatch::Prefix {
+                    value: "".to_string(),
+                })
+    }
 }
 
 /// Defines semantics for matching an HTTP request based on conditions

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -21,7 +21,7 @@ async fn main() {
     )
     .await
     .unwrap();
-    tokio::spawn(client.config_server(8009));
+    tokio::spawn(client.csds_server(8009));
 
     let nginx = Attachment::Service(ServiceAttachment {
         name: "nginx".to_string(),

--- a/crates/junction-core/src/config.rs
+++ b/crates/junction-core/src/config.rs
@@ -1,4 +1,13 @@
+use junction_api_types::backend::Backend;
+
 pub(crate) mod endpoints;
 pub(crate) mod load_balancer;
 pub(crate) use load_balancer::EndpointGroup;
 pub(crate) use load_balancer::LoadBalancer;
+
+/// A [Backend] and the [LoadBalancer] it's configured with.
+#[derive(Debug)]
+pub struct BackendLb {
+    pub backend: Backend,
+    pub load_balancer: LoadBalancer,
+}

--- a/crates/junction-core/src/config/load_balancer.rs
+++ b/crates/junction-core/src/config/load_balancer.rs
@@ -111,7 +111,6 @@ impl Locality {
 
 #[derive(Debug)]
 pub enum LoadBalancer {
-    Unspecified(RoundRobinLb),
     RoundRobin(RoundRobinLb),
     RingHash(RingHashLb),
 }
@@ -126,7 +125,6 @@ impl LoadBalancer {
     ) -> Option<&'ep crate::EndpointAddress> {
         match self {
             LoadBalancer::RoundRobin(lb) => lb.pick_endpoint(locality_endpoints),
-            LoadBalancer::Unspecified(lb) => lb.pick_endpoint(locality_endpoints),
             LoadBalancer::RingHash(lb) => {
                 let hash_params;
                 if !lb.config.hash_params.is_empty() {
@@ -151,7 +149,7 @@ impl LoadBalancer {
         match config {
             LbPolicy::RoundRobin => LoadBalancer::RoundRobin(RoundRobinLb::default()),
             LbPolicy::RingHash(x) => LoadBalancer::RingHash(RingHashLb::new(x)),
-            LbPolicy::Unspecified => LoadBalancer::Unspecified(RoundRobinLb::default()),
+            LbPolicy::Unspecified => LoadBalancer::RoundRobin(RoundRobinLb::default()),
         }
     }
 }
@@ -183,7 +181,7 @@ impl RoundRobinLb {
 /// Envoy, this load balancer ignores endpoint weights.
 ///
 #[derive(Debug)]
-pub(crate) struct RingHashLb {
+pub struct RingHashLb {
     config: RingHashParams,
     ring: RwLock<Ring>,
 }

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -55,10 +55,10 @@ pub use resources::ResourceVersion;
 pub(crate) use resources::{ResourceType, ResourceVec};
 
 pub(crate) mod csds;
+use crate::config::{BackendLb, EndpointGroup};
 
 #[cfg(test)]
 mod test;
-use crate::config;
 
 // FIXME: nonce is global for a conneciton, not per resource type????
 
@@ -121,10 +121,7 @@ impl AdsClient {
     pub fn get_target(
         &self,
         attachment: &Attachment,
-    ) -> (
-        Option<Arc<config::LoadBalancer>>,
-        Option<Arc<config::EndpointGroup>>,
-    ) {
+    ) -> (Option<Arc<BackendLb>>, Option<Arc<EndpointGroup>>) {
         self.cache.get_target(attachment)
     }
 

--- a/crates/junction-core/src/xds/csds.rs
+++ b/crates/junction-core/src/xds/csds.rs
@@ -78,7 +78,7 @@ impl ClientStatusDiscoveryService for Server {
         }
 
         let node = request.node;
-        let generic_xds_configs: Vec<_> = self.cache.iter_any().map(to_generic_config).collect();
+        let generic_xds_configs: Vec<_> = self.cache.iter_xds().map(to_generic_config).collect();
 
         Ok(Response::new(ClientStatusResponse {
             config: vec![ClientConfig {


### PR DESCRIPTION
Allows dumping junction config. To make this easy, BackendLb now exists to pair together a LoadBalancer and a Backend policy, so that we can keep the defaults map and the xDS cache storing the same thing. For everyone's sanity, the defaults map also has Arc values now.