### PR TITLE
Require ports for Backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "h2",
  "http 1.1.0",
  "junction-api",
+ "k8s-openapi",
  "once_cell",
  "petgraph",
  "prost",

--- a/crates/junction-api-gen/src/main.rs
+++ b/crates/junction-api-gen/src/main.rs
@@ -9,10 +9,10 @@ use junction_typeinfo::TypeInfo as _;
 fn main() {
     let items = vec![
         junction_api::Target::item(),
-        junction_api::RouteTarget::item(),
-        junction_api::BackendTarget::item(),
+        junction_api::VirtualHost::item(),
+        junction_api::BackendId::item(),
         junction_api::Fraction::item(),
-        junction_api::http::WeightedTarget::item(),
+        junction_api::http::WeightedBackend::item(),
         junction_api::http::RouteTimeouts::item(),
         junction_api::http::RouteRetry::item(),
         junction_api::http::HeaderValue::item(),

--- a/crates/junction-api-gen/src/main.rs
+++ b/crates/junction-api-gen/src/main.rs
@@ -9,6 +9,8 @@ use junction_typeinfo::TypeInfo as _;
 fn main() {
     let items = vec![
         junction_api::Target::item(),
+        junction_api::RouteTarget::item(),
+        junction_api::BackendTarget::item(),
         junction_api::Fraction::item(),
         junction_api::http::WeightedTarget::item(),
         junction_api::http::RouteTimeouts::item(),

--- a/crates/junction-api/src/backend.rs
+++ b/crates/junction-api/src/backend.rs
@@ -1,7 +1,7 @@
 //! Backends are the logical target of network traffic. They have an identity and
 //! a load-balancing policy. See [Backend] to get started.
 
-use crate::BackendTarget;
+use crate::BackendId;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "typeinfo")]
@@ -16,7 +16,7 @@ use junction_typeinfo::TypeInfo;
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct Backend {
     /// A unique description of what this backend is.
-    pub target: BackendTarget,
+    pub id: BackendId,
 
     /// How traffic to this target should be load balanced.
     pub lb: LbPolicy,
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn test_backend_json_roundtrip() {
         let test_json = json!({
-            "target": { "name": "foo", "namespace": "bar", "port": 789 },
+            "id": { "name": "foo", "namespace": "bar", "port": 789 },
             "lb": {
                 "type": "Unspecified",
             },

--- a/crates/junction-core/Cargo.toml
+++ b/crates/junction-core/Cargo.toml
@@ -12,7 +12,6 @@ form_urlencoded = { workspace = true }
 futures = { workspace = true }
 h2 = { workspace = true }
 http = { workspace = true }
-junction-api = { workspace = true }
 once_cell = { workspace = true }
 petgraph = { workspace = true }
 prost = { workspace = true }
@@ -31,6 +30,9 @@ tracing = { workspace = true }
 xds-api = { workspace = true, features = ["descriptor"] }
 xxhash-rust = { workspace = true }
 
+junction-api = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
+k8s-openapi = { version = "0.23", features = ["v1_29"] }

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -1,7 +1,7 @@
 use http::HeaderValue;
 use junction_api::{
     backend::{Backend, LbPolicy},
-    http::{HeaderMatch, Route, RouteMatch, RouteRule, WeightedTarget},
+    http::{HeaderMatch, Route, RouteMatch, RouteRule, WeightedBackend},
     Regex, Target,
 };
 use junction_core::Client;
@@ -30,7 +30,7 @@ async fn main() {
     let nginx_staging = Target::kube_service("default", "nginx-staging").unwrap();
 
     let default_routes = vec![Route {
-        target: nginx.clone().into_route(None),
+        vhost: nginx.clone().into_vhost(None),
         rules: vec![
             RouteRule {
                 matches: vec![RouteMatch {
@@ -40,15 +40,15 @@ async fn main() {
                     }],
                     ..Default::default()
                 }],
-                backends: vec![WeightedTarget {
-                    target: nginx_staging.clone().into_backend(80),
+                backends: vec![WeightedBackend {
+                    backend: nginx_staging.clone().into_backend(80),
                     weight: 1,
                 }],
                 ..Default::default()
             },
             RouteRule {
-                backends: vec![WeightedTarget {
-                    target: nginx.clone().into_backend(80),
+                backends: vec![WeightedBackend {
+                    backend: nginx.clone().into_backend(80),
                     weight: 1,
                 }],
                 ..Default::default()
@@ -57,11 +57,11 @@ async fn main() {
     }];
     let default_backends = vec![
         Backend {
-            target: nginx.into_backend(80),
+            id: nginx.into_backend(80),
             lb: LbPolicy::Unspecified,
         },
         Backend {
-            target: nginx_staging.into_backend(80),
+            id: nginx_staging.into_backend(80),
             lb: LbPolicy::Unspecified,
         },
     ];

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -53,7 +53,6 @@ impl EndpointAddress {
         Some(Self::SocketAddr(SocketAddr::new(ip, port)))
     }
 
-    #[allow(unused)]
     pub(crate) fn from_dns_name(xds_address: &xds_core::SocketAddress) -> Option<Self> {
         let address = xds_address.address.clone();
         let port = match xds_address.port_specifier.as_ref()? {

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use junction_api::Target;
+use junction_api::{BackendTarget, RouteTarget};
 
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -13,37 +13,40 @@ pub enum Error {
     #[error("invalid route configuration")]
     InvalidRoutes {
         message: &'static str,
-        target: Target,
+        target: RouteTarget,
         rule: usize,
     },
 
     #[error("invalid backend configuration")]
     InvalidBackends {
         message: &'static str,
-        target: Target,
+        target: BackendTarget,
     },
 
     #[error(
         "no routing info is available for any of the following targets: [{}]",
         format_targets(.routes)
     )]
-    NoRouteMatched { routes: Vec<Target> },
+    NoRouteMatched { routes: Vec<RouteTarget> },
 
     #[error("using route '{route}': no routing rules matched the request")]
-    NoRuleMatched { route: Target },
+    NoRuleMatched { route: RouteTarget },
 
     #[error("{route}: backend not found: {backend}")]
     NoBackend {
-        route: Target,
+        route: RouteTarget,
         rule: usize,
-        backend: Target,
+        backend: BackendTarget,
     },
 
     #[error("{backend}: no reachable endpoints")]
-    NoReachableEndpoints { route: Target, backend: Target },
+    NoReachableEndpoints {
+        route: RouteTarget,
+        backend: BackendTarget,
+    },
 }
 
-fn format_targets(targets: &[Target]) -> String {
+fn format_targets(targets: &[RouteTarget]) -> String {
     targets
         .iter()
         .map(|a| a.to_string())

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use junction_api::{BackendTarget, RouteTarget};
+use junction_api::{BackendId, VirtualHost};
 
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -13,41 +13,41 @@ pub enum Error {
     #[error("invalid route configuration")]
     InvalidRoutes {
         message: &'static str,
-        target: RouteTarget,
+        vhost: VirtualHost,
         rule: usize,
     },
 
     #[error("invalid backend configuration")]
     InvalidBackends {
         message: &'static str,
-        target: BackendTarget,
+        backend: BackendId,
     },
 
     #[error(
-        "no routing info is available for any of the following targets: [{}]",
-        format_targets(.routes)
+        "no routing info is available for any of the following vhosts: [{}]",
+        format_vhosts(.routes)
     )]
-    NoRouteMatched { routes: Vec<RouteTarget> },
+    NoRouteMatched { routes: Vec<VirtualHost> },
 
     #[error("using route '{route}': no routing rules matched the request")]
-    NoRuleMatched { route: RouteTarget },
+    NoRuleMatched { route: VirtualHost },
 
-    #[error("{route}: backend not found: {backend}")]
+    #[error("{vhost}: backend not found: {backend}")]
     NoBackend {
-        route: RouteTarget,
+        vhost: VirtualHost,
         rule: usize,
-        backend: BackendTarget,
+        backend: BackendId,
     },
 
-    #[error("{backend}: no reachable endpoints")]
+    #[error("{vhost}: no reachable endpoints")]
     NoReachableEndpoints {
-        route: RouteTarget,
-        backend: BackendTarget,
+        vhost: VirtualHost,
+        backend: BackendId,
     },
 }
 
-fn format_targets(targets: &[RouteTarget]) -> String {
-    targets
+fn format_vhosts(vhosts: &[VirtualHost]) -> String {
+    vhosts
         .iter()
         .map(|a| a.to_string())
         .collect::<Vec<_>>()

--- a/crates/junction-core/src/load_balancer.rs
+++ b/crates/junction-core/src/load_balancer.rs
@@ -3,7 +3,7 @@ use junction_api::{
     backend::{
         Backend, LbPolicy, RingHashParams, SessionAffinityHashParam, SessionAffinityHashParamType,
     },
-    BackendTarget, Target,
+    BackendId, Target,
 };
 use std::{
     collections::BTreeMap,
@@ -24,13 +24,10 @@ pub(crate) struct EndpointGroup {
 }
 
 impl EndpointGroup {
-    pub(crate) fn from_xds(
-        target: &BackendTarget,
-        cla: &xds_endpoint::ClusterLoadAssignment,
-    ) -> Self {
+    pub(crate) fn from_xds(target: &BackendId, cla: &xds_endpoint::ClusterLoadAssignment) -> Self {
         let make_address = match target.target {
             Target::Dns(_) => EndpointAddress::from_socket_addr,
-            Target::Service(_) => EndpointAddress::from_dns_name,
+            Target::KubeService(_) => EndpointAddress::from_dns_name,
         };
 
         let mut endpoints = BTreeMap::new();

--- a/crates/junction-core/src/load_balancer.rs
+++ b/crates/junction-core/src/load_balancer.rs
@@ -3,7 +3,7 @@ use junction_api::{
     backend::{
         Backend, LbPolicy, RingHashParams, SessionAffinityHashParam, SessionAffinityHashParamType,
     },
-    Target,
+    BackendTarget, Target,
 };
 use std::{
     collections::BTreeMap,
@@ -24,9 +24,12 @@ pub(crate) struct EndpointGroup {
 }
 
 impl EndpointGroup {
-    pub(crate) fn from_xds(target: &Target, cla: &xds_endpoint::ClusterLoadAssignment) -> Self {
-        let make_address = match target {
-            Target::DNS(_) => EndpointAddress::from_socket_addr,
+    pub(crate) fn from_xds(
+        target: &BackendTarget,
+        cla: &xds_endpoint::ClusterLoadAssignment,
+    ) -> Self {
+        let make_address = match target.target {
+            Target::Dns(_) => EndpointAddress::from_socket_addr,
             Target::Service(_) => EndpointAddress::from_dns_name,
         };
 

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
 use enum_map::EnumMap;
 use junction_api::backend::Backend;
 use junction_api::http::Route;
-use junction_api::Target;
+use junction_api::BackendTarget;
 use smol_str::SmolStr;
 use xds_api::pb::google::protobuf;
 use xds_api::{
@@ -526,7 +526,10 @@ pub(crate) struct LoadAssignment {
 }
 
 impl LoadAssignment {
-    pub(crate) fn from_xds(target: Target, xds: xds_endpoint::ClusterLoadAssignment) -> Self {
+    pub(crate) fn from_xds(
+        target: BackendTarget,
+        xds: xds_endpoint::ClusterLoadAssignment,
+    ) -> Self {
         let endpoint_group = Arc::new(EndpointGroup::from_xds(&target, &xds));
 
         Self {

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
 use enum_map::EnumMap;
 use junction_api::backend::Backend;
 use junction_api::http::Route;
-use junction_api::BackendTarget;
+use junction_api::BackendId;
 use smol_str::SmolStr;
 use xds_api::pb::google::protobuf;
 use xds_api::{
@@ -526,10 +526,7 @@ pub(crate) struct LoadAssignment {
 }
 
 impl LoadAssignment {
-    pub(crate) fn from_xds(
-        target: BackendTarget,
-        xds: xds_endpoint::ClusterLoadAssignment,
-    ) -> Self {
+    pub(crate) fn from_xds(target: BackendId, xds: xds_endpoint::ClusterLoadAssignment) -> Self {
         let endpoint_group = Arc::new(EndpointGroup::from_xds(&target, &xds));
 
         Self {

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -8,19 +8,10 @@ Duration = str | int | float
 """A duration expressed as a number of seconds or a string like '1h30m27s42ms'"""
 
 
-class TargetDNS(typing.TypedDict):
-    type: typing.Literal["DNS"]
+class TargetDns(typing.TypedDict):
+    type: typing.Literal["Dns"]
     hostname: str
     """The DNS name to target."""
-
-    port: int
-    """The port number to target/attach to.
-
-    When attaching policies, if it is not specified, the target will apply
-    to all connections that don't have a specific port specified.
-
-    When being used to lookup a backend after a matched rule, if it is not
-    specified then it will use the same port as the incoming request"""
 
 
 class TargetService(typing.TypedDict):
@@ -32,17 +23,38 @@ class TargetService(typing.TypedDict):
     """The namespace of the Kubernetes service to target. This must be explicitly
     specified, and won't be inferred from context."""
 
+
+Target = TargetDns | TargetService
+
+
+class RouteTarget(typing.TypedDict):
+    hostname: str
+    """The DNS name to target."""
+
+    name: str
+    """The name of the Kubernetes Service to target."""
+
+    namespace: str
+    """The namespace of the Kubernetes service to target. This must be explicitly
+    specified, and won't be inferred from context."""
+
+    type: typing.Literal["Dns"] | typing.Literal["Service"]
     port: int
-    """The port number of the Kubernetes service to target/ attach to.
-
-    When attaching policies, if it is not specified, the target will apply
-    to all connections that don't have a specific port specified.
-
-    When being used to lookup a backend after a matched rule, if it is not
-    specified then it will use the same port as the incoming request"""
 
 
-Target = TargetDNS | TargetService
+class BackendTarget(typing.TypedDict):
+    hostname: str
+    """The DNS name to target."""
+
+    name: str
+    """The name of the Kubernetes Service to target."""
+
+    namespace: str
+    """The namespace of the Kubernetes service to target. This must be explicitly
+    specified, and won't be inferred from context."""
+
+    type: typing.Literal["Dns"] | typing.Literal["Service"]
+    port: int
 
 
 class Fraction(typing.TypedDict):
@@ -64,16 +76,8 @@ class WeightedTarget(typing.TypedDict):
     """The namespace of the Kubernetes service to target. This must be explicitly
     specified, and won't be inferred from context."""
 
+    type: typing.Literal["Dns"] | typing.Literal["Service"]
     port: int
-    """The port number to target/attach to.
-
-    When attaching policies, if it is not specified, the target will apply
-    to all connections that don't have a specific port specified.
-
-    When being used to lookup a backend after a matched rule, if it is not
-    specified then it will use the same port as the incoming request"""
-
-    type: typing.Literal["DNS"] | typing.Literal["Service"]
 
 
 class RouteTimeouts(typing.TypedDict):
@@ -251,7 +255,7 @@ class Route(typing.TypedDict):
     one [RouteRule]. When a [RouteRule] matches, it also describes where and how
     the traffic should be directed to a [Backend](crate::backend::Backend)."""
 
-    target: Target
+    target: RouteTarget
     """The target for this route. The target determines the hostnames that map
     to this route."""
 
@@ -312,9 +316,8 @@ class Backend(typing.TypedDict):
     traffic routed to this backend will use its load balancing policy to evenly
     spread traffic across all available endpoints."""
 
-    target: Target
-    """The target this backend represents. A target may be a Kubernetes Service
-    or a DNS name. See [Target] for more."""
+    target: BackendTarget
+    """A unique description of what this backend is."""
 
     lb: LbPolicy
     """How traffic to this target should be load balanced."""

--- a/junction-python/samples/routing-and-load-balancing/client.py
+++ b/junction-python/samples/routing-and-load-balancing/client.py
@@ -39,7 +39,7 @@ def retry_sample(args):
     }
     default_routes: List[junction.config.Route] = [
         {
-            "target": default_target,
+            "vhost": default_target,
             "rules": [
                 {
                     "matches": [
@@ -83,9 +83,7 @@ def retry_sample(args):
 
 
 def path_match_sample(args):
-    print_header(
-        "Header Match - 50% of /feature-1/index sent to a different backend target"
-    )
+    print_header("Header Match - 50% of /feature-1/index sent to a different backend")
 
     default_target: junction.config.Target = {
         "name": "jct-http-server",
@@ -97,7 +95,7 @@ def path_match_sample(args):
     }
     default_routes: List[junction.config.Route] = [
         {
-            "target": default_target,
+            "vhost": default_target,
             "rules": [
                 {
                     "matches": [{"path": {"value": "/feature-1/index"}}],
@@ -162,7 +160,7 @@ def ring_hash_sample(args):
     }
     default_backends: List[junction.config.Backend] = [
         {
-            "target": default_target,
+            "id": default_target,
             "lb": {
                 "type": "RingHash",
                 "minRingSize": 1024,
@@ -202,7 +200,7 @@ def timeouts_sample(args):
     }
     default_routes: List[junction.config.Route] = [
         {
-            "target": default_target,
+            "vhost": default_target,
             "rules": [
                 {
                     "backends": [
@@ -246,7 +244,7 @@ def urllib3_sample(args):
     }
     default_routes: List[junction.config.Route] = [
         {
-            "target": default_target,
+            "vhost": default_target,
             "rules": [
                 {
                     "backends": [

--- a/junction-python/samples/routing-and-load-balancing/client.py
+++ b/junction-python/samples/routing-and-load-balancing/client.py
@@ -53,12 +53,12 @@ def retry_sample(args):
                         codes=[502], attempts=2, backoff="1ms"
                     ),
                     "backends": [
-                        feature_target,
+                        {**feature_target, "port": 8008},
                     ],
                 },
                 {
                     "backends": [
-                        default_target,
+                        {**default_target, "port": 8008},
                     ]
                 },
             ],
@@ -105,16 +105,18 @@ def path_match_sample(args):
                         {
                             **default_target,
                             "weight": 50,
+                            "port": 8008,
                         },
                         {
                             **feature_target,
                             "weight": 50,
+                            "port": 8008,
                         },
                     ],
                 },
                 {
                     "backends": [
-                        default_target,
+                        {**default_target, "port": 8008},
                     ]
                 },
             ],
@@ -158,7 +160,6 @@ def ring_hash_sample(args):
         "namespace": "default",
         "port": 8008,
     }
-    default_routes: List[junction.config.Route] = []
     default_backends: List[junction.config.Backend] = [
         {
             "target": default_target,
@@ -169,7 +170,7 @@ def ring_hash_sample(args):
             },
         }
     ]
-    session = junction.requests.Session(default_routes, default_backends)
+    session = junction.requests.Session(default_backends=default_backends)
 
     results = []
     for headers in [{}, {"USER": "user"}]:
@@ -205,7 +206,7 @@ def timeouts_sample(args):
             "rules": [
                 {
                     "backends": [
-                        default_target,
+                        {**default_target, "port": 8008},
                     ],
                     "timeouts": {"backend_request": "50ms"},
                 }
@@ -249,7 +250,7 @@ def urllib3_sample(args):
             "rules": [
                 {
                     "backends": [
-                        default_target,
+                        {**default_target, "port": 8008},
                     ],
                     "timeouts": {"backend_request": "50ms"},
                 }

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -315,8 +315,10 @@ fn dump_kube_route(
 ) -> PyResult<String> {
     let route: Route = pythonize::depythonize_bound(route)?;
 
-    let (namespace, name) = match &route.target.target {
-        junction_api::Target::Service(svc) => (Some(svc.namespace.clone()), Some(svc.name.clone())),
+    let (namespace, name) = match &route.vhost.target {
+        junction_api::Target::KubeService(svc) => {
+            (Some(svc.namespace.clone()), Some(svc.name.clone()))
+        }
         _ => (None, None),
     };
 

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -315,7 +315,7 @@ fn dump_kube_route(
 ) -> PyResult<String> {
     let route: Route = pythonize::depythonize_bound(route)?;
 
-    let (namespace, name) = match &route.target {
+    let (namespace, name) = match &route.target.target {
         junction_api::Target::Service(svc) => (Some(svc.namespace.clone()), Some(svc.name.clone())),
         _ => (None, None),
     };

--- a/junction-python/tests/test_routes.py
+++ b/junction-python/tests/test_routes.py
@@ -5,18 +5,18 @@ import pytest
 
 
 @pytest.fixture
-def nginx() -> junction.config.TargetService:
+def nginx() -> junction.config.Target:
     return {"namespace": "default", "name": "nginx"}
 
 
 @pytest.fixture
-def nginx_staging() -> junction.config.TargetService:
+def nginx_staging() -> junction.config.Target:
     return {"namespace": "default", "name": "nginx-staging"}
 
 
 def test_check_basic_route(nginx):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [{"backends": [{**nginx, "port": 80}]}],
     }
 
@@ -32,7 +32,7 @@ def test_check_basic_route(nginx):
 
 def test_check_basic_route_url_port(nginx):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [{"backends": [{**nginx, "port": 8888}]}],
     }
 
@@ -48,7 +48,7 @@ def test_check_basic_route_url_port(nginx):
 
 def test_check_basic_route_with_port(nginx):
     route: config.Route = {
-        "target": {**nginx, "port": 1234},
+        "vhost": {**nginx, "port": 1234},
         "rules": [{"backends": [{**nginx, "port": 1234}]}],
     }
 
@@ -82,7 +82,7 @@ def test_check_retry_and_timeouts(nginx):
     }
 
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [
             {"backends": [{**nginx, "port": 80}], "retry": retry, "timeouts": timeouts}
         ],
@@ -101,7 +101,7 @@ def test_check_retry_and_timeouts(nginx):
 
 def test_check_redirect_route(nginx, nginx_staging):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [{"backends": [{**nginx_staging, "port": 80}]}],
     }
 
@@ -117,7 +117,7 @@ def test_check_redirect_route(nginx, nginx_staging):
 
 def test_no_fallthrough(nginx, nginx_staging):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [
             {
                 "backends": [{**nginx_staging, "port": 80}],
@@ -141,7 +141,7 @@ def test_no_fallthrough(nginx, nginx_staging):
 
 def test_no_target(nginx, nginx_staging):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [
             {
                 "backends": [{**nginx_staging, "port": 80}],
@@ -170,7 +170,7 @@ def test_no_target(nginx, nginx_staging):
 )
 def test_check_headers_matches_default(headers, nginx, nginx_staging):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [
             {
                 "backends": [{**nginx_staging, "port": 80}],
@@ -194,7 +194,7 @@ def test_check_headers_matches_default(headers, nginx, nginx_staging):
 
 def test_check_headers_match(nginx, nginx_staging):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [
             {
                 "backends": [{**nginx_staging, "port": 80}],
@@ -220,7 +220,7 @@ def test_check_headers_match(nginx, nginx_staging):
 
 def test_check_path_matches_default(nginx, nginx_staging):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [
             {
                 "backends": [{**nginx_staging, "port": 80}],
@@ -245,7 +245,7 @@ def test_check_path_matches_default(nginx, nginx_staging):
 
 def test_check_path_matches(nginx, nginx_staging):
     route: config.Route = {
-        "target": nginx,
+        "vhost": nginx,
         "rules": [
             {
                 "backends": [{**nginx_staging, "port": 80}],


### PR DESCRIPTION
First pass at requiring ports for Backends. This involved no longer having `Target` everywhere, and specifying `Route` and `Backend` targets differently. There's more work here to make here to start allowing passthrough-ports by making the `backends` section of a RouteRule optional - in that case we'll use the top-level `Route` info and fill in the port based on the request URL. That may come in another commit or in another PR, but is what's required to undo the change from https://github.com/junction-labs/ezbake/pull/35.

`Target` is no longer the greatest name and needs some work to clean up - I'm tempted to rename `RouteTarget` to something like `RouteName` and `BackendTarget` to something like `BackendId`.