### PR TITLE
Move public types to top level, hide the shared module

### DIFF
--- a/crates/junction-api-gen/src/main.rs
+++ b/crates/junction-api-gen/src/main.rs
@@ -8,10 +8,9 @@ use junction_typeinfo::TypeInfo as _;
 /// This is not a general purpose tool.
 fn main() {
     let items = vec![
-        junction_api::shared::Fraction::item(),
-        junction_api::shared::WeightedTarget::item(),
-        junction_api::shared::Target::item(),
-        junction_api::shared::SessionAffinityHashParam::item(),
+        junction_api::Target::item(),
+        junction_api::Fraction::item(),
+        junction_api::http::WeightedTarget::item(),
         junction_api::http::RouteTimeouts::item(),
         junction_api::http::RouteRetry::item(),
         junction_api::http::HeaderValue::item(),
@@ -28,9 +27,10 @@ fn main() {
         // junction_api::http::RequestRedirectFilter::item(),
         // junction_api::http::UrlRewriteFilter::item(),
         // junction_api::http::RouteFilter::item(),
-        junction_api::shared::SessionAffinity::item(),
         junction_api::http::RouteRule::item(),
         junction_api::http::Route::item(),
+        junction_api::backend::SessionAffinityHashParam::item(),
+        junction_api::backend::SessionAffinity::item(),
         junction_api::backend::LbPolicy::item(),
         junction_api::backend::Backend::item(),
     ];

--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -3,8 +3,9 @@
 //! A [Route] specifies the all of the top-level configuration for all HTTP
 //! traffic that matches a particular URL.
 
-use crate::shared::{
-    Duration, Fraction, PortNumber, PreciseHostname, Regex, Target, WeightedTarget,
+use crate::{
+    shared::{Duration, Fraction, Regex},
+    PortNumber, PreciseHostname, Target,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -591,6 +592,22 @@ pub struct RouteRetry {
     pub backoff: Option<Duration>,
 }
 
+const fn default_weight() -> u32 {
+    1
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
+pub struct WeightedTarget {
+    #[serde(default = "default_weight")]
+    pub weight: u32,
+
+    #[serde(flatten)]
+    pub target: Target,
+    //Todo: gateway API also allows filters here under an extended support condition we need to
+    // decide whether this is one where its simpler just to drop it.
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -601,7 +618,8 @@ mod tests {
     use super::*;
     use crate::{
         http::{HeaderMatch, RouteRule},
-        shared::{DNSTarget, Regex, ServiceTarget, Target, WeightedTarget},
+        shared::Regex,
+        DNSTarget, ServiceTarget, Target,
     };
 
     #[test]

--- a/crates/junction-api/src/kube/backend.rs
+++ b/crates/junction-api/src/kube/backend.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::backend::{Backend, LbPolicy};
 use crate::error::{Error, ErrorContext};
-use crate::shared::{ServiceTarget, Target};
+use crate::{ServiceTarget, Target};
 
 use k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec};
 use kube::api::ObjectMeta;
@@ -139,6 +139,8 @@ mod test {
     use k8s_openapi::api::core::v1::{ServicePort, ServiceSpec};
     use kube::api::ObjectMeta;
 
+    use crate::DNSTarget;
+
     use super::*;
 
     macro_rules! annotations {
@@ -186,7 +188,7 @@ mod test {
         );
 
         let backend = Backend {
-            target: Target::DNS(crate::shared::DNSTarget {
+            target: Target::DNS(DNSTarget {
                 hostname: "example.com".to_string(),
                 port: None,
             }),

--- a/crates/junction-api/src/lib.rs
+++ b/crates/junction-api/src/lib.rs
@@ -8,12 +8,17 @@
 //! Use the `junction-client` crate if you want to make requests and resolve
 //! addresses with Junction.
 
+#[cfg(any(feature = "kube", feature = "xds"))]
 mod error;
+
+#[cfg(any(feature = "kube", feature = "xds"))]
 pub use error::Error;
 
 pub mod backend;
 pub mod http;
-pub mod shared;
+
+mod shared;
+pub use shared::{Duration, Fraction, Regex};
 
 #[cfg(feature = "xds")]
 mod xds;
@@ -21,10 +26,243 @@ mod xds;
 #[cfg(feature = "kube")]
 mod kube;
 
+#[cfg(feature = "typeinfo")]
+use junction_typeinfo::TypeInfo;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "xds")]
 macro_rules! value_or_default {
     ($value:expr, $default:expr) => {
         $value.as_ref().map(|v| v.value).unwrap_or($default)
     };
 }
 
+#[cfg(feature = "xds")]
 pub(crate) use value_or_default;
+
+/// The fully qualified domain name of a network host. This matches the RFC 1123 definition of a
+/// hostname with 1 notable exception that numeric IP addresses are not allowed.
+pub type PreciseHostname = String;
+
+/// Defines a network port.
+pub type PortNumber = u16;
+
+#[derive(
+    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, JsonSchema, PartialOrd, Ord,
+)]
+#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
+pub struct ServiceTarget {
+    ///
+    /// The name of the Kubernetes Service
+    ///
+    pub name: String,
+
+    ///
+    /// The namespace of the Kubernetes service. FIXME(namespace): what should the semantic be when
+    /// this is not specified: default, namespace of client, namespace of EZbake?
+    ///
+    pub namespace: String,
+
+    ///
+    /// The port number of the Kubernetes service to target/ attach to.
+    ///
+    /// When attaching policies, if it is not specified, the target will apply to all connections
+    /// that don't have a specific port specified.
+    ///
+    /// When being used to lookup a backend after a matched rule, if it is not specified then it
+    /// will use the same port as the incoming request
+    ///
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<PortNumber>,
+}
+
+#[derive(
+    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, JsonSchema, PartialOrd, Ord,
+)]
+#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
+pub struct DNSTarget {
+    ///
+    /// The DNS Name to target/attach to
+    ///
+    pub hostname: PreciseHostname,
+
+    ///
+    /// The port number to target/attach to.
+    ///
+    /// When attaching policies, if it is not specified, the target will apply to all connections
+    /// that don't have a specific port specified.
+    ///
+    /// When being used to lookup a backend after a matched rule, if it is not specified then it
+    /// will use the same port as the incoming request
+    ///
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<PortNumber>,
+}
+
+#[derive(
+    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, JsonSchema, PartialOrd, Ord,
+)]
+#[serde(tag = "type")]
+#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
+pub enum Target {
+    DNS(DNSTarget),
+
+    #[serde(untagged)]
+    Service(ServiceTarget),
+}
+
+static KUBE_SERVICE_SUFFIX: &str = ".svc.cluster.local";
+
+impl std::fmt::Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.as_hostname())?;
+
+        if let Some(port) = self.port() {
+            f.write_fmt(format_args!(":{port}"))?;
+        }
+
+        Ok(())
+    }
+}
+
+///
+///  FIXME(ports): nothing with ports here will work until we move to xdstp
+///
+///  FIXME(DNS): For kube service hostnames, forcing the use of the ".svc.cluster.local" suffix is
+///  icky,in that it stops the current k8s behavior of clients sending a request to
+///  http://service_name, and having the namespace resolved based on where the client is running.
+///
+///  However without it, we are going to have a hard time here saying when an incoming hostname is
+///  targeted at DNS, vs when it is targeted at a kube service. That might not be a problem though,
+///  in that if we can process XDS NACKs, we can use something at a higher level to work out what it
+///  is.
+///
+///  So punting thinking more about this until we support DNS properly.
+///
+impl Target {
+    pub fn as_hostname(&self) -> String {
+        match self {
+            Target::DNS(c) => c.hostname.clone(),
+            Target::Service(c) => format!("{}.{}{}", c.name, c.namespace, KUBE_SERVICE_SUFFIX),
+        }
+    }
+
+    pub fn from_hostname(hostname: &str, port: Option<u16>) -> Self {
+        if hostname.ends_with(KUBE_SERVICE_SUFFIX) {
+            let mut parts = hostname.split('.');
+            let name = parts.next().unwrap().to_string();
+            let namespace = parts.next().unwrap().to_string();
+            Target::Service(ServiceTarget {
+                name,
+                namespace,
+                port,
+            })
+        } else {
+            Target::DNS(DNSTarget {
+                hostname: hostname.to_string(),
+                port,
+            })
+        }
+    }
+
+    // FIXME(DNS): no reason we cannot support DNS here, but likely it should be determined by whats
+    // in the cluster config so passed as a extra parameter
+    #[cfg(feature = "xds")]
+    pub fn from_cluster_xds_name(name: &str) -> Result<Self, Error> {
+        let parts: Vec<&str> = name.split('/').collect();
+        if parts.len() == 3 && parts[2].eq("cluster") {
+            Ok(Target::Service(ServiceTarget {
+                name: parts[1].to_string(),
+                namespace: parts[0].to_string(),
+                port: None,
+            }))
+        } else {
+            Err(Error::new_static("unable to cluster name"))
+        }
+    }
+
+    pub fn xds_cluster_name(&self) -> String {
+        match self {
+            // FIXME: this is wrong
+            Target::DNS(c) => c.hostname.clone(),
+            Target::Service(c) => format!("{}/{}/cluster", c.namespace, c.name),
+        }
+    }
+
+    pub fn xds_endpoints_name(&self) -> String {
+        match self {
+            // FIXME: this is wrong
+            Target::DNS(c) => c.hostname.clone(),
+            Target::Service(c) => format!("{}/{}/endpoints", c.namespace, c.name),
+        }
+    }
+
+    pub fn from_listener_xds_name(name: &str) -> Option<Self> {
+        //for now, the listener name is just the hostname
+        Some(Self::from_hostname(name, None))
+    }
+
+    pub fn xds_listener_name(&self) -> String {
+        //FIXME(ports): for now this is just the hostname, with no support for port
+        self.as_hostname()
+    }
+
+    pub fn xds_default_listener_name(&self) -> String {
+        match self {
+            Target::DNS(c) => format!("{hostname}/default", hostname = c.hostname),
+            Target::Service(c) => {
+                format!("{}.{}.junction.default", c.name, c.namespace)
+            }
+        }
+    }
+
+    pub fn port(&self) -> Option<u16> {
+        match self {
+            Target::DNS(c) => c.port,
+            //FIXME(namespace): work out what to do if namespace is optional
+            Target::Service(c) => c.port,
+        }
+    }
+
+    pub fn with_port(&self, port: u16) -> Self {
+        match self {
+            Target::DNS(c) => Target::DNS(DNSTarget {
+                port: Some(port),
+                hostname: c.hostname.clone(),
+            }),
+
+            Target::Service(c) => Target::Service(ServiceTarget {
+                port: Some(port),
+                name: c.name.clone(),
+                namespace: c.namespace.clone(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_target {
+
+    use crate::{ServiceTarget, Target};
+    use serde_json::json;
+
+    #[test]
+    fn test_parses_target() {
+        let target = json!({
+            "type": "service",
+            "name": "foo",
+            "namespace": "potato",
+        });
+
+        assert_eq!(
+            serde_json::from_value::<Target>(target).unwrap(),
+            Target::Service(ServiceTarget {
+                name: "foo".to_string(),
+                namespace: "potato".to_string(),
+                port: None
+            }),
+        )
+    }
+}

--- a/crates/junction-api/src/shared.rs
+++ b/crates/junction-api/src/shared.rs
@@ -3,7 +3,6 @@
 use core::fmt;
 use kube::core::Duration as KubeDuration;
 use once_cell::sync::Lazy;
-use regex;
 use schemars::JsonSchema;
 use serde::de::{self, Visitor};
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
@@ -13,14 +12,8 @@ use std::time::Duration as StdDuration;
 #[cfg(feature = "typeinfo")]
 use junction_typeinfo::TypeInfo;
 
+#[cfg(feature = "xds")]
 use crate::error::Error;
-
-/// The fully qualified domain name of a network host. This matches the RFC 1123 definition of a
-/// hostname with 1 notable exception that numeric IP addresses are not allowed.
-pub type PreciseHostname = String;
-
-/// Defines a network port.
-pub type PortNumber = u16;
 
 /// A fraction, expressed as a numerator and a denominator.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -171,7 +164,7 @@ impl From<Duration> for StdDuration {
 /// sure that the incoming duration is valid according to GEP-2257.
 ///
 /// ```rust
-/// use junction_api::shared::Duration;
+/// use junction_api::Duration;
 /// use std::convert::TryFrom;
 /// use std::time::Duration as StdDuration;
 ///
@@ -215,7 +208,7 @@ impl TryFrom<StdDuration> for Duration {
 /// sure that the incoming duration is valid according to GEP-2257.
 ///
 /// ```rust
-/// use junction_api::shared::Duration;
+/// use junction_api::Duration;
 /// use std::convert::TryFrom;
 /// use std::str::FromStr;
 /// use kube::core::Duration as KubeDuration;
@@ -352,7 +345,7 @@ impl Duration {
 /// went wrong.
 ///
 /// ```rust
-/// use junction_api::shared::Duration;
+/// use junction_api::Duration;
 /// use std::str::FromStr;
 ///
 /// let duration = Duration::from_str("1h");
@@ -419,7 +412,7 @@ impl FromStr for Duration {
 ///   unit first.
 ///
 /// ```rust
-/// use junction_api::shared::Duration;
+/// use junction_api::Duration;
 /// use std::fmt::Display;
 ///
 /// // Zero-valued durations are always formatted as "0s".
@@ -596,8 +589,6 @@ impl TryFrom<Duration> for xds_api::pb::google::protobuf::Duration {
 #[cfg(test)]
 mod test_duration {
     use super::*;
-
-    use serde_json;
 
     #[test]
     /// Duration should deserialize from strings, an int number of seconds, or a
@@ -858,296 +849,5 @@ mod test_duration {
                 expected
             );
         }
-    }
-}
-
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, JsonSchema, PartialOrd, Ord,
-)]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub struct ServiceTarget {
-    ///
-    /// The name of the Kubernetes Service
-    ///
-    pub name: String,
-
-    ///
-    /// The namespace of the Kubernetes service. FIXME(namespace): what should the semantic be when
-    /// this is not specified: default, namespace of client, namespace of EZbake?
-    ///
-    pub namespace: String,
-
-    ///
-    /// The port number of the Kubernetes service to target/ attach to.
-    ///
-    /// When attaching policies, if it is not specified, the target will apply to all connections
-    /// that don't have a specific port specified.
-    ///
-    /// When being used to lookup a backend after a matched rule, if it is not specified then it
-    /// will use the same port as the incoming request
-    ///
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub port: Option<PortNumber>,
-}
-
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, JsonSchema, PartialOrd, Ord,
-)]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub struct DNSTarget {
-    ///
-    /// The DNS Name to target/attach to
-    ///
-    pub hostname: PreciseHostname,
-
-    ///
-    /// The port number to target/attach to.
-    ///
-    /// When attaching policies, if it is not specified, the target will apply to all connections
-    /// that don't have a specific port specified.
-    ///
-    /// When being used to lookup a backend after a matched rule, if it is not specified then it
-    /// will use the same port as the incoming request
-    ///
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub port: Option<PortNumber>,
-}
-
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, JsonSchema, PartialOrd, Ord,
-)]
-#[serde(tag = "type")]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub enum Target {
-    DNS(DNSTarget),
-
-    #[serde(untagged)]
-    Service(ServiceTarget),
-}
-
-static KUBE_SERVICE_SUFFIX: &str = ".svc.cluster.local";
-
-impl std::fmt::Display for Target {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.as_hostname())?;
-
-        if let Some(port) = self.port() {
-            f.write_fmt(format_args!(":{port}"))?;
-        }
-
-        Ok(())
-    }
-}
-
-///
-///  FIXME(ports): nothing with ports here will work until we move to xdstp
-///
-///  FIXME(DNS): For kube service hostnames, forcing the use of the ".svc.cluster.local" suffix is
-///  icky,in that it stops the current k8s behavior of clients sending a request to
-///  http://service_name, and having the namespace resolved based on where the client is running.
-///
-///  However without it, we are going to have a hard time here saying when an incoming hostname is
-///  targeted at DNS, vs when it is targeted at a kube service. That might not be a problem though,
-///  in that if we can process XDS NACKs, we can use something at a higher level to work out what it
-///  is.
-///
-///  So punting thinking more about this until we support DNS properly.
-///
-impl Target {
-    pub fn as_hostname(&self) -> String {
-        match self {
-            Target::DNS(c) => c.hostname.clone(),
-            Target::Service(c) => format!("{}.{}{}", c.name, c.namespace, KUBE_SERVICE_SUFFIX),
-        }
-    }
-
-    pub fn from_hostname(hostname: &str, port: Option<u16>) -> Self {
-        if hostname.ends_with(KUBE_SERVICE_SUFFIX) {
-            let mut parts = hostname.split('.');
-            let name = parts.next().unwrap().to_string();
-            let namespace = parts.next().unwrap().to_string();
-            Target::Service(ServiceTarget {
-                name,
-                namespace,
-                port,
-            })
-        } else {
-            Target::DNS(DNSTarget {
-                hostname: hostname.to_string(),
-                port,
-            })
-        }
-    }
-
-    // FIXME(DNS): no reason we cannot support DNS here, but likely it should be determined by whats
-    // in the cluster config so passed as a extra parameter
-    pub fn from_cluster_xds_name(name: &str) -> Result<Self, Error> {
-        let parts: Vec<&str> = name.split('/').collect();
-        if parts.len() == 3 && parts[2].eq("cluster") {
-            Ok(Target::Service(ServiceTarget {
-                name: parts[1].to_string(),
-                namespace: parts[0].to_string(),
-                port: None,
-            }))
-        } else {
-            Err(Error::new_static("unable to cluster name"))
-        }
-    }
-
-    pub fn xds_cluster_name(&self) -> String {
-        match self {
-            // FIXME: this is wrong
-            Target::DNS(c) => c.hostname.clone(),
-            Target::Service(c) => format!("{}/{}/cluster", c.namespace, c.name),
-        }
-    }
-
-    pub fn xds_endpoints_name(&self) -> String {
-        match self {
-            // FIXME: this is wrong
-            Target::DNS(c) => c.hostname.clone(),
-            Target::Service(c) => format!("{}/{}/endpoints", c.namespace, c.name),
-        }
-    }
-
-    pub fn from_listener_xds_name(name: &str) -> Option<Self> {
-        //for now, the listener name is just the hostname
-        Some(Self::from_hostname(name, None))
-    }
-
-    pub fn xds_listener_name(&self) -> String {
-        //FIXME(ports): for now this is just the hostname, with no support for port
-        self.as_hostname()
-    }
-
-    pub fn xds_default_listener_name(&self) -> String {
-        match self {
-            Target::DNS(c) => format!("{hostname}/default", hostname = c.hostname),
-            Target::Service(c) => {
-                format!("{}.{}.junction.default", c.name, c.namespace)
-            }
-        }
-    }
-
-    pub fn port(&self) -> Option<u16> {
-        match self {
-            Target::DNS(c) => c.port,
-            //FIXME(namespace): work out what to do if namespace is optional
-            Target::Service(c) => c.port,
-        }
-    }
-
-    pub fn with_port(&self, port: u16) -> Self {
-        match self {
-            Target::DNS(c) => Target::DNS(DNSTarget {
-                port: Some(port),
-                hostname: c.hostname.clone(),
-            }),
-
-            Target::Service(c) => Target::Service(ServiceTarget {
-                port: Some(port),
-                name: c.name.clone(),
-                namespace: c.namespace.clone(),
-            }),
-        }
-    }
-}
-
-const fn default_weight() -> u32 {
-    1
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub struct WeightedTarget {
-    #[serde(default = "default_weight")]
-    pub weight: u32,
-
-    #[serde(flatten)]
-    pub target: Target,
-    //Todo: gateway API also allows filters here under an extended support condition we need to
-    // decide whether this is one where its simpler just to drop it.
-}
-
-#[cfg(test)]
-mod test_target {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_parses_target() {
-        let target = json!({
-            "type": "service",
-            "name": "foo",
-            "namespace": "potato",
-        });
-
-        assert_eq!(
-            serde_json::from_value::<Target>(target).unwrap(),
-            Target::Service(ServiceTarget {
-                name: "foo".to_string(),
-                namespace: "potato".to_string(),
-                port: None
-            }),
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
-#[serde(tag = "type")]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub enum SessionAffinityHashParamType {
-    /// Hash the value of a header. If the header has multiple values, they will all be used as hash
-    /// input.
-    #[serde(alias = "header")]
-    Header {
-        /// The name of the header to use as hash input.
-        name: String,
-    },
-}
-
-// FIXME: Ben votes to skip the extra "affinity" naming here as its redundant
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub struct SessionAffinityHashParam {
-    /// Whether to stop immediately after hashing this value.
-    ///
-    /// This is useful if you want to try to hash a value, and then fall back to another as a
-    /// default if it wasn't set.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub terminal: bool,
-
-    #[serde(flatten)]
-    pub matcher: SessionAffinityHashParamType,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, JsonSchema)]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub struct SessionAffinity {
-    #[serde(
-        default,
-        skip_serializing_if = "Vec::is_empty",
-        alias = "hashParams",
-        alias = "HashParams"
-    )]
-    pub hash_params: Vec<SessionAffinityHashParam>,
-}
-
-#[cfg(test)]
-mod test_session_affinity {
-    use crate::shared::SessionAffinity;
-    use serde_json::json;
-
-    #[test]
-    fn parses_session_affinity_policy() {
-        let test_json = json!({
-            "hash_params": [
-                { "type": "Header", "name": "FOO",  "terminal": true },
-                { "type": "Header", "name": "FOO"}
-            ]
-        });
-        let obj: SessionAffinity = serde_json::from_value(test_json.clone()).unwrap();
-        let output_json = serde_json::to_value(obj).unwrap();
-        assert_eq!(test_json, output_json);
     }
 }

