### PR TITLE
Use Target name as xDS resource name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,6 @@ dependencies = [
  "kube",
  "once_cell",
  "regex",
- "schemars",
  "serde",
  "serde_json",
  "serde_yml 0.0.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
+name = "arbtest"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23909d5fb517fac2a8a4c887e847dbe41dd22ec46914586f5727980d0a193fdc"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +991,8 @@ dependencies = [
 name = "junction-api"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
+ "arbtest",
  "gateway-api",
  "http 1.1.0",
  "junction-typeinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ petgraph = "0.6"
 prost = "0.12"
 rand = "0.8"
 regex = "1.10.6"
-schemars = "0.8.21"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
 serde_yml = "0.0.10"

--- a/crates/junction-api/Cargo.toml
+++ b/crates/junction-api/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 http = { workspace = true }
 regex = { workspace = true }
-schemars = { workspace = true }
 serde = { workspace = true, default-features = false }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/junction-api/Cargo.toml
+++ b/crates/junction-api/Cargo.toml
@@ -25,6 +25,8 @@ gateway-api = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 serde_yml = "0.0.12"
+arbtest = "0.3"
+arbitrary = "1.3"
 
 [features]
 default = ["kube", "xds"]

--- a/crates/junction-api/src/backend.rs
+++ b/crates/junction-api/src/backend.rs
@@ -2,14 +2,13 @@
 //! a load-balancing policy. See [Backend] to get started.
 
 use crate::Target;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "typeinfo")]
 use junction_typeinfo::TypeInfo;
 
 /// Policy for configuring a ketama-style consistent hashing algorithm.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct RingHashParams {
