### PR TITLE
Use the generated-by tag to pick between default and xds routes

### DIFF
--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -80,31 +80,6 @@ impl Route {
             }],
         }
     }
-
-    #[doc(hidden)]
-    pub fn is_passthrough_route(&self) -> bool {
-        let rule = match &self.rules.as_slice() {
-            &[rule] => rule,
-            _ => return false,
-        };
-
-        let route_match = match &rule.matches.as_slice() {
-            &[route_match] => route_match,
-            _ => return false,
-        };
-
-        // one backend
-        rule.backends.len() == 1
-            // nothing else set
-            && rule.filters.is_empty()
-            && rule.timeouts.is_none()
-            && rule.retry.is_none()
-            // route_match is the empty path prefix match
-            && route_match == &RouteMatch {
-                path: Some(PathMatch::empty_prefix()),
-                ..Default::default()
-            }
-    }
 }
 
 /// Defines semantics for matching an HTTP request based on conditions (matches), processing it
@@ -658,15 +633,6 @@ mod tests {
         shared::Regex,
         Target,
     };
-
-    #[test]
-    fn test_passthrough_route() {
-        let route = Route::passthrough_route(VirtualHost {
-            target: Target::dns("example.com").unwrap(),
-            port: None,
-        });
-        assert!(route.is_passthrough_route())
-    }
 
     #[test]
     fn test_header_matcher() {

--- a/crates/junction-api/src/xds/backend.rs
+++ b/crates/junction-api/src/xds/backend.rs
@@ -261,7 +261,6 @@ impl SessionAffinity {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::http::Route;
 
     #[test]
     fn test_unspecified_lb_roundtrips() {
@@ -330,19 +329,6 @@ mod test {
         )
         .unwrap();
         assert_eq!(parsed, backend);
-    }
-
-    #[test]
-    fn test_passthrough_route_is_passthrough() {
-        let web = Target::kube_service("prod", "web").unwrap();
-
-        let backend = Backend {
-            id: web.into_backend(4321),
-            lb: LbPolicy::RoundRobin,
-        };
-
-        let route = Route::from_xds(&backend.to_xds_passthrough_route()).unwrap();
-        assert!(route.is_passthrough_route());
     }
 
     #[test]

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -300,16 +300,10 @@ impl Client {
     }
 }
 
-/// check whether or not a Route is inferred.
-///
-/// while moving to this, also checks is_passthrough_route so it works with
-/// older ezbakes
-pub(crate) fn is_generated_route(route: &Route) -> bool {
-    let is_generated = route
+fn is_generated_route(route: &Route) -> bool {
+    route
         .tags
-        .contains_key(junction_api::http::tags::GENERATED_BY);
-
-    is_generated || route.is_passthrough_route()
+        .contains_key(junction_api::http::tags::GENERATED_BY)
 }
 
 /// Generate the list of Targets that this URL maps to, taking into account the


### PR DESCRIPTION
Stop guessing at when a Route was auto-generated based on structure and start using the explicit junctionlabs.io/generated-by tag on Routes.