### PR TITLE
Make route resolution stateless

### DIFF
--- a/crates/junction-api-types/src/backend.rs
+++ b/crates/junction-api-types/src/backend.rs
@@ -59,6 +59,10 @@ pub enum LbPolicy {
 }
 
 impl LbPolicy {
+    pub fn is_unspecified(&self) -> bool {
+        matches!(self, Self::Unspecified)
+    }
+
     pub(crate) fn from_xds(cluster: &xds_cluster::Cluster) -> Option<Self> {
         match cluster.lb_policy() {
             // for ROUND_ROBIN, ignore the slow_start_config entirely and return a brand new

--- a/crates/junction-core/src/config.rs
+++ b/crates/junction-core/src/config.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use junction_api_types::backend::Backend;
 
 pub(crate) mod endpoints;
 pub(crate) mod load_balancer;
+use junction_api_types::http::Route;
+use junction_api_types::shared::Target;
 pub(crate) use load_balancer::EndpointGroup;
 pub(crate) use load_balancer::LoadBalancer;
 
@@ -10,4 +15,53 @@ pub(crate) use load_balancer::LoadBalancer;
 pub struct BackendLb {
     pub config: Backend,
     pub load_balancer: LoadBalancer,
+}
+
+pub(crate) trait ConfigCache {
+    fn get_route(&self, target: &Target) -> Option<Arc<Route>>;
+    fn get_backend(&self, target: &Target) -> (Option<Arc<BackendLb>>, Option<Arc<EndpointGroup>>);
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StaticConfig {
+    pub routes: HashMap<String, Arc<Route>>,
+    pub backends: HashMap<String, Arc<BackendLb>>,
+}
+
+impl StaticConfig {
+    pub(crate) fn new(routes: Vec<Route>, backends: Vec<Backend>) -> Self {
+        let routes = routes
+            .into_iter()
+            .map(|x| (x.target.as_listener_xds_name(), Arc::new(x)))
+            .collect();
+
+        let backends = backends
+            .into_iter()
+            .map(|config| {
+                let load_balancer = LoadBalancer::from_config(&config.lb);
+                (
+                    config.target.as_cluster_xds_name(),
+                    Arc::new(BackendLb {
+                        config,
+                        load_balancer,
+                    }),
+                )
+            })
+            .collect();
+
+        Self { routes, backends }
+    }
+}
+
+impl ConfigCache for StaticConfig {
+    fn get_route(&self, target: &Target) -> Option<Arc<Route>> {
+        self.routes.get(&target.as_listener_xds_name()).cloned()
+    }
+
+    fn get_backend(&self, target: &Target) -> (Option<Arc<BackendLb>>, Option<Arc<EndpointGroup>>) {
+        (
+            self.backends.get(&target.as_cluster_xds_name()).cloned(),
+            None,
+        )
+    }
 }

--- a/crates/junction-core/src/config/endpoints.rs
+++ b/crates/junction-core/src/config/endpoints.rs
@@ -4,6 +4,11 @@ use xds_api::pb::envoy::config::{core::v3 as xds_core, endpoint::v3 as xds_endpo
 
 // FIXME: do we need to to support returning filters/rewrites? does supporting
 //        header filters mean adding headers to Endpoint?
+//
+// FIXME: Vec<Endpoints> is probably the wrong thing to return from all our
+// resolve methods. We probably need a struct that has something like a list
+// of primary endpoints to cycle through on retries, and a seprate list of
+// endpoints to mirror traffic to. Figure that out once we support mirroring.
 
 /// An HTTP endpoint to make a request to.
 ///

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use junction_api_types::shared::Target;
 
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
@@ -6,7 +8,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("invalid url: {0}")]
-    InvalidUrl(&'static str),
+    InvalidUrl(Cow<'static, str>),
 
     #[error("invalid route configuration")]
     InvalidRoutes {

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -4,6 +4,8 @@
 mod error;
 mod url;
 
+use std::sync::Arc;
+
 pub use crate::error::{Error, Result};
 pub use crate::url::Url;
 
@@ -21,4 +23,36 @@ mod client;
 mod xds;
 
 pub use client::Client;
+use config::StaticConfig;
+use junction_api_types::http::Route;
+use junction_api_types::shared::Target;
 pub use xds::{ResourceVersion, XdsConfig};
+
+/// Check route resolution.
+///
+/// Resolves a route against a table of routes, returning the chosen [Route],
+/// the index of the rule that matched, and the [Target] selected from the
+/// route.
+///
+/// [Client::resolve_endpoints] resolves routes in exactly the same way as this
+/// function. Use it to test routing configuration without requiring a full
+/// client or connecting to a control plane.
+pub fn check_route(
+    routes: Vec<Route>,
+    method: &http::Method,
+    url: crate::Url,
+    headers: &http::HeaderMap,
+) -> Result<(Route, usize, Target)> {
+    let config = StaticConfig::new(routes, Vec::new());
+    let (_, resolved) =
+        client::resolve_routes(&StaticConfig::default(), &config, method, url, headers)
+            .map_err(|(_, e)| e)?;
+
+    // Drop the other copies of the resolved routes and unwrap the Arc.
+    //
+    // safety: we completely own these routes, and the only copies should be
+    // the one returned and the one in `config` we're dropping here.
+    std::mem::drop(config);
+    let route = Arc::into_inner(resolved.route).unwrap();
+    Ok((route, resolved.rule, resolved.backend))
+}

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -30,8 +30,7 @@ use bytes::Bytes;
 use cache::{Cache, CacheReader};
 use enum_map::EnumMap;
 use futures::TryStreamExt;
-use junction_api_types::{http::Route, shared::Target};
-use std::{io::ErrorKind, sync::Arc, time::Duration};
+use std::{io::ErrorKind, time::Duration};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Endpoint;
@@ -55,7 +54,6 @@ pub use resources::ResourceVersion;
 pub(crate) use resources::{ResourceType, ResourceVec};
 
 pub(crate) mod csds;
-use crate::config::{BackendLb, EndpointGroup};
 
 #[cfg(test)]
 mod test;
@@ -112,17 +110,6 @@ impl AdsClient {
         };
 
         Ok((client, task))
-    }
-
-    pub fn get_route(&self, target: &Target) -> Option<Arc<Route>> {
-        self.cache.get_route(target)
-    }
-
-    pub fn get_target(
-        &self,
-        target: &Target,
-    ) -> (Option<Arc<BackendLb>>, Option<Arc<EndpointGroup>>) {
-        self.cache.get_target(target)
     }
 
     pub fn subscribe(&self, resource_type: ResourceType, name: String) -> Result<(), ()> {

--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -1,5 +1,5 @@
 import typing
-from junction.junction import Junction, default_client
+from junction.junction import Junction, default_client, check_route
 
 from . import config, requests, urllib3
 
@@ -28,4 +28,4 @@ def _get_client(
     return default_client(**client_kwargs)
 
 
-__all__ = (Junction, config, urllib3, requests, default_client)
+__all__ = (Junction, config, urllib3, requests, check_route, default_client)

--- a/junction-python/junction/urllib3.py
+++ b/junction-python/junction/urllib3.py
@@ -68,7 +68,7 @@ class PoolManager(urllib3.PoolManager):
             kw["headers"] = self.headers
 
         # TODO: pass in defaults here - timeouts, routing rules, etc.
-        endpoints = self.junction.resolve_endpoints(
+        endpoints = self.junction.resolve_http(
             method,
             url,
             kw["headers"],


### PR DESCRIPTION
Make route resolution stateless - it now depends on having a primary and default ConfigCache passed in instead of always using the config from the ads cache. This allows unit-testing route config independent of having a connection to an ADS server.

It also allows us to start specifying our own route config behavior in tests, which I haven't done yet. Also changes the name of a couple methods and adds some docs I noticed were missing.