### PR TITLE
Allow omitting backends and route rules to pass-through ports

### DIFF
--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -55,6 +55,7 @@ pub struct Route {
 
     /// The rules that determine whether a request matches and where traffic
     /// should be routed.
+    #[serde(default)]
     pub rules: Vec<RouteRule>,
 }
 
@@ -65,8 +66,6 @@ impl Route {
     /// If this RouteTarget has no port specified, `80` will be used for the
     /// backend.
     pub fn passthrough_route(target: VirtualHost) -> Route {
-        // FIXME: stop assuming 80.
-        let backend = target.with_default_port(80).into_backend().unwrap();
         Route {
             vhost: target,
             tags: Default::default(),
@@ -75,7 +74,6 @@ impl Route {
                     path: Some(PathMatch::empty_prefix()),
                     ..Default::default()
                 }],
-                backends: vec![WeightedBackend { backend, weight: 1 }],
                 ..Default::default()
             }],
         }
@@ -144,6 +142,11 @@ pub struct RouteRule {
     pub retry: Option<RouteRetry>,
 
     /// Where the traffic should route if this rule matches.
+    ///
+    /// If no backends are specified, traffic is sent to the VirtualHost this
+    /// route was defined with, using the request's port to fill in any
+    /// defaults.
+    #[serde(default)]
     pub backends: Vec<WeightedBackend>,
 }
 

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
     #[error("{vhost}: backend not found: {backend}")]
     NoBackend {
         vhost: VirtualHost,
-        rule: usize,
+        rule: Option<usize>,
         backend: BackendId,
     },
 

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -5,22 +5,107 @@ use junction_api::{BackendId, VirtualHost};
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// An error when using the Junction client.
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+#[error("{inner}")]
+pub struct Error {
+    // boxed to keep the size of the error down. this apparently has a large
+    // effect on the performance of calls to functions that return
+    // Result<_, Error>.
+    //
+    // https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
+    // https://docs.rs/serde_json/latest/src/serde_json/error.rs.html#15-20
+    inner: Box<ErrorImpl>,
+}
+
+impl Error {
+    /// Returns `true` if this is a temporary error.
+    ///
+    /// Temporary errors may occur because of a network timeout or because of
+    /// lag fetching a configuration from a Junction server.
+    pub fn is_temporary(&self) -> bool {
+        matches!(
+            *self.inner,
+            ErrorImpl::NoRouteMatched { .. }
+                | ErrorImpl::NoBackend { .. }
+                | ErrorImpl::NoRuleMatched { .. }
+                | ErrorImpl::NoReachableEndpoints { .. }
+        )
+    }
+}
+
+impl Error {
+    // url problems
+
+    pub(crate) fn into_invalid_url(message: String) -> Self {
+        let inner = ErrorImpl::InvalidUrl(Cow::Owned(message));
+        Self {
+            inner: Box::new(inner),
+        }
+    }
+
+    pub(crate) fn invalid_url(message: &'static str) -> Self {
+        let inner = ErrorImpl::InvalidUrl(Cow::Borrowed(message));
+        Self {
+            inner: Box::new(inner),
+        }
+    }
+
+    // route problems
+
+    pub(crate) fn no_route_matched(routes: Vec<VirtualHost>) -> Self {
+        Self {
+            inner: Box::new(ErrorImpl::NoRouteMatched { routes }),
+        }
+    }
+
+    pub(crate) fn no_rule_matched(route: VirtualHost) -> Self {
+        Self {
+            inner: Box::new(ErrorImpl::NoRuleMatched { route }),
+        }
+    }
+
+    pub(crate) fn invalid_route(message: &'static str, vhost: VirtualHost, rule: usize) -> Self {
+        Self {
+            inner: Box::new(ErrorImpl::InvalidRoute {
+                message,
+                vhost,
+                rule,
+            }),
+        }
+    }
+
+    // backend problems
+
+    pub(crate) fn no_backend(vhost: VirtualHost, rule: Option<usize>, backend: BackendId) -> Self {
+        Self {
+            inner: Box::new(ErrorImpl::NoBackend {
+                vhost,
+                rule,
+                backend,
+            }),
+        }
+    }
+
+    pub(crate) fn no_reachable_endpoints(vhost: VirtualHost, backend: BackendId) -> Self {
+        Self {
+            inner: Box::new(ErrorImpl::NoReachableEndpoints { vhost, backend }),
+        }
+    }
+
+    // methods
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorImpl {
     #[error("invalid url: {0}")]
     InvalidUrl(Cow<'static, str>),
 
     #[error("invalid route configuration")]
-    InvalidRoutes {
+    InvalidRoute {
         message: &'static str,
         vhost: VirtualHost,
         rule: usize,
-    },
-
-    #[error("invalid backend configuration")]
-    InvalidBackends {
-        message: &'static str,
-        backend: BackendId,
     },
 
     #[error(
@@ -52,20 +137,4 @@ fn format_vhosts(vhosts: &[VirtualHost]) -> String {
         .map(|a| a.to_string())
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-impl Error {
-    pub(crate) fn invalid_url(message: String) -> Self {
-        Self::InvalidUrl(Cow::Owned(message))
-    }
-
-    pub(crate) fn is_temporary(&self) -> bool {
-        matches!(
-            self,
-            Error::NoRouteMatched { .. }
-                | Error::NoBackend { .. }
-                | Error::NoRuleMatched { .. }
-                | Error::NoReachableEndpoints { .. }
-        )
-    }
 }

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -263,7 +263,11 @@ class RouteRule(typing.TypedDict):
     """How to retry requests. If not specified, requests are not retried."""
 
     backends: typing.List[WeightedBackend]
-    """Where the traffic should route if this rule matches."""
+    """Where the traffic should route if this rule matches.
+
+    If no backends are specified, traffic is sent to the VirtualHost this
+    route was defined with, using the request's port to fill in any
+    defaults."""
 
 
 class Route(typing.TypedDict):

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -285,7 +285,7 @@ fn check_route(
     method: &str,
     url: &str,
     headers: &Bound<PyMapping>,
-) -> PyResult<(Py<PyAny>, usize, Py<PyAny>)> {
+) -> PyResult<(Py<PyAny>, Option<usize>, Py<PyAny>)> {
     let url: junction_core::Url = url
         .parse()
         .map_err(|e| PyValueError::new_err(format!("{e}")))?;
@@ -428,7 +428,7 @@ impl Junction {
         url: &str,
         headers: &Bound<PyMapping>,
         dynamic: bool,
-    ) -> PyResult<(Py<PyAny>, usize, Py<PyAny>)> {
+    ) -> PyResult<(Py<PyAny>, Option<usize>, Py<PyAny>)> {
         let method = method_from_py(method)?;
         let url =
             junction_core::Url::from_str(url).map_err(|e| PyValueError::new_err(format!("{e}")))?;


### PR DESCRIPTION
allows specifying a route with either missing backends, or missing match rules all together, that pass through traffic to a Route's vhost. this is a convenient shorthand for allowing routes that just configure timeouts and retries without getting into any route matching features. For example, this is now valid:

```python
    route: config.Route = {
        "vhost": nginx,
        "rules": [
            {
                "retry": {
                    "attempts": 3,
                }
            },
        ],
    }
```
There's a fair bit of line noise in this PR, but the meat of the interesting changes are in `junction-core` in `client.rs`. 

### xDS Notes

To get this to work with xDS, I'm shoving the route's `vhost` into the RouteAction cluster specifier instead of a `BackendId`. The client tries to parse a `BackendId` with a port, and if it can't find one, tries to parse the cluster specfier as a VirtualHost and compare it to the parent RouteConfiguraiton's virtual host. I'm not entirely happy with this being stringly-typed, and may try to see if we can use [one of the other options](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-routeaction) in RouteAction to do this more nicely.

Whatever we do with RouteConfigurations and RouteActions, these passthrough routes are outside of what gRPC xDS support can handle. The xdstp:// URLs don't make it easy to pull in request data outside of Listeners. Before committing to this, we should poke at how other folks are using the Gateway API passthrough HTTPRoutes to configure Envoy.