### PR TITLE
Make empty modules private, and add some basic module doc everywhere

### DIFF
--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -1,3 +1,8 @@
+//! HTTP routing configuration.
+//!
+//! A [Route] specifies the all of the top-level configuration for all HTTP
+//! traffic that matches a particular URL.
+
 use crate::shared::{
     Duration, Fraction, PortNumber, PreciseHostname, Regex, Target, WeightedTarget,
 };
@@ -7,11 +12,18 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "typeinfo")]
 use junction_typeinfo::TypeInfo;
 
+/// High level policy that describes how a request to a specific hostname should
+/// be routed.
+///
+/// Routes contain a target that describes the hostname to match and at least
+/// one [RouteRule]. When a [RouteRule] matches, it also describes where and how
+/// the traffic should be directed to a [Backend](crate::backend::Backend).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct Route {
-    /// The target for this route.
+    /// The target for this route. The target determines the hostnames that map
+    /// to this route.
     pub target: Target,
 
     /// The route rules that determine whether any URLs match.
@@ -458,6 +470,7 @@ pub enum PathModifier {
     ///
     /// ReplacePrefixMatch is only compatible with a `PathPrefix` route match.
     ///
+    /// ```plaintext,no_run
     /// Request Path | Prefix Match | Replace Prefix | Modified Path
     /// -------------|--------------|----------------|----------
     /// /foo/bar     | /foo         | /xyz           | /xyz/bar
@@ -471,6 +484,7 @@ pub enum PathModifier {
     /// /foo         | /foo         | <empty string> | /
     /// /foo/        | /foo         | /              | /
     /// /foo         | /foo         | /              | /
+    /// ```
     ReplacePrefixMatch {
         #[serde(alias = "replacePrefixMatch")]
         replace_prefix_match: String,
@@ -562,7 +576,7 @@ pub struct RequestMirrorFilter {
 
 /// Specifies a way of configuring client retry policy.
 ///
-/// ( Modelled on the forthcoming Gateway API type https://gateway-api.sigs.k8s.io/geps/gep-1731/ )
+/// Modelled on the forthcoming [Gateway API type](https://gateway-api.sigs.k8s.io/geps/gep-1731/).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]

--- a/crates/junction-api/src/kube/http.rs
+++ b/crates/junction-api/src/kube/http.rs
@@ -14,8 +14,6 @@ use crate::shared::Regex;
 
 impl crate::http::Route {
     /// Convert an [HTTPRouteSpec] into a [Route][crate::http::Route].
-    ///
-    /// This is an alias for [HTTPRouteSpec::try_into] or [Self::try_from].
     #[inline]
     pub fn from_gateway_httproute(route_spec: &HTTPRouteSpec) -> Result<crate::http::Route, Error> {
         route_spec.try_into()
@@ -23,8 +21,6 @@ impl crate::http::Route {
 
     /// Convert this [Route][crate::http::Route] into a Gateway API
     /// [HTTPRouteSpec].
-    ///
-    /// This is an alias for [HTTPRouteSpec::try_from] or [Self::try_into].
     #[inline]
     pub fn to_gateway_httproute_spec(&self) -> Result<HTTPRouteSpec, Error> {
         self.try_into()

--- a/crates/junction-api/src/lib.rs
+++ b/crates/junction-api/src/lib.rs
@@ -1,5 +1,14 @@
-mod error;
+//! Junction API Configuration.
+//!
+//! These types let you express routing and load balancing configuration as data
+//! structures. The `kube` and `xds` features of this crate let you convert
+//! Junction configuration to Kubernetes objects and xDS resources respectively.
+//!
+//! Use this crate directly if you're looking to build and export configuration.
+//! Use the `junction-client` crate if you want to make requests and resolve
+//! addresses with Junction.
 
+mod error;
 pub use error::Error;
 
 pub mod backend;
@@ -7,10 +16,10 @@ pub mod http;
 pub mod shared;
 
 #[cfg(feature = "xds")]
-pub mod xds;
+mod xds;
 
 #[cfg(feature = "kube")]
-pub mod kube;
+mod kube;
 
 macro_rules! value_or_default {
     ($value:expr, $default:expr) => {

--- a/crates/junction-api/src/shared.rs
+++ b/crates/junction-api/src/shared.rs
@@ -1,3 +1,5 @@
+//! Shared configuration.
+
 use core::fmt;
 use kube::core::Duration as KubeDuration;
 use once_cell::sync::Lazy;
@@ -30,8 +32,9 @@ pub struct Fraction {
     pub denominator: Option<i32>,
 }
 
-/// A regular expression that will be processed by Rust's standard library
-/// (https://docs.rs/regex/latest/regex/)
+/// A regular expression.
+///
+/// `Regex` has same syntax and semantics as Rust's [`regex` crate](https://docs.rs/regex/latest/regex/).
 #[derive(Clone)]
 pub struct Regex(regex::Regex);
 
@@ -117,8 +120,8 @@ impl PartialEq for Regex {
     }
 }
 
-/// A duration type where parsing and formatting obey the k8s Gateway API GEP-2257
-/// (https://gateway-api.sigs.k8s.io/geps/gep-2257).
+/// A duration type where parsing and formatting obey the k8s
+/// [Gateway API GEP-2257](https://gateway-api.sigs.k8s.io/geps/gep-2257).
 ///
 /// This means when parsing from a string, the string must match `^([0-9]{1,5}(h|m|s|ms)){1,4}$` and
 /// is otherwise parsed the same way that Go's `time.ParseDuration` parses durations.


### PR DESCRIPTION
Cleaned up some modules that didn't need to be public, added some very basic rustdoc everywhere, and fixed a bunch of broken links.