@@ -44,7 +43,7 @@ pub(crate) const fn default_min_ring_size() -> u32 {
 // TODO: Random, Maglev
 //
 /// A policy describing how traffic to this target should be load balanced.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[serde(tag = "type")]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub enum LbPolicy {
@@ -127,7 +126,7 @@ mod tests {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub enum SessionAffinityHashParamType {
@@ -141,7 +140,7 @@ pub enum SessionAffinityHashParamType {
 }
 
 // FIXME: Ben votes to skip the extra "affinity" naming here as its redundant
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct SessionAffinityHashParam {
     /// Whether to stop immediately after hashing this value.
@@ -155,7 +154,7 @@ pub struct SessionAffinityHashParam {
     pub matcher: SessionAffinityHashParamType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct SessionAffinity {
     #[serde(

--- a/crates/junction-api/src/error.rs
+++ b/crates/junction-api/src/error.rs
@@ -5,7 +5,6 @@ use std::{borrow::Cow, fmt::Write as _, str::FromStr};
 /// Errors should be treated as opaque, and contain a message about what went
 /// wrong and a jsonpath style path to the field that caused problems.
 #[derive(Clone, thiserror::Error)]
-#[error("{path_str}: {message}", path_str = self.path())]
 pub struct Error {
     // an error message
     message: String,
@@ -15,6 +14,16 @@ pub struct Error {
     // the leaf of the path is built up at path[0] with the root of the
     // struct at the end. see ErrorContext for how this gets done.
     path: Vec<PathEntry>,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.path.is_empty() {
+            write!(f, "{}: ", self.path())?;
+        }
+
+        f.write_str(&self.message)
+    }
 }
 
 impl std::fmt::Debug for Error {

--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -7,7 +7,6 @@ use crate::{
     shared::{Duration, Fraction, Regex},
     PortNumber, PreciseHostname, Target,
 };
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "typeinfo")]
@@ -578,7 +577,7 @@ pub struct RequestMirrorFilter {
 /// Specifies a way of configuring client retry policy.
 ///
 /// Modelled on the forthcoming [Gateway API type](https://gateway-api.sigs.k8s.io/geps/gep-1731/).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct RouteRetry {

--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     shared::{Duration, Fraction, Regex},
-    PortNumber, PreciseHostname, Target,
+    Hostname, Name, Target,
 };
 use serde::{Deserialize, Serialize};
 
@@ -508,7 +508,7 @@ pub struct RequestRedirectFilter {
     /// The hostname to be used in the value of the `Location` header in the response. When empty,
     /// the hostname in the `Host` header of the request is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hostname: Option<PreciseHostname>,
+    pub hostname: Option<Name>,
 
     /// Defines parameters used to modify the path of the incoming request. The modified path is
     /// then used to construct the `Location` header. When empty, the request path is used as-is.
@@ -532,7 +532,7 @@ pub struct RequestRedirectFilter {
     /// * A Location header that will use HTTPS (whether that is determined via the Listener
     ///   protocol or the Scheme field) _and_ use port 443.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub port: Option<PortNumber>,
+    pub port: Option<u16>,
 
     /// The HTTP status code to be used in response.
     #[serde(default, skip_serializing_if = "Option::is_none", alias = "statusCode")]
@@ -547,7 +547,7 @@ pub struct RequestRedirectFilter {
 pub struct UrlRewriteFilter {
     /// The value to be used to replace the Host header value during forwarding.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hostname: Option<PreciseHostname>,
+    pub hostname: Option<Hostname>,
 
     /// Defines a path rewrite.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -618,13 +618,13 @@ mod tests {
     use crate::{
         http::{HeaderMatch, RouteRule},
         shared::Regex,
-        DNSTarget, ServiceTarget, Target,
+        DNSTarget, Hostname, ServiceTarget, Target,
     };
 
     #[test]
     fn test_passthrough_route() {
         let route = Route::passthrough_route(Target::DNS(DNSTarget {
-            hostname: "example.com".to_string(),
+            hostname: Hostname::from_static("example.com"),
             port: None,
         }));
         assert!(route.is_passthrough_route())
@@ -657,7 +657,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_retry_policy() {
+    fn deserialize_retry_policy() {
         let test_json = json!({
             "codes":[ 1, 2 ],
             "attempts": 3,
@@ -669,7 +669,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_http_route() {
+    fn deserialize_route_rule() {
         let test_json = json!({
             "matches":[
                 {
@@ -719,8 +719,8 @@ mod tests {
             }),
             Route {
                 target: Target::Service(ServiceTarget {
-                    name: "foo".to_string(),
-                    namespace: "bar".to_string(),
+                    name: Name::from_static("foo"),
+                    namespace: Name::from_static("bar"),
                     ..Default::default()
                 }),
                 rules: vec![RouteRule {
@@ -730,8 +730,8 @@ mod tests {
                     retry: None,
                     backends: vec![WeightedTarget {
                         target: Target::Service(ServiceTarget {
-                            name: "foo".to_string(),
-                            namespace: "bar".to_string(),
+                            name: Name::from_static("foo"),
+                            namespace: Name::from_static("bar"),
                             ..Default::default()
                         }),
                         weight: 1,

--- a/crates/junction-api/src/lib.rs
+++ b/crates/junction-api/src/lib.rs
@@ -29,7 +29,6 @@ mod kube;
 #[cfg(feature = "typeinfo")]
 use junction_typeinfo::TypeInfo;
 
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "xds")]
@@ -49,9 +48,7 @@ pub type PreciseHostname = String;
 /// Defines a network port.
 pub type PortNumber = u16;
 
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, JsonSchema, PartialOrd, Ord,
-)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct ServiceTarget {
     ///
@@ -78,9 +75,7 @@ pub struct ServiceTarget {
     pub port: Option<PortNumber>,
 }
 
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, JsonSchema, PartialOrd, Ord,
-)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct DNSTarget {
     ///
@@ -101,9 +96,7 @@ pub struct DNSTarget {
     pub port: Option<PortNumber>,
 }
 
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, JsonSchema, PartialOrd, Ord,
-)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(tag = "type")]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub enum Target {

--- a/crates/junction-api/src/lib.rs
+++ b/crates/junction-api/src/lib.rs
@@ -8,10 +8,9 @@
 //! Use the `junction-client` crate if you want to make requests and resolve
 //! addresses with Junction.
 
-#[cfg(any(feature = "kube", feature = "xds"))]
 mod error;
+use std::{ops::Deref, str::FromStr};
 
-#[cfg(any(feature = "kube", feature = "xds"))]
 pub use error::Error;
 
 pub mod backend;
@@ -29,7 +28,7 @@ mod kube;
 #[cfg(feature = "typeinfo")]
 use junction_typeinfo::TypeInfo;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::Visitor, Deserialize, Serialize};
 
 #[cfg(feature = "xds")]
 macro_rules! value_or_default {
@@ -41,184 +40,440 @@ macro_rules! value_or_default {
 #[cfg(feature = "xds")]
 pub(crate) use value_or_default;
 
-/// The fully qualified domain name of a network host. This matches the RFC 1123 definition of a
-/// hostname with 1 notable exception that numeric IP addresses are not allowed.
-pub type PreciseHostname = String;
+macro_rules! newtype_string {
+    ($(#[$id_attr:meta])* pub $name:ident) => {
+        $(#[$id_attr])*
+        #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(String);
 
-/// Defines a network port.
-pub type PortNumber = u16;
+        impl Deref for $name {
+            type Target = str;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub struct ServiceTarget {
-    ///
-    /// The name of the Kubernetes Service
-    ///
-    pub name: String,
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
 
-    ///
-    /// The namespace of the Kubernetes service. FIXME(namespace): what should the semantic be when
-    /// this is not specified: default, namespace of client, namespace of EZbake?
-    ///
-    pub namespace: String,
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
 
-    ///
-    /// The port number of the Kubernetes service to target/ attach to.
-    ///
-    /// When attaching policies, if it is not specified, the target will apply to all connections
-    /// that don't have a specific port specified.
-    ///
-    /// When being used to lookup a backend after a matched rule, if it is not specified then it
-    /// will use the same port as the incoming request
-    ///
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub port: Option<PortNumber>,
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{:?}", self.0)
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                // implements both visit_str and visit_string in case that moving the
+                // string into this $name instead of cloning is possible.
+                struct NameVisitor;
+
+                impl<'de> Visitor<'de> for NameVisitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("a valid DNS $name")
+                    }
+
+                    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        let name: Result<$name, Error> = v.try_into();
+                        name.map_err(|e: Error| E::custom(e.to_string()))
+                    }
+
+                    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        $name::from_str(v).map_err(|e| E::custom(e.to_string()))
+                    }
+                }
+
+                deserializer.deserialize_string(NameVisitor)
+            }
+        }
+
+        #[cfg(feature = "typeinfo")]
+        impl junction_typeinfo::TypeInfo for $name {
+            fn kind() -> junction_typeinfo::Kind {
+                junction_typeinfo::Kind::String
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = Error;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::validate(s.as_bytes())?;
+                Ok($name(s.to_string()))
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = Error;
+
+            fn try_from(value: String) -> Result<$name, Self::Error> {
+                $name::validate(value.as_bytes())?;
+                Ok($name(value))
+            }
+        }
+
+        impl<'a> TryFrom<&'a str> for $name {
+            type Error = Error;
+
+            fn try_from(value: &'a str) -> Result<$name, Self::Error> {
+                $name::validate(value.as_bytes())?;
+                Ok($name(value.to_string()))
+            }
+        }
+    }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub struct DNSTarget {
-    ///
-    /// The DNS Name to target/attach to
-    ///
-    pub hostname: PreciseHostname,
+// A lookup table of valid RFC 1123 name characters. RFC 1035 labels use
+// this table as well but ignore the '.' character.
+//
+// Adapted from the table used in the http crate to valid URI and Authority
+// strings.
+//
+// https://github.com/hyperium/http/blob/master/src/uri/mod.rs#L146-L153
+#[rustfmt::skip]
+const DNS_CHARS: [u8; 256] = [
+//  0      1      2      3      4      5      6      7      8      9
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //   x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //  1x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //  2x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //  3x
+    0,     0,     0,     0,     0,  b'-',  b'.',     0,  b'0',  b'1', //  4x
+ b'2',  b'3',  b'4',  b'5',  b'6',  b'7',  b'8',  b'9',     0,     0, //  5x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //  6x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //  7x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, //  8x
+    0,     0,     0,     0,     0,     0,     0,  b'a',  b'b',  b'c', //  9x
+ b'd',  b'e',  b'f',  b'g',  b'h',  b'i',  b'j',  b'k',  b'l',  b'm', // 10x
+ b'n',  b'o',  b'p',  b'q',  b'r',  b's',  b't',  b'u',  b'v',  b'w', // 11x
+ b'x',  b'y',  b'z',     0,     0,     0,     0,     0,     0,     0, // 12x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 13x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 14x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 15x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 16x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 17x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 18x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 19x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 20x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 21x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 22x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 23x
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0, // 24x
+    0,     0,     0,     0,     0,     0,                              // 25x
+];
 
+newtype_string! {
+    /// AN RFC 1123 DNS domain name.
     ///
-    /// The port number to target/attach to.
-    ///
-    /// When attaching policies, if it is not specified, the target will apply to all connections
-    /// that don't have a specific port specified.
-    ///
-    /// When being used to lookup a backend after a matched rule, if it is not specified then it
-    /// will use the same port as the incoming request
-    ///
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub port: Option<PortNumber>,
+    /// This name must be no more than 253 characters, and can only contain
+    /// lowercase ascii alphanumeric charaters, `.` and `-`.
+    pub Hostname
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[serde(tag = "type")]
-#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
-pub enum Target {
-    DNS(DNSTarget),
+impl Hostname {
+    /// The RFC 1035 max length. We don't add any extra validation to it, since
+    /// there's a variety of places Name gets used and they won't all have the
+    /// same constraints.
+    const MAX_LEN: usize = 253;
 
-    #[serde(untagged)]
-    Service(ServiceTarget),
-}
+    /// Create a new hostname from a static string.
+    ///
+    /// Assumes that a human being has manually validated that this is a valid
+    /// hostname and will panic if it is not.
+    pub fn from_static(src: &'static str) -> Self {
+        Self::validate(src.as_bytes()).expect("expected a static Name to be valid");
+        Self(src.to_string())
+    }
 
-static KUBE_SERVICE_SUFFIX: &str = ".svc.cluster.local";
+    fn validate(bs: &[u8]) -> Result<(), Error> {
+        if bs.len() > Self::MAX_LEN {
+            return Err(Error::new_static(
+                "Hostname must not be longer than 253 characters",
+            ));
+        }
 
-impl std::fmt::Display for Target {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.as_hostname())?;
-
-        if let Some(port) = self.port() {
-            f.write_fmt(format_args!(":{port}"))?;
+        for (i, &b) in bs.iter().enumerate() {
+            match (i, DNS_CHARS[b as usize]) {
+                (_, 0) => return Err(Error::new_static("Hostname contains an invalid character")),
+                (0, b'-' | b'.') => {
+                    return Err(Error::new_static(
+                        "Hostname must start with an alphanumeric character",
+                    ))
+                }
+                (i, b'-' | b'.') if i == bs.len() => {
+                    return Err(Error::new_static(
+                        "Hostname must end with an alphanumeric character",
+                    ))
+                }
+                _ => (),
+            }
         }
 
         Ok(())
     }
 }
 
-///
-///  FIXME(ports): nothing with ports here will work until we move to xdstp
-///
-///  FIXME(DNS): For kube service hostnames, forcing the use of the ".svc.cluster.local" suffix is
-///  icky,in that it stops the current k8s behavior of clients sending a request to
-///  http://service_name, and having the namespace resolved based on where the client is running.
-///
-///  However without it, we are going to have a hard time here saying when an incoming hostname is
-///  targeted at DNS, vs when it is targeted at a kube service. That might not be a problem though,
-///  in that if we can process XDS NACKs, we can use something at a higher level to work out what it
-///  is.
-///
-///  So punting thinking more about this until we support DNS properly.
-///
-impl Target {
-    pub fn as_hostname(&self) -> String {
-        match self {
-            Target::DNS(c) => c.hostname.clone(),
-            Target::Service(c) => format!("{}.{}{}", c.name, c.namespace, KUBE_SERVICE_SUFFIX),
+newtype_string! {
+    /// An RFC 1035 compatible name. This name must be useable as a component of a
+    /// DNS subdomain - it must start with a lowercase ascii alphabetic character
+    /// and may only consist of ascii lowercase alphanumeric characters and the `-`
+    /// character.
+    pub Name
+}
+
+impl Name {
+    // RFC 1035 max length.
+    const MAX_LEN: usize = 63;
+
+    /// Create a new name from a static string.
+    ///
+    /// Assumes that a human being has manually validated that this is a valid name
+    /// and will panic if it is not.
+    pub fn from_static(src: &'static str) -> Self {
+        Self::validate(src.as_bytes()).expect("expected a static Name to be valid");
+        Self(src.to_string())
+    }
+
+    /// Check that a `str` is a valid Name.
+    ///
+    /// Being a valid name also implies that the slice is valid utf-8.
+    fn validate(bs: &[u8]) -> Result<(), Error> {
+        if bs.len() > Self::MAX_LEN {
+            return Err(Error::new_static(
+                "Name must not be longer than 63 characters",
+            ));
         }
-    }
 
-    pub fn from_hostname(hostname: &str, port: Option<u16>) -> Self {
-        if hostname.ends_with(KUBE_SERVICE_SUFFIX) {
-            let mut parts = hostname.split('.');
-            let name = parts.next().unwrap().to_string();
-            let namespace = parts.next().unwrap().to_string();
-            Target::Service(ServiceTarget {
-                name,
-                namespace,
-                port,
-            })
-        } else {
-            Target::DNS(DNSTarget {
-                hostname: hostname.to_string(),
-                port,
-            })
-        }
-    }
-
-    // FIXME(DNS): no reason we cannot support DNS here, but likely it should be determined by whats
-    // in the cluster config so passed as a extra parameter
-    #[cfg(feature = "xds")]
-    pub fn from_cluster_xds_name(name: &str) -> Result<Self, Error> {
-        let parts: Vec<&str> = name.split('/').collect();
-        if parts.len() == 3 && parts[2].eq("cluster") {
-            Ok(Target::Service(ServiceTarget {
-                name: parts[1].to_string(),
-                namespace: parts[0].to_string(),
-                port: None,
-            }))
-        } else {
-            Err(Error::new_static("unable to cluster name"))
-        }
-    }
-
-    pub fn xds_cluster_name(&self) -> String {
-        match self {
-            // FIXME: this is wrong
-            Target::DNS(c) => c.hostname.clone(),
-            Target::Service(c) => format!("{}/{}/cluster", c.namespace, c.name),
-        }
-    }
-
-    pub fn xds_endpoints_name(&self) -> String {
-        match self {
-            // FIXME: this is wrong
-            Target::DNS(c) => c.hostname.clone(),
-            Target::Service(c) => format!("{}/{}/endpoints", c.namespace, c.name),
-        }
-    }
-
-    pub fn from_listener_xds_name(name: &str) -> Option<Self> {
-        //for now, the listener name is just the hostname
-        Some(Self::from_hostname(name, None))
-    }
-
-    pub fn xds_listener_name(&self) -> String {
-        //FIXME(ports): for now this is just the hostname, with no support for port
-        self.as_hostname()
-    }
-
-    pub fn xds_default_listener_name(&self) -> String {
-        match self {
-            Target::DNS(c) => format!("{hostname}/default", hostname = c.hostname),
-            Target::Service(c) => {
-                format!("{}.{}.junction.default", c.name, c.namespace)
+        for (i, &b) in bs.iter().enumerate() {
+            match (i, DNS_CHARS[b as usize]) {
+                (_, 0 | b'.') => {
+                    return Err(Error::new_static("Name contains an invalid character"))
+                }
+                (0, b'-' | b'0'..=b'9') => {
+                    return Err(Error::new_static("Name must start with [a-z]"))
+                }
+                (i, b'-') if i == bs.len() => {
+                    return Err(Error::new_static(
+                        "Name must end with an alphanumeric character",
+                    ))
+                }
+                _ => (),
             }
         }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
+#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
+pub struct ServiceTarget {
+    /// The name of the Kubernetes Service to target.
+    pub name: Name,
+
+    /// The namespace of the Kubernetes service to target. This must be explicitly
+    /// specified, and won't be inferred from context.
+    pub namespace: Name,
+
+    /// The port number of the Kubernetes service to target/ attach to.
+    ///
+    /// When attaching policies, if it is not specified, the target will apply
+    /// to all connections that don't have a specific port specified.
+    ///
+    /// When being used to lookup a backend after a matched rule, if it is not
+    /// specified then it will use the same port as the incoming request
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+}
+
+impl ServiceTarget {
+    const SUBDOMAIN: &'static str = ".svc.cluster.local";
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
+#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
+pub struct DNSTarget {
+    /// The DNS name to target.
+    pub hostname: Hostname,
+
+    /// The port number to target/attach to.
+    ///
+    /// When attaching policies, if it is not specified, the target will apply
+    /// to all connections that don't have a specific port specified.
+    ///
+    /// When being used to lookup a backend after a matched rule, if it is not
+    /// specified then it will use the same port as the incoming request
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(tag = "type")]
+#[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
+pub enum Target {
+    #[serde(alias = "dns")]
+    DNS(DNSTarget),
+
+    #[serde(untagged)]
+    Service(ServiceTarget),
+}
+
+impl std::fmt::Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.write_name(f)
+    }
+}
+
+impl Target {
+    const BACKEND_SUBDOMAIN: &'static str = ".lb.jct";
+
+    pub fn name(&self) -> String {
+        let mut buf = String::new();
+        self.write_name(&mut buf).unwrap();
+        buf
+    }
+
+    fn write_name(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        match self {
+            Target::DNS(dns) => {
+                w.write_str(&dns.hostname)?;
+
+                if let Some(port) = dns.port {
+                    write!(w, ":{port}")?;
+                }
+            }
+            Target::Service(svc) => {
+                write!(
+                    w,
+                    "{name}.{namespace}{subdomain}",
+                    name = svc.name,
+                    namespace = svc.namespace,
+                    subdomain = ServiceTarget::SUBDOMAIN,
+                )?;
+
+                if let Some(port) = svc.port {
+                    write!(w, ":{port}")?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[doc(hidden)]
+    pub fn passthrough_route_name(&self) -> String {
+        let mut buf = String::new();
+        self.write_passthrough_route_name(&mut buf).unwrap();
+        buf
+    }
+
+    fn write_passthrough_route_name(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        match self {
+            Target::DNS(dns) => {
+                write!(w, "{}{}", dns.hostname, Target::BACKEND_SUBDOMAIN)?;
+
+                if let Some(port) = dns.port {
+                    write!(w, ":{port}")?;
+                }
+            }
+            Target::Service(svc) => {
+                write!(
+                    w,
+                    "{name}.{namespace}{svc}{backend}",
+                    name = svc.name,
+                    namespace = svc.namespace,
+                    svc = ServiceTarget::SUBDOMAIN,
+                    backend = Target::BACKEND_SUBDOMAIN,
+                )?;
+
+                if let Some(port) = svc.port {
+                    write!(w, ":{port}")?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn from_name(name: &str) -> Result<Self, Error> {
+        let (name, port) = parse_port(name)?;
+        let hostname = Hostname::from_str(name)?;
+
+        let target = match name {
+            n if n.ends_with(ServiceTarget::SUBDOMAIN) => {
+                let parts: Vec<_> = hostname.split('.').collect();
+                if parts.len() != 5 {
+                    return Err(Error::new_static(
+                        "invalid Service target: name and namespace must be valid DNS labels",
+                    ));
+                }
+
+                let name = parts[0].parse()?;
+                let namespace = parts[1].parse()?;
+                Target::Service(ServiceTarget {
+                    name,
+                    namespace,
+                    port,
+                })
+            }
+            _ => Target::DNS(DNSTarget { hostname, port }),
+        };
+        Ok(target)
+    }
+
+    #[doc(hidden)]
+    pub fn from_passthrough_route_name(name: &str) -> Result<Self, Error> {
+        let (name, port) = parse_port(name)?;
+        let hostname = Hostname::from_str(name)?;
+
+        let Some(hostname) = hostname.strip_suffix(Target::BACKEND_SUBDOMAIN) else {
+            return Err(Error::new_static("expected a Junction backend name"));
+        };
+
+        let mut target = Self::from_name(hostname)?;
+        if let Some(port) = port {
+            target = target.with_port(port);
+        }
+        Ok(target)
     }
 
     pub fn port(&self) -> Option<u16> {
         match self {
-            Target::DNS(c) => c.port,
-            //FIXME(namespace): work out what to do if namespace is optional
-            Target::Service(c) => c.port,
+            Target::DNS(dns) => dns.port,
+            Target::Service(svc) => svc.port,
         }
     }
 
+    /// Return a clone of this Target with its port set.
     pub fn with_port(&self, port: u16) -> Self {
         match self {
             Target::DNS(c) => Target::DNS(DNSTarget {
@@ -233,17 +488,47 @@ impl Target {
             }),
         }
     }
+
+    /// Return a clone of this Target with a port set to `default_port` if it
+    /// doesn't already have a port.
+    pub fn with_default_port(&self, default_port: u16) -> Self {
+        match self {
+            Target::DNS(dns) => match dns.port {
+                Some(_) => self.clone(),
+                None => self.clone().with_port(default_port),
+            },
+            Target::Service(svc) => match svc.port {
+                Some(_) => self.clone(),
+                None => self.clone().with_port(default_port),
+            },
+        }
+    }
+}
+
+#[inline]
+fn parse_port(s: &str) -> Result<(&str, Option<u16>), Error> {
+    let (name, port) = match s.split_once(':') {
+        Some((name, port)) => (name, Some(port)),
+        None => (s, None),
+    };
+
+    let port = match port {
+        Some(port) => {
+            Some(u16::from_str(port).map_err(|_| Error::new_static("invalid port number"))?)
+        }
+        None => None,
+    };
+
+    Ok((name, port))
 }
 
 #[cfg(test)]
-mod test_target {
-
-    use crate::{ServiceTarget, Target};
-    use serde_json::json;
+mod test {
+    use super::*;
 
     #[test]
-    fn test_parses_target() {
-        let target = json!({
+    fn test_parses_json() {
+        let target = serde_json::json!({
             "type": "service",
             "name": "foo",
             "namespace": "potato",
@@ -252,10 +537,185 @@ mod test_target {
         assert_eq!(
             serde_json::from_value::<Target>(target).unwrap(),
             Target::Service(ServiceTarget {
-                name: "foo".to_string(),
-                namespace: "potato".to_string(),
+                name: Name::from_static("foo"),
+                namespace: Name::from_static("potato"),
                 port: None
             }),
-        )
+        );
+
+        let target = serde_json::json!({
+            "type": "dns",
+            "hostname": "example.com"
+        });
+
+        assert_eq!(
+            serde_json::from_value::<Target>(target).unwrap(),
+            Target::DNS(DNSTarget {
+                hostname: Hostname::from_static("example.com"),
+                port: None
+            }),
+        );
+    }
+
+    #[test]
+    fn test_target_route_name() {
+        assert_route_name(
+            Target::Service(ServiceTarget {
+                name: Name::from_static("potato"),
+                namespace: Name::from_static("production"),
+                port: None,
+            }),
+            "potato.production.svc.cluster.local",
+        );
+
+        assert_route_name(
+            Target::Service(ServiceTarget {
+                name: Name::from_static("potato"),
+                namespace: Name::from_static("production"),
+                port: Some(443),
+            }),
+            "potato.production.svc.cluster.local:443",
+        );
+
+        assert_route_name(
+            Target::DNS(DNSTarget {
+                hostname: Hostname::from_static("cool-stuff.example.com"),
+                port: None,
+            }),
+            "cool-stuff.example.com",
+        );
+
+        assert_route_name(
+            Target::DNS(DNSTarget {
+                hostname: Hostname::from_static("cool-stuff.example.com"),
+                port: Some(1234),
+            }),
+            "cool-stuff.example.com:1234",
+        );
+    }
+
+    #[track_caller]
+    fn assert_route_name(target: Target, str: &'static str) {
+        assert_eq!(&target.name(), str);
+        let parsed = Target::from_name(str).unwrap();
+        assert_eq!(parsed, target);
+    }
+
+    #[test]
+    fn test_target_backend_name() {
+        assert_backend_name(
+            Target::Service(ServiceTarget {
+                name: Name::from_static("potato"),
+                namespace: Name::from_static("production"),
+                port: None,
+            }),
+            "potato.production.svc.cluster.local.lb.jct",
+        );
+
+        assert_backend_name(
+            Target::Service(ServiceTarget {
+                name: Name::from_static("potato"),
+                namespace: Name::from_static("production"),
+                port: Some(443),
+            }),
+            "potato.production.svc.cluster.local.lb.jct:443",
+        );
+
+        assert_backend_name(
+            Target::DNS(DNSTarget {
+                hostname: Hostname::from_static("cool-stuff.example.com"),
+                port: None,
+            }),
+            "cool-stuff.example.com.lb.jct",
+        );
+
+        assert_backend_name(
+            Target::DNS(DNSTarget {
+                hostname: Hostname::from_static("cool-stuff.example.com"),
+                port: Some(1234),
+            }),
+            "cool-stuff.example.com.lb.jct:1234",
+        );
+    }
+
+    #[track_caller]
+    fn assert_backend_name(target: Target, str: &'static str) {
+        assert_eq!(&target.passthrough_route_name(), str);
+        let parsed = Target::from_passthrough_route_name(str).unwrap();
+        assert_eq!(parsed, target);
+    }
+
+    #[test]
+    fn test_valid_name() {
+        let alphabetic: Vec<char> = (b'a'..=b'z').map(|b| b as char).collect();
+        let full_alphabet: Vec<char> = (b'a'..=b'z')
+            .chain(b'0'..=b'9')
+            .chain([b'-'])
+            .map(|b| b as char)
+            .collect();
+
+        arbtest::arbtest(|u| {
+            let input = arbitrary_string(u, &alphabetic, &full_alphabet, Name::MAX_LEN);
+            let res = Name::from_str(&input);
+
+            assert!(
+                res.is_ok(),
+                "string should be a valid name: {input:?} (len={}): {}",
+                input.len(),
+                res.unwrap_err(),
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_valid_hostname() {
+        let alphanumeric: Vec<char> = (b'a'..=b'z')
+            .chain(b'0'..=b'9')
+            .map(|b| b as char)
+            .collect();
+        let full_alphabet: Vec<char> = (b'a'..=b'z')
+            .chain(b'0'..=b'9')
+            .chain([b'-', b'.'])
+            .map(|b| b as char)
+            .collect();
+
+        arbtest::arbtest(|u| {
+            let input = arbitrary_string(u, &alphanumeric, &full_alphabet, Hostname::MAX_LEN);
+            let res = Hostname::from_str(&input);
+            assert!(
+                res.is_ok(),
+                "string should be a valid hostname: {input:?} (len={}): {}",
+                input.len(),
+                res.unwrap_err(),
+            );
+            Ok(())
+        });
+    }
+
+    fn arbitrary_string(
+        u: &mut arbitrary::Unstructured,
+        first_and_last: &[char],
+        alphabet: &[char],
+        max_len: usize,
+    ) -> String {
+        let len: usize = u.choose_index(max_len).unwrap();
+        let mut input = String::new();
+
+        if len > 0 {
+            input.push(*u.choose(first_and_last).unwrap());
+        }
+
+        if len > 1 {
+            for _ in 1..(len - 1) {
+                input.push(*u.choose(alphabet).unwrap());
+            }
+        }
+
+        if len > 2 {
+            input.push(*u.choose(first_and_last).unwrap());
+        }
+
+        input
     }
 }

--- a/crates/junction-api/src/shared.rs
+++ b/crates/junction-api/src/shared.rs
@@ -3,7 +3,6 @@
 use core::fmt;
 use kube::core::Duration as KubeDuration;
 use once_cell::sync::Lazy;
-use schemars::JsonSchema;
 use serde::de::{self, Visitor};
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
@@ -122,7 +121,7 @@ impl PartialEq for Regex {
 /// When formatting as a string, zero-valued durations must always be formatted as `0s`, and
 /// non-zero durations must be formatted to with only one instance of each applicable unit, greatest
 /// unit first.
-#[derive(Copy, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Duration(StdDuration);
 
 /// Regex pattern defining valid strings.

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -2,7 +2,7 @@ use http::HeaderValue;
 use junction_api::{
     backend::{Backend, LbPolicy},
     http::{HeaderMatch, Route, RouteMatch, RouteRule, WeightedTarget},
-    Regex, ServiceTarget, Target,
+    Name, Regex, ServiceTarget, Target,
 };
 use junction_core::Client;
 use std::{env, str::FromStr, time::Duration};
@@ -27,13 +27,13 @@ async fn main() {
     tokio::spawn(client.csds_server(8009));
 
     let nginx = Target::Service(ServiceTarget {
-        name: "nginx".to_string(),
-        namespace: "default".to_string(),
+        name: Name::from_static("nginx"),
+        namespace: Name::from_static("default"),
         port: Some(80),
     });
     let nginx_staging = Target::Service(ServiceTarget {
-        name: "nginx-staging".to_string(),
-        namespace: "default".to_string(),
+        name: Name::from_static("nginx-staging"),
+        namespace: Name::from_static("default"),
         port: Some(80),
     });
 
@@ -86,9 +86,8 @@ async fn main() {
     };
 
     loop {
-        let prod_endpoints = client.resolve_http(&http::Method::GET, url.clone(), &prod_headers);
-        let staging_endpoints =
-            client.resolve_http(&http::Method::GET, url.clone(), &staging_headers);
+        let prod_endpoints = client.resolve_http(&http::Method::GET, &url, &prod_headers);
+        let staging_endpoints = client.resolve_http(&http::Method::GET, &url, &staging_headers);
 
         let mut error = false;
         if let Err(e) = &prod_endpoints {

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -39,7 +39,7 @@ pub enum Error {
         backend: Target,
     },
 
-    #[error("{backend}: no endpoints are healthy")]
+    #[error("{backend}: no reachable endpoints")]
     NoReachableEndpoints { route: Target, backend: Target },
 }
 
@@ -52,6 +52,10 @@ fn format_targets(targets: &[Target]) -> String {
 }
 
 impl Error {
+    pub(crate) fn invalid_url(message: String) -> Self {
+        Self::InvalidUrl(Cow::Owned(message))
+    }
+
     pub(crate) fn is_temporary(&self) -> bool {
         matches!(
             self,

--- a/crates/junction-core/src/url.rs
+++ b/crates/junction-core/src/url.rs
@@ -95,11 +95,19 @@ impl Url {
         self.scheme.as_str()
     }
 
+    pub fn authority(&self) -> &str {
+        self.authority.as_str()
+    }
+
     pub fn hostname(&self) -> &str {
         self.authority.host()
     }
 
-    pub fn port(&self) -> u16 {
+    pub fn port(&self) -> Option<u16> {
+        self.authority.port_u16()
+    }
+
+    pub fn default_port(&self) -> u16 {
         self.authority
             .port_u16()
             .unwrap_or_else(|| match self.scheme.as_ref() {

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -360,7 +360,7 @@ pub(crate) struct RouteConfig {
     pub xds: xds_route::RouteConfiguration,
     pub route: Arc<Route>,
     pub clusters: Vec<ResourceName<Cluster>>,
-    pub default_action: Option<(ResourceName<Cluster>, xds_route::RouteAction)>,
+    pub passthrough_action: Option<(ResourceName<Cluster>, xds_route::RouteAction)>,
 }
 
 impl RouteConfig {
@@ -427,7 +427,7 @@ impl RouteConfig {
             xds,
             route,
             clusters,
-            default_action,
+            passthrough_action: default_action,
         })
     }
 }

--- a/crates/junction-core/src/xds/test.rs
+++ b/crates/junction-core/src/xds/test.rs
@@ -195,7 +195,7 @@ pub fn api_listener_inline_routes(
 
     let http_router_filter = Router::default();
     let route_specifier = RouteSpecifier::RouteConfig(xds_route::RouteConfiguration {
-        name: "test_routes".to_string(),
+        name: name.to_string(),
         virtual_hosts,
         ..Default::default()
     });

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -11,35 +11,35 @@ Duration = str | int | float
 class TargetDNS(typing.TypedDict):
     type: typing.Literal["DNS"]
     hostname: str
-    """The DNS Name to target/attach to"""
+    """The DNS name to target."""
 
     port: int
     """The port number to target/attach to.
 
-    When attaching policies, if it is not specified, the target will apply to all connections
-    that don't have a specific port specified.
+    When attaching policies, if it is not specified, the target will apply
+    to all connections that don't have a specific port specified.
 
-    When being used to lookup a backend after a matched rule, if it is not specified then it
-    will use the same port as the incoming request"""
+    When being used to lookup a backend after a matched rule, if it is not
+    specified then it will use the same port as the incoming request"""
 
 
 class TargetService(typing.TypedDict):
     type: typing.Literal["Service"]
     name: str
-    """The name of the Kubernetes Service"""
+    """The name of the Kubernetes Service to target."""
 
     namespace: str
-    """The namespace of the Kubernetes service. FIXME(namespace): what should the semantic be when
-    this is not specified: default, namespace of client, namespace of EZbake?"""
+    """The namespace of the Kubernetes service to target. This must be explicitly
+    specified, and won't be inferred from context."""
 
     port: int
     """The port number of the Kubernetes service to target/ attach to.
 
-    When attaching policies, if it is not specified, the target will apply to all connections
-    that don't have a specific port specified.
+    When attaching policies, if it is not specified, the target will apply
+    to all connections that don't have a specific port specified.
 
-    When being used to lookup a backend after a matched rule, if it is not specified then it
-    will use the same port as the incoming request"""
+    When being used to lookup a backend after a matched rule, if it is not
+    specified then it will use the same port as the incoming request"""
 
 
 Target = TargetDNS | TargetService
@@ -55,23 +55,23 @@ class Fraction(typing.TypedDict):
 class WeightedTarget(typing.TypedDict):
     weight: int
     hostname: str
-    """The DNS Name to target/attach to"""
+    """The DNS name to target."""
 
     name: str
-    """The name of the Kubernetes Service"""
+    """The name of the Kubernetes Service to target."""
 
     namespace: str
-    """The namespace of the Kubernetes service. FIXME(namespace): what should the semantic be when
-    this is not specified: default, namespace of client, namespace of EZbake?"""
+    """The namespace of the Kubernetes service to target. This must be explicitly
+    specified, and won't be inferred from context."""
 
     port: int
     """The port number to target/attach to.
 
-    When attaching policies, if it is not specified, the target will apply to all connections
-    that don't have a specific port specified.
+    When attaching policies, if it is not specified, the target will apply
+    to all connections that don't have a specific port specified.
 
-    When being used to lookup a backend after a matched rule, if it is not specified then it
-    will use the same port as the incoming request"""
+    When being used to lookup a backend after a matched rule, if it is not
+    specified then it will use the same port as the incoming request"""
 
     type: typing.Literal["DNS"] | typing.Literal["Service"]
 

--- a/junction-python/samples/routing-and-load-balancing/client.py
+++ b/junction-python/samples/routing-and-load-balancing/client.py
@@ -53,19 +53,18 @@ def retry_sample(args):
                         codes=[502], attempts=2, backoff="1ms"
                     ),
                     "backends": [
-                        feature_target,
+                        {**feature_target, "port": 8008},
                     ],
                 },
                 {
                     "backends": [
-                        default_target,
+                        {**default_target, "port": 8008},
                     ]
                 },
             ],
         }
     ]
-    default_backends: List[junction.config.Backend] = []
-    session = junction.requests.Session(default_routes, default_backends)
+    session = junction.requests.Session(default_routes)
 
     results = []
     for code in [501, 502]:
@@ -157,6 +156,7 @@ def ring_hash_sample(args):
     default_target: junction.config.Target = {
         "name": "jct-http-server",
         "namespace": "default",
+        "port": 8008,
     }
     default_routes: List[junction.config.Route] = []
     default_backends: List[junction.config.Backend] = [
@@ -311,7 +311,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Samples for Junction")
     parser.add_argument(
         "--base-url",
-        default="http://jct-http-server.default.svc.cluster.local",
+        default="http://jct-http-server.default.svc.cluster.local:8008",
         help="The base url to send requests to",
     )
     parser.add_argument(


### PR DESCRIPTION
Huge update that uses `Target::name` as the canonical xDS name we request, everywhere. This requires an update to `ezbake` to be functional. There's some chicken-and-egg dependence here, since to update `ezbake` we need this code to land. I'm going to try to have `ezbake` depend on this branch, build a new container, and then run smoke tests here.

### xDS uses Target names

All of our xDS now uses `Target::name` as it's Listener/Cluster/etc. name. While there's no xDS level requirement for a strict naming convention, we need to be able to encode a Target into a xDS name so we can decode exactly what kind of Target we're getting when we convert a `RouteConfiguration` to a `Route` or a `Cluster` to a `Backend`.

### Ports ports ports ports

Getting serious about `Target::name` means taking ports seriously, and rationalizing multiple ports per service. We're now effectively forcing ports to exist on `Backend` targets, but allowing them to be optional (aka "just use the URL's port") when matching `Route`s. There will be a follow-up PR to formalize this.

### Name validation

I threw validation of names into the mix here, as it felt relevant. It could (should?) have been a separate PR, but it isn't. The big deal is that we now have a `Name` type that corresponds to an RFC 1035 DNS label, and a `Hostname` type that corresponds to an RFC 1123 DNS hostname. This should keep us entirely compatible with k8s and DNS for validation up front instead of having fun errors at runtime.

### Less JSONSchema

We had some vestigial jsonschema hanging out that we thought we were going to use for CRDs. Since we're not using CRDs, I stripped it out.