### PR TITLE
Change k8s Service representation, add functions for dumping YAML

### DIFF
--- a/.github/workflows/junction-python-ci.yml
+++ b/.github/workflows/junction-python-ci.yml
@@ -75,7 +75,6 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ env.rust_stable }}
-          
     - uses: Swatinem/rust-cache@v2
 
     - name: Set up Python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "pythonize",
  "serde",
  "serde_json",
+ "serde_yml 0.0.10",
  "tokio",
  "xds-api",
 ]

--- a/crates/junction-api/src/kube/backend.rs
+++ b/crates/junction-api/src/kube/backend.rs
@@ -1,410 +1,317 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use crate::backend::{Backend, LbPolicy};
-use crate::error::{path_from_str, path_str, Error, PathEntry};
+use crate::error::{Error, ErrorContext};
 use crate::shared::{ServiceTarget, Target};
 
-use serde::{Deserialize, Serialize};
-use serde_json::Map;
-use serde_json::Value;
+use k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec};
+use kube::api::ObjectMeta;
+use kube::{Resource, ResourceExt};
+
+const LB_ANNOTATION: &str = "junctionlabs.io/backend.lb";
 
 impl Backend {
-    /// Write this [Backend] config as flattened K/V pairs, into an
-    /// existing map of Kube annotations.
+    /// Generate a partial [Service] from this backend.
     ///
-    /// Annotation keys are always prefixed with `junctionlabs.io`.
-    pub fn as_annotations(&self, annotations: &mut BTreeMap<String, String>) -> Result<(), Error> {
-        let as_json = serde_json::to_value(PartialBackend::borrow(self)).map_err(|_| {
-            Error::new_static("failed to serialize Backend. this is a bug, please file an issue")
-        })?;
-        flatten_value(Some("junctionlabs.io"), &as_json, annotations)
+    /// This service can be used to patch and overwrite an existing Service
+    /// using the `kube` crate or saved as json/yaml and used to patch an
+    /// existing service with `kubectl patch`.
+    pub fn to_service_patch(&self) -> Service {
+        let mut svc = Service {
+            metadata: ObjectMeta {
+                annotations: Some(BTreeMap::new()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let lb_json = serde_json::to_string(&self.lb)
+            .expect("Failed to serialize Backend. this is a bug in Junction, not your code");
+        svc.annotations_mut()
+            .insert(LB_ANNOTATION.to_string(), lb_json);
+
+        match &self.target {
+            Target::DNS(dns) => {
+                svc.spec = Some(ServiceSpec {
+                    type_: Some("ExternalName".to_string()),
+                    external_name: Some(dns.hostname.clone()),
+                    ..Default::default()
+                })
+            }
+            Target::Service(service) => {
+                let meta = svc.meta_mut();
+                meta.name = Some(service.name.clone());
+                meta.namespace = Some(service.namespace.clone());
+
+                svc.spec = Some(ServiceSpec {
+                    ports: Some(vec![ServicePort {
+                        port: service.port.map(|p| p as i32).unwrap_or(80),
+                        protocol: Some("TCP".to_string()),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                })
+            }
+        };
+
+        svc
     }
 
-    /// Parse a [Backend] from flattened K/V pairs.
+    /// Read one or more [Backend]s from a Kubernetes [Service]. A backend will
+    /// be generated for every distinct port the [Service] is configured with.
     ///
-    /// Expects annotation keys to be prefixed with `junctionlabs.io`.
-    pub fn from_annotations(
-        namespace: &str,
-        name: &str,
-        port: Option<u16>,
-        annotations: &BTreeMap<String, String>,
-    ) -> Result<Self, Error> {
-        let value = unflatten_value(annotations.iter(), Some("junctionlabs.io"))?;
+    /// > NOTE: This method currently only supports generating backends with
+    /// > [Service targets][Target::Service]. Support for DNS services coming soon!.
+    pub fn from_service(svc: &Service) -> Result<Vec<Self>, Error> {
+        // FIXME: recognize and generate DNS targets for ExternalName services.
+        let lb: LbPolicy = match svc.annotations().get(LB_ANNOTATION) {
+            Some(s) => serde_json::from_str(s)
+                .map_err(|e| Error::new(format!("failed to deserialize lb: {e}")))?,
+            None => LbPolicy::default(),
+        };
 
-        let partial: PartialBackend = serde_json::from_value(value)
-            .map_err(|e| Error::new(format!("failed to deserialize lb: {e}")).with_field("lb"))?;
+        let (namespace, name) = (
+            as_ref_or_else(&svc.meta().namespace, "missing namespace")
+                .with_fields("meta", "name")?,
+            as_ref_or_else(&svc.meta().name, "missing name").with_fields("meta", "name")?,
+        );
 
-        let backend = partial.into_backend(Target::Service(ServiceTarget {
-            name: name.to_string(),
-            namespace: namespace.to_string(),
-            port,
-        }));
-
-        Ok(backend)
-    }
-}
-
-/// The parts of a [Backend] that should be serialized to/from annotations.
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct PartialBackend<'a> {
-    #[serde(default)]
-    lb: Cow<'a, LbPolicy>,
-}
-
-impl<'a> PartialBackend<'a> {
-    fn borrow(backend: &'a Backend) -> Self {
-        Self {
-            lb: Cow::Borrowed(&backend.lb),
+        let spec = as_ref_or_else(&svc.spec, "missing spec").with_field("spec")?;
+        if matches!(spec.type_.as_deref(), Some("ExternalName")) {
+            return Err(Error::new_static(
+                "ExternalName services are currently unsupported",
+            ));
         }
-    }
 
-    fn into_backend(self, target: Target) -> Backend {
-        Backend {
-            target,
-            lb: self.lb.into_owned(),
-        }
-    }
-}
+        let mut backends = vec![];
+        let ports = as_ref_or_else(&spec.ports, "missing ports").with_fields("spec", "ports")?;
+        match &ports.as_slice() {
+            [svc_port] => {
+                let port = if svc_port.port == 80 {
+                    None
+                } else {
+                    Some(convert_port(svc_port.port).with_field_index("ports", 0)?)
+                };
 
-fn to_annotation_value(value: &Value) -> String {
-    if let Some(str) = value.as_str() {
-        str.to_string()
-    } else {
-        value.to_string()
-    }
-}
+                let target = Target::Service(ServiceTarget {
+                    name: name.to_string(),
+                    namespace: namespace.to_string(),
+                    port,
+                });
+                backends.push(Backend { target, lb })
+            }
+            svc_ports => {
+                for (i, svc_port) in svc_ports.iter().enumerate() {
+                    let port: u16 = convert_port(svc_port.port)
+                        .with_field("port")
+                        .with_field_index("ports", i)?;
 
-fn from_annotation_value(s: &str) -> Value {
-    match Value::from_str(s) {
-        Ok(v) => v,
-        Err(_) => Value::String(s.to_string()),
-    }
-}
-
-fn flatten_value(
-    prefix: Option<&'static str>,
-    value: &Value,
-    dst: &mut BTreeMap<String, String>,
-) -> Result<(), Error> {
-    struct Visitor<'a> {
-        prefix: Option<&'static str>,
-        dst: &'a mut BTreeMap<String, String>,
-        path: Vec<PathEntry>,
-    }
-
-    impl<'a> Visitor<'a> {
-        fn visit_any(&mut self, v: &Value) -> Result<(), Error> {
-            match v {
-                Value::Array(items) => self.visit_array(items)?,
-                Value::Object(m) => self.visit_map(m)?,
-                value => {
-                    let path = path_str(self.prefix, self.path.iter());
-                    self.dst.insert(path, to_annotation_value(value));
+                    let target = Target::Service(ServiceTarget {
+                        name: name.to_string(),
+                        namespace: namespace.to_string(),
+                        port: Some(port),
+                    });
+                    backends.push(Backend {
+                        target,
+                        lb: lb.clone(),
+                    })
                 }
             }
-
-            Ok(())
         }
 
-        fn visit_map(&mut self, map: &Map<String, Value>) -> Result<(), Error> {
-            for (key, v) in map.iter() {
-                self.path.push(PathEntry::from(key.clone()));
-
-                match v {
-                    Value::Array(items) => self.visit_array(items)?,
-                    Value::Object(m) => self.visit_map(m)?,
-                    value => self.visit_any(value)?,
-                }
-
-                self.path.pop();
-            }
-
-            Ok(())
-        }
-
-        fn visit_array(&mut self, array: &[Value]) -> Result<(), Error> {
-            for (i, e) in array.iter().enumerate() {
-                self.path.push(PathEntry::Index(i));
-                self.visit_any(e)?;
-                self.path.pop();
-            }
-
-            Ok(())
-        }
-    }
-
-    match value {
-        Value::Object(map) => {
-            let mut v = Visitor {
-                dst,
-                prefix,
-                path: vec![],
-            };
-            v.visit_map(map)
-        }
-        _ => Err(Error::new_static("only objects can be flattened")),
+        Ok(backends)
     }
 }
 
-fn unflatten_value<'a>(
-    kvs: impl Iterator<Item = (&'a String, &'a String)>,
-    prefix: Option<&'static str>,
-) -> Result<Value, Error> {
-    let mut m = Map::new();
-
-    for (k, v) in kvs {
-        if prefix.map_or(true, |p| k.starts_with(p)) {
-            let mut path = path_from_str(k)?;
-            path.reverse();
-
-            match path.pop() {
-                Some(PathEntry::Field(field)) => {
-                    let value = from_annotation_value(v);
-                    unflatten_object_field(&mut m, path, field.to_string(), value)?
-                }
-                Some(PathEntry::Index(_)) => {
-                    return Err(Error::new_static("can't unflatten a top-level array"))
-                }
-                None => return Err(Error::new_static("empty key path")),
-            }
-        }
-    }
-
-    Ok(Value::Object(m))
+#[inline]
+fn convert_port(port: i32) -> Result<u16, Error> {
+    port.try_into()
+        .map_err(|_| Error::new(format!("port value '{port}' is out of range")))
 }
 
-fn unflatten_object_field(
-    m: &mut Map<String, Value>,
-    mut key_path: Vec<PathEntry>,
-    field: String,
-    value: Value,
-) -> Result<(), Error> {
-    match key_path.pop() {
-        Some(PathEntry::Field(next_field)) => {
-            let entry = m.entry(field).or_insert_with(|| Value::Object(Map::new()));
-            let nested = entry
-                .as_object_mut()
-                .ok_or_else(|| Error::new_static("can't set properties on a non-map field"))?;
-
-            unflatten_object_field(nested, key_path, next_field.to_string(), value)
-        }
-        Some(PathEntry::Index(idx)) => {
-            let entry = m.entry(field).or_insert_with(|| Value::Array(Vec::new()));
-            let nested = entry.as_array_mut().ok_or_else(|| {
-                // TODO: it'd be nice to put the value in this message, but
-                // borrowck is mean
-                Error::new_static("can't set elements on a non-array field")
-            })?;
-
-            unflatten_array_field(nested, key_path, idx, value)
-        }
-        None => {
-            m.insert(field, value);
-            Ok(())
-        }
-    }
-}
-
-fn unflatten_array_field(
-    v: &mut Vec<Value>,
-    mut key_path: Vec<PathEntry>,
-    idx: usize,
-    value: Value,
-) -> Result<(), Error> {
-    if v.len() <= idx {
-        v.resize(idx + 1, Value::Null);
-    }
-
-    match key_path.pop() {
-        Some(PathEntry::Field(field)) => {
-            let m = match &mut v[idx] {
-                v @ Value::Null => {
-                    *v = Value::Object(Map::new());
-                    v.as_object_mut().unwrap()
-                }
-                Value::Object(map) => map,
-                _ => {
-                    return Err(Error::new(format!(
-                        "can't set properties on non-map array element: '{}'",
-                        v[idx]
-                    )))
-                }
-            };
-
-            unflatten_object_field(m, key_path, field.to_string(), value)
-        }
-        Some(PathEntry::Index(nested_idx)) => {
-            let nested = match &mut v[idx] {
-                v @ Value::Null => {
-                    *v = Value::Array(Vec::new());
-                    v.as_array_mut().unwrap()
-                }
-                Value::Array(nested) => nested,
-                _ => {
-                    return Err(Error::new(format!(
-                        "can't set elements on non-array array element: '{}'",
-                        v[idx],
-                    )))
-                }
-            };
-
-            unflatten_array_field(nested, key_path, nested_idx, value)
-        }
-        None => {
-            v[idx] = value;
-            Ok(())
-        }
-    }
+#[inline]
+fn as_ref_or_else<'a, T>(f: &'a Option<T>, message: &'static str) -> Result<&'a T, Error> {
+    f.as_ref().ok_or_else(|| Error::new_static(message))
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{backend::LbPolicy, shared::ServiceTarget};
+    use k8s_openapi::api::core::v1::{ServicePort, ServiceSpec};
+    use kube::api::ObjectMeta;
 
     use super::*;
 
+    macro_rules! annotations {
+        ($($k:expr => $v:expr),* $(,)*) => {{
+            let mut annotations = BTreeMap::new();
+            $(
+                annotations.insert($k.to_string(), $v.to_string());
+            )*
+            annotations
+        }}
+    }
+
     #[test]
-    fn test_backend_empty_annotations() {
-        let annotations = BTreeMap::new();
-        let default_backend = Backend::from_annotations("foo", "bar", None, &annotations).unwrap();
+    fn test_to_service_patch() {
+        let backend = Backend {
+            target: Target::Service(ServiceTarget {
+                name: "foo".to_string(),
+                namespace: "bar".to_string(),
+                port: None,
+            }),
+            lb: LbPolicy::RoundRobin,
+        };
 
         assert_eq!(
-            default_backend,
-            Backend {
+            backend.to_service_patch(),
+            Service {
+                metadata: ObjectMeta {
+                    namespace: Some("bar".to_string()),
+                    name: Some("foo".to_string()),
+                    annotations: Some(
+                        annotations! { "junctionlabs.io/backend.lb" => r#"{"type":"RoundRobin"}"# }
+                    ),
+                    ..Default::default()
+                },
+                spec: Some(ServiceSpec {
+                    ports: Some(vec![ServicePort {
+                        port: 80,
+                        protocol: Some("TCP".to_string()),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                }),
+                status: None,
+            }
+        );
+
+        let backend = Backend {
+            target: Target::DNS(crate::shared::DNSTarget {
+                hostname: "example.com".to_string(),
+                port: None,
+            }),
+            lb: LbPolicy::RoundRobin,
+        };
+
+        assert_eq!(
+            backend.to_service_patch(),
+            Service {
+                metadata: ObjectMeta {
+                    annotations: Some(
+                        annotations! { "junctionlabs.io/backend.lb" => r#"{"type":"RoundRobin"}"# }
+                    ),
+                    ..Default::default()
+                },
+                spec: Some(ServiceSpec {
+                    type_: Some("ExternalName".to_string()),
+                    external_name: Some("example.com".to_string()),
+                    ..Default::default()
+                }),
+                status: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_from_basic_svc() {
+        let svc = Service {
+            metadata: ObjectMeta {
+                namespace: Some("bar".to_string()),
+                name: Some("foo".to_string()),
+                ..Default::default()
+            },
+            spec: Some(ServiceSpec {
+                ports: Some(vec![ServicePort {
+                    port: 80,
+                    protocol: Some("TCP".to_string()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            status: None,
+        };
+
+        assert_eq!(
+            Backend::from_service(&svc).unwrap(),
+            vec![Backend {
                 target: Target::Service(ServiceTarget {
-                    name: "bar".to_string(),
-                    namespace: "foo".to_string(),
-                    port: None
+                    name: "foo".to_string(),
+                    namespace: "bar".to_string(),
+                    port: None,
                 }),
                 lb: LbPolicy::Unspecified,
-            }
+            },]
         )
     }
 
     #[test]
-    fn test_backend_roundtrips() {
-        let web = ServiceTarget {
-            name: "web".to_string(),
-            namespace: "prod".to_string(),
-            port: None,
-        };
-
-        let backend = Backend {
-            target: Target::Service(web.clone()),
-            lb: crate::backend::LbPolicy::RingHash(crate::backend::RingHashParams {
-                min_ring_size: 1024,
-                hash_params: vec![
-                    crate::shared::SessionAffinityHashParam {
-                        terminal: false,
-                        matcher: crate::shared::SessionAffinityHashParamType::Header {
-                            name: "x-user".to_string(),
-                        },
+    fn test_from_svc_multiple_ports() {
+        let svc = Service {
+            metadata: ObjectMeta {
+                namespace: Some("bar".to_string()),
+                name: Some("foo".to_string()),
+                annotations: Some(
+                    annotations! { "junctionlabs.io/backend.lb" => r#"{"type":"RoundRobin"}"# },
+                ),
+                ..Default::default()
+            },
+            spec: Some(ServiceSpec {
+                ports: Some(vec![
+                    ServicePort {
+                        name: Some("http".to_string()),
+                        port: 80,
+                        protocol: Some("TCP".to_string()),
+                        ..Default::default()
                     },
-                    crate::shared::SessionAffinityHashParam {
-                        terminal: false,
-                        matcher: crate::shared::SessionAffinityHashParamType::Header {
-                            name: "x-env".to_string(),
-                        },
+                    ServicePort {
+                        name: Some("https".to_string()),
+                        port: 443,
+                        protocol: Some("TCP".to_string()),
+                        ..Default::default()
                     },
-                ],
+                ]),
+                ..Default::default()
             }),
+            status: None,
         };
 
-        assert_eq!(backend, {
-            let mut annotations = BTreeMap::new();
-            backend.as_annotations(&mut annotations).unwrap();
-            Backend::from_annotations(&web.namespace, &web.name, web.port, &annotations).unwrap()
-        });
-    }
-
-    #[test]
-    fn test_flatten_unflatten() {
-        let value = serde_json::json!({
-            "foo": ["hi", "potato"],
-            "bar": {
-                "baz": {
-                    "one": 1,
-                    "three": [1, 2, 3],
-                    "two": "two",
-                },
-                "hi": false,
-            },
-            "arrays": [
-                ["one", 1],
-                [2, "two"],
-            ],
-        });
-        let expected: BTreeMap<String, String> = BTreeMap::from_iter(
-            [
-                ("arrays[0][0]", "one"),
-                ("arrays[0][1]", "1"),
-                ("arrays[1][0]", "2"),
-                ("arrays[1][1]", "two"),
-                ("bar.baz.one", "1"),
-                ("bar.baz.three[0]", "1"),
-                ("bar.baz.three[1]", "2"),
-                ("bar.baz.three[2]", "3"),
-                ("bar.baz.two", "two"),
-                ("bar.hi", "false"),
-                ("foo[0]", "hi"),
-                ("foo[1]", "potato"),
-            ]
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v.to_string())),
-        );
-
-        let mut flattened = BTreeMap::new();
-        flatten_value(None, &value, &mut flattened).unwrap();
-
-        assert_eq!(flattened, expected);
-        assert_eq!(unflatten_value(flattened.iter(), None).unwrap(), value);
-    }
-
-    #[test]
-    fn test_flatten_unflatten_prefix() {
-        let value = serde_json::json!({
-            "foo": ["hi", "potato"],
-            "bar": {
-                "baz": {
-                    "one": 1,
-                    "three": [1, 2, 3],
-                    "two": "two",
-                },
-                "hi": false,
-            },
-            "arrays": [
-                ["one", 1],
-                [2, "two"],
-            ],
-        });
-        let expected: BTreeMap<String, String> = BTreeMap::from_iter(
-            [
-                ("prefix/arrays[0][0]", "one"),
-                ("prefix/arrays[0][1]", "1"),
-                ("prefix/arrays[1][0]", "2"),
-                ("prefix/arrays[1][1]", "two"),
-                ("prefix/bar.baz.one", "1"),
-                ("prefix/bar.baz.three[0]", "1"),
-                ("prefix/bar.baz.three[1]", "2"),
-                ("prefix/bar.baz.three[2]", "3"),
-                ("prefix/bar.baz.two", "two"),
-                ("prefix/bar.hi", "false"),
-                ("prefix/foo[0]", "hi"),
-                ("prefix/foo[1]", "potato"),
-            ]
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v.to_string())),
-        );
-
-        let mut flattened = BTreeMap::new();
-        flatten_value(Some("prefix"), &value, &mut flattened).unwrap();
-
-        assert_eq!(flattened, expected);
         assert_eq!(
-            unflatten_value(flattened.iter(), Some("prefix")).unwrap(),
-            value
-        );
+            Backend::from_service(&svc).unwrap(),
+            vec![
+                Backend {
+                    target: Target::Service(ServiceTarget {
+                        name: "foo".to_string(),
+                        namespace: "bar".to_string(),
+                        port: Some(80),
+                    }),
+                    lb: LbPolicy::RoundRobin,
+                },
+                Backend {
+                    target: Target::Service(ServiceTarget {
+                        name: "foo".to_string(),
+                        namespace: "bar".to_string(),
+                        port: Some(443),
+                    }),
+                    lb: LbPolicy::RoundRobin,
+                },
+            ]
+        )
+    }
+
+    #[test]
+    fn test_svc_patch_roundtrip() {
+        let backend = Backend {
+            target: Target::Service(ServiceTarget {
+                name: "foo".to_string(),
+                namespace: "bar".to_string(),
+                port: None,
+            }),
+            lb: LbPolicy::RoundRobin,
+        };
+
+        assert_eq!(
+            Backend::from_service(&backend.to_service_patch()).unwrap(),
+            vec![backend.clone()]
+        )
     }
 }

--- a/junction-python/Cargo.toml
+++ b/junction-python/Cargo.toml
@@ -17,6 +17,7 @@ junction-api = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_yml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 xds-api = { workspace = true, features = ["pbjson"] }
 pyo3 = { version = "0.21", features = ["abi3-py38", "serde"] }

--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -1,17 +1,25 @@
 import typing
-from junction.junction import Junction, default_client, check_route
+from junction.junction import (
+    Junction,
+    default_client,
+    check_route,
+    dump_kube_backend,
+    dump_kube_route,
+)
 
 from . import config, requests, urllib3
 
 
-##
-## Purpose of this function is to convert between the non-pyo3
-## route and backend structs by passing them as kwargs
-##
-def _get_client(
+def _default_client(
     default_routes: typing.List[config.Route] | None,
     default_backends: typing.List[config.Backend] | None,
 ) -> Junction:
+    """
+    Return a Junction client with default Routes and Backends.
+
+    Uses the passed defaults to create a new client with default Routes
+    and Backends.
+    """
     client_kwargs = {}
     if default_routes:
         # This check is just in case the user does something dumb as otherwise
@@ -28,4 +36,13 @@ def _get_client(
     return default_client(**client_kwargs)
 
 
-__all__ = (Junction, config, urllib3, requests, check_route, default_client)
+__all__ = (
+    Junction,
+    config,
+    urllib3,
+    requests,
+    check_route,
+    default_client,
+    dump_kube_backend,
+    dump_kube_route,
+)

--- a/junction-python/junction/requests.py
+++ b/junction-python/junction/requests.py
@@ -198,12 +198,12 @@ class Session(requests.Session):
     ) -> None:
         super().__init__()
 
-        if not junction_client:
-            junction_client = junction._get_client(
+        if junction_client:
+            self.junction = junction_client
+        else:
+            self.junction = junction._default_client(
                 default_routes=default_routes, default_backends=default_backends
             )
 
-        self.junction = junction_client
-
-        self.mount("https://", HTTPAdapter(junction_client=junction_client))
-        self.mount("http://", HTTPAdapter(junction_client=junction_client))
+        self.mount("https://", HTTPAdapter(junction_client=self.junction))
+        self.mount("http://", HTTPAdapter(junction_client=self.junction))

--- a/junction-python/junction/urllib3.py
+++ b/junction-python/junction/urllib3.py
@@ -50,7 +50,7 @@ class PoolManager(urllib3.PoolManager):
         if junction_client:
             self.junction = junction_client
         else:
-            self.junction = junction._get_client(
+            self.junction = junction._default_client(
                 default_routes=default_routes, default_backends=default_backends
             )
 


### PR DESCRIPTION
# Saving Backends and Routes to k8s

This PR adds some basic public functions for dumping backends and routes as Kubernetes objects. The python versions dump straight to YAML, while the Rust versions return structured data.

Routes get dumped as straight HTTPRoute objects:

```python
for route in some_cool_routes:
    print("---")
    print(junction.dump_kube_route(route))
```

```bash
$ python dump-routes.py > routes.yaml
$ kubectl apply -f routes.yaml
```

While Backends get dumped as partial Service objects that can be applied with `kubectl patch`. 

```python
with open("backend-patch.yaml", mode='w') as f:
    f.write(junction.dump_backend(backend))
```
```bash
$ python dump-backend.py
$ kubectl patch --patch-file backend-patch.yaml svc/cool-service
```



Once this is done, I can get an `ezbake` released that reads HTTPRoutes and Services and we'll have completed the loop.



# Swapping Service annotation format

In figuring out how to dump yaml, it ended up making sense to swap how we do annotations. Rather than deconstructing a Backend into individual field annotations, let's just shove the entire `lb` config in a single annotation. That makes it much easier to update a Service with `kubectl patch` or remove junction config with `kubectl annotate`.