### PR TITLE
Add an unstructured `tags` field to Route

### DIFF
--- a/crates/junction-api-gen/src/python.rs
+++ b/crates/junction-api-gen/src/python.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use askama::Template;
 
 // TODO: To make mypy happy, we have to make TypedDict keys optional. This

--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -3,6 +3,8 @@
 //! A [Route] specifies the all of the top-level configuration for all HTTP
 //! traffic that matches a particular URL.
 
+use std::collections::BTreeMap;
+
 use crate::{
     shared::{Duration, Fraction, Regex},
     BackendId, Hostname, Name, Target, VirtualHost,
@@ -34,6 +36,10 @@ pub struct Route {
     /// list of `rules` to route traffic.
     pub vhost: VirtualHost,
 
+    /// A list of arbitrary tags that can be added to a Route.
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
+
     /// The rules that determine whether a request matches and where traffic
     /// should be routed.
     pub rules: Vec<RouteRule>,
@@ -50,6 +56,7 @@ impl Route {
         let backend = target.with_default_port(80).into_backend().unwrap();
         Route {
             vhost: target,
+            tags: Default::default(),
             rules: vec![RouteRule {
                 matches: vec![RouteMatch {
                     path: Some(PathMatch::empty_prefix()),
@@ -740,6 +747,7 @@ mod tests {
                     target: Target::kube_service("bar", "foo").unwrap(),
                     port: None,
                 },
+                tags: Default::default(),
                 rules: vec![RouteRule {
                     matches: vec![],
                     filters: vec![],

--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -14,6 +14,15 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "typeinfo")]
 use junction_typeinfo::TypeInfo;
 
+#[doc(hidden)]
+pub mod tags {
+    //! Well known tags for Routes.
+
+    /// Marks a Route as inferred from an environment and not configured by a
+    /// human being.
+    pub const INFERRED: &str = "junctionlabs.io/inferred";
+}
+
 /// A Route is high level policy that describes how a request to a specific
 /// [virtual host][crate::VirtualHost] should be routed.
 ///

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -31,6 +31,7 @@ async fn main() {
 
     let default_routes = vec![Route {
         vhost: nginx.clone().into_vhost(None),
+        tags: Default::default(),
         rules: vec![
             RouteRule {
                 matches: vec![RouteMatch {

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -591,6 +591,7 @@ mod test {
     fn test_resolve_route_no_backends() {
         let route = Route {
             vhost: Target::dns("example.com").unwrap().into_vhost(None),
+            tags: Default::default(),
             rules: vec![],
         };
 
@@ -621,6 +622,7 @@ mod test {
 
         let route = Route {
             vhost: Target::dns("example.com").unwrap().into_vhost(None),
+            tags: Default::default(),
             rules: vec![
                 RouteRule {
                     matches: vec![RouteMatch {
@@ -705,6 +707,7 @@ mod test {
 
         let route = Route {
             vhost: Target::dns("example.com").unwrap().into_vhost(None),
+            tags: Default::default(),
             rules: vec![
                 RouteRule {
                     matches: vec![RouteMatch {

--- a/crates/junction-typeinfo/src/lib.rs
+++ b/crates/junction-typeinfo/src/lib.rs
@@ -31,6 +31,7 @@ pub enum Kind {
     Union(&'static str, Vec<Variant>),
     Tuple(Vec<Kind>),
     Array(Box<Kind>),
+    Map(Box<Kind>, Box<Kind>),
     Object(&'static str),
 }
 
@@ -230,6 +231,12 @@ impl<T: TypeInfo> TypeInfo for Vec<T> {
 
     fn fields() -> Vec<Field> {
         Vec::new()
+    }
+}
+
+impl<K: TypeInfo, V: TypeInfo> TypeInfo for BTreeMap<K, V> {
+    fn kind() -> Kind {
+        crate::Kind::Map(Box::new(K::kind()), Box::new(V::kind()))
     }
 }
 

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -286,6 +286,9 @@ class Route(typing.TypedDict):
     """This route's virtual host. Traffic to this virutal host will use the
     list of `rules` to route traffic."""
 
+    tags: typing.Dict[str, str]
+    """A list of arbitrary tags that can be added to a Route."""
+
     rules: typing.List[RouteRule]
     """The rules that determine whether a request matches and where traffic
     should be routed."""


### PR DESCRIPTION
Adds an unstructured tags field to `Route` so we can smuggle metadata. xDS supports this with an explicit `metadata` field on RouteConfigurations and Listeners, and the Kube APIs support this through `annotations`.

The only downstream impact of that change is:

- We had to add `typing.Dict` support to junction-api-gen
- The conversions to/from the Gateway API structs now require full objects instead of just the `spec` so that we can look at annotations.