--- a/crates/junction-api/src/xds/http.rs
+++ b/crates/junction-api/src/xds/http.rs
@@ -4,9 +4,10 @@ use crate::{
     error::{Error, ErrorContext},
     http::{
         HeaderMatch, Method, PathMatch, QueryParamMatch, Route, RouteMatch, RouteRetry, RouteRule,
-        RouteTimeouts,
+        RouteTimeouts, WeightedTarget,
     },
-    shared::{Duration, Regex, Target, WeightedTarget},
+    shared::{Duration, Regex},
+    Target,
 };
 use xds_api::pb::{
     envoy::{
@@ -549,9 +550,65 @@ where
     }
 }
 
+impl WeightedTarget {
+    pub(crate) fn to_xds(targets: &[Self]) -> Option<xds_route::route_action::ClusterSpecifier> {
+        match targets {
+            [] => None,
+            [target] => Some(xds_route::route_action::ClusterSpecifier::Cluster(
+                target.target.xds_cluster_name(),
+            )),
+            targets => {
+                let clusters = targets
+                    .iter()
+                    .map(|wt| xds_route::weighted_cluster::ClusterWeight {
+                        name: wt.target.xds_cluster_name(),
+                        weight: Some(wt.weight.into()),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(
+                    xds_route::WeightedCluster {
+                        clusters,
+                        ..Default::default()
+                    },
+                ))
+            }
+        }
+    }
+
+    pub(crate) fn from_xds(
+        xds: Option<&xds_route::route_action::ClusterSpecifier>,
+    ) -> Result<Vec<Self>, Error> {
+        match xds {
+            Some(xds_route::route_action::ClusterSpecifier::Cluster(name)) => Ok(vec![Self {
+                target: Target::from_cluster_xds_name(name).with_field("cluster")?,
+                weight: 1,
+            }]),
+            Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(
+                weighted_clusters,
+            )) => {
+                let clusters = weighted_clusters.clusters.iter().enumerate().map(|(i, w)| {
+                    let target =
+                        Target::from_cluster_xds_name(&w.name).with_field_index("name", i)?;
+                    let weight = crate::value_or_default!(w.weight, 1);
+
+                    Ok(Self { target, weight })
+                });
+
+                clusters
+                    .collect::<Result<Vec<_>, _>>()
+                    .with_fields("weighted_clusters", "clusters")
+            }
+            Some(_) => Err(Error::new_static("unsupporetd cluster specifier")),
+            None => Err(Error::new_static("missing cluster specifier")),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use crate::shared::ServiceTarget;
+    use crate::ServiceTarget;
 
     use super::*;
 

--- a/crates/junction-api/src/xds/shared.rs
+++ b/crates/junction-api/src/xds/shared.rs
@@ -1,11 +1,6 @@
 use std::str::FromStr;
 
-use crate::{
-    error::{Error, ErrorContext},
-    shared::{Regex, SessionAffinity, SessionAffinityHashParam, Target, WeightedTarget},
-};
-
-use xds_api::pb::envoy::config::route::v3 as xds_route;
+use crate::{error::Error, shared::Regex};
 
 pub(crate) fn parse_xds_regex(
     p: &xds_api::pb::envoy::r#type::matcher::v3::RegexMatcher,
@@ -19,80 +14,5 @@ pub(crate) fn regex_matcher(
     xds_api::pb::envoy::r#type::matcher::v3::RegexMatcher {
         regex: regex.to_string(),
         engine_type: None,
-    }
-}
-
-impl SessionAffinity {
-    pub fn from_xds(
-        hash_policy: &[xds_route::route_action::HashPolicy],
-    ) -> Result<Option<Self>, Error> {
-        if hash_policy.is_empty() {
-            return Ok(None);
-        }
-
-        let hash_params = hash_policy
-            .iter()
-            .enumerate()
-            .map(|(i, h)| SessionAffinityHashParam::from_xds(h).with_index(i))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        debug_assert!(!hash_params.is_empty(), "hash params must not be empty");
-        Ok(Some(Self { hash_params }))
-    }
-}
-
-impl WeightedTarget {
-    pub(crate) fn to_xds(targets: &[Self]) -> Option<xds_route::route_action::ClusterSpecifier> {
-        match targets {
-            [] => None,
-            [target] => Some(xds_route::route_action::ClusterSpecifier::Cluster(
-                target.target.xds_cluster_name(),
-            )),
-            targets => {
-                let clusters = targets
-                    .iter()
-                    .map(|wt| xds_route::weighted_cluster::ClusterWeight {
-                        name: wt.target.xds_cluster_name(),
-                        weight: Some(wt.weight.into()),
-                        ..Default::default()
-                    })
-                    .collect();
-
-                Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(
-                    xds_route::WeightedCluster {
-                        clusters,
-                        ..Default::default()
-                    },
-                ))
-            }
-        }
-    }
-
-    pub(crate) fn from_xds(
-        xds: Option<&xds_route::route_action::ClusterSpecifier>,
-    ) -> Result<Vec<Self>, Error> {
-        match xds {
-            Some(xds_route::route_action::ClusterSpecifier::Cluster(name)) => Ok(vec![Self {
-                target: Target::from_cluster_xds_name(name).with_field("cluster")?,
-                weight: 1,
-            }]),
-            Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(
-                weighted_clusters,
-            )) => {
-                let clusters = weighted_clusters.clusters.iter().enumerate().map(|(i, w)| {
-                    let target =
-                        Target::from_cluster_xds_name(&w.name).with_field_index("name", i)?;
-                    let weight = crate::value_or_default!(w.weight, 1);
-
-                    Ok(Self { target, weight })
-                });
-
-                clusters
-                    .collect::<Result<Vec<_>, _>>()
-                    .with_fields("weighted_clusters", "clusters")
-            }
-            Some(_) => Err(Error::new_static("unsupporetd cluster specifier")),
-            None => Err(Error::new_static("missing cluster specifier")),
-        }
     }
 }

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -1,8 +1,8 @@
 use http::HeaderValue;
 use junction_api::{
     backend::{Backend, LbPolicy},
-    http::*,
-    shared::{Regex, ServiceTarget, Target, WeightedTarget},
+    http::{HeaderMatch, Route, RouteMatch, RouteRule, WeightedTarget},
+    Regex, ServiceTarget, Target,
 };
 use junction_core::Client;
 use std::{env, str::FromStr, time::Duration};

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -6,7 +6,7 @@ use crate::{
 use junction_api::{
     backend::Backend,
     http::{HeaderMatch, PathMatch, QueryParamMatch, Route, RouteMatch, RouteRule},
-    shared::Target,
+    Target,
 };
 use std::future::Future;
 use std::time::Duration;

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use junction_api::shared::Target;
+use junction_api::Target;
 
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -18,7 +18,7 @@ pub use client::Client;
 pub use xds::{ResourceVersion, XdsConfig};
 
 use junction_api::http::Route;
-use junction_api::shared::Target;
+use junction_api::Target;
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/junction-core/src/load_balancer.rs
+++ b/crates/junction-core/src/load_balancer.rs
@@ -1,7 +1,10 @@
 use crate::EndpointAddress;
 use junction_api::{
-    backend::{Backend, LbPolicy, RingHashParams},
-    shared::{SessionAffinity, SessionAffinityHashParam, SessionAffinityHashParamType, Target},
+    backend::{
+        Backend, LbPolicy, RingHashParams, SessionAffinity, SessionAffinityHashParam,
+        SessionAffinityHashParamType,
+    },
+    Target,
 };
 use std::{
     collections::BTreeMap,

--- a/crates/junction-core/src/xds/cache.rs
+++ b/crates/junction-core/src/xds/cache.rs
@@ -76,7 +76,7 @@
 use crossbeam_skiplist::SkipMap;
 use enum_map::EnumMap;
 use junction_api::http::Route;
-use junction_api::shared::Target;
+use junction_api::Target;
 use petgraph::{
     graph::{DiGraph, NodeIndex},
     visit::{self, Visitable},
@@ -1005,7 +1005,7 @@ impl Cache {
 
 #[cfg(test)]
 mod test {
-    use junction_api::{backend::LbPolicy, shared::ServiceTarget};
+    use junction_api::{backend::LbPolicy, ServiceTarget};
 
     use super::*;
     use crate::xds::test as xds_test;

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
 use enum_map::EnumMap;
 use junction_api::backend::Backend;
 use junction_api::http::Route;
-use junction_api::shared::Target;
+use junction_api::Target;
 use smol_str::SmolStr;
 use xds_api::pb::google::protobuf;
 use xds_api::{

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -8,37 +8,6 @@ Duration = str | int | float
 """A duration expressed as a number of seconds or a string like '1h30m27s42ms'"""
 
 
-class Fraction(typing.TypedDict):
-    """A fraction, expressed as a numerator and a denominator."""
-
-    numerator: int
-    denominator: int
-
-
-class WeightedTarget(typing.TypedDict):
-    weight: int
-    hostname: str
-    """The DNS Name to target/attach to"""
-
-    name: str
-    """The name of the Kubernetes Service"""
-
-    namespace: str
-    """The namespace of the Kubernetes service. FIXME(namespace): what should the semantic be when
-    this is not specified: default, namespace of client, namespace of EZbake?"""
-
-    port: int
-    """The port number to target/attach to.
-
-    When attaching policies, if it is not specified, the target will apply to all connections
-    that don't have a specific port specified.
-
-    When being used to lookup a backend after a matched rule, if it is not specified then it
-    will use the same port as the incoming request"""
-
-    type: typing.Literal["DNS"] | typing.Literal["Service"]
-
-
 class TargetDNS(typing.TypedDict):
     type: typing.Literal["DNS"]
     hostname: str
@@ -76,17 +45,35 @@ class TargetService(typing.TypedDict):
 Target = TargetDNS | TargetService
 
 
-class SessionAffinityHashParam(typing.TypedDict):
-    terminal: bool
-    """Whether to stop immediately after hashing this value.
+class Fraction(typing.TypedDict):
+    """A fraction, expressed as a numerator and a denominator."""
 
-    This is useful if you want to try to hash a value, and then fall back to another as a
-    default if it wasn't set."""
+    numerator: int
+    denominator: int
+
+
+class WeightedTarget(typing.TypedDict):
+    weight: int
+    hostname: str
+    """The DNS Name to target/attach to"""
 
     name: str
-    """The name of the header to use as hash input."""
+    """The name of the Kubernetes Service"""
 
-    type: typing.Literal["Header"]
+    namespace: str
+    """The namespace of the Kubernetes service. FIXME(namespace): what should the semantic be when
+    this is not specified: default, namespace of client, namespace of EZbake?"""
+
+    port: int
+    """The port number to target/attach to.
+
+    When attaching policies, if it is not specified, the target will apply to all connections
+    that don't have a specific port specified.
+
+    When being used to lookup a backend after a matched rule, if it is not specified then it
+    will use the same port as the incoming request"""
+
+    type: typing.Literal["DNS"] | typing.Literal["Service"]
 
 
 class RouteTimeouts(typing.TypedDict):
@@ -215,10 +202,6 @@ class RouteMatch(typing.TypedDict):
     request has the specified method."""
 
 
-class SessionAffinity(typing.TypedDict):
-    hash_params: typing.List[SessionAffinityHashParam]
-
-
 class RouteRule(typing.TypedDict):
     """Defines semantics for matching an HTTP request based on conditions (matches), processing it
     (filters), and forwarding the request to an API object (backendRefs)."""
@@ -274,6 +257,23 @@ class Route(typing.TypedDict):
 
     rules: typing.List[RouteRule]
     """The route rules that determine whether any URLs match."""
+
+
+class SessionAffinityHashParam(typing.TypedDict):
+    terminal: bool
+    """Whether to stop immediately after hashing this value.
+
+    This is useful if you want to try to hash a value, and then fall back to another as a
+    default if it wasn't set."""
+
+    name: str
+    """The name of the header to use as hash input."""
+
+    type: typing.Literal["Header"]
+
+
+class SessionAffinity(typing.TypedDict):
+    hash_params: typing.List[SessionAffinityHashParam]
 
 
 class LbPolicyRoundRobin(typing.TypedDict):

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -341,9 +341,7 @@ fn dump_kube_route(
     let route: Route = pythonize::depythonize_bound(route)?;
 
     let (namespace, name) = match &route.target {
-        junction_api::shared::Target::Service(svc) => {
-            (Some(svc.namespace.clone()), Some(svc.name.clone()))
-        }
+        junction_api::Target::Service(svc) => (Some(svc.namespace.clone()), Some(svc.name.clone())),
         _ => (None, None),
     };
 


### PR DESCRIPTION
More public API reshaping. After this change, `junction_api::shared` is no more. The types we want folks to use are all exposed at the top-level of the crate, or in `http` or `backend`.

There should be no actual change in functionality here.