### PR TITLE
Use a built wheel in smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,3 +1,10 @@
+# run a smoke test of junction against the latest ezbake image
+#
+# this builds a wheel at the current version, installs it in the most vanilla
+# python image possible, and then runs the tests in a k3d cluster.
+#
+# at some point it should be possible to re-use this wheel to run pytests
+# and combine this job with junction-python-ci.
 name: smoke test
 
 on:
@@ -21,38 +28,74 @@ env:
   rust_min: 1.79
 
 jobs:
+  build-wheel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+    - name: build wheels
+      uses: PyO3/maturin-action@v1
+      with:
+        target: x86_64
+        args: --release --out dist --manifest-path junction-python/Cargo.toml
+        sccache: 'true'
+        manylinux: auto
+    - name: upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-linux-x86_64
+        path: dist/*.whl
+
   smoke-test:
     runs-on: ubuntu-latest
-    
+    needs: [build-wheel]
     steps:
       - name: checkout code
         uses: actions/checkout@master
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
       - uses: AbsaOSS/k3d-action@v2
         name: "Create single k3d Cluster with imported Registry"
         with:
-          cluster-name: test-cluster-1
+          cluster-name: test-cluster
           args: >-
             --agents 1
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-      - name: set up ezbake and server
+      - name: build server
         run: |
-          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+          docker build --tag jct_http_server:latest \
+              --file junction-python/samples/routing-and-load-balancing/Dockerfile-server .
+          k3d image import jct_http_server:latest -c test-cluster
+      - name: build client
+        run: |
+          docker build --tag jct_http_client:latest \
+            --file junction-python/samples/routing-and-load-balancing/Dockerfile-client . \
+            --build-arg junction_wheel=dist/**/*.whl
+          k3d image import jct_http_client:latest -c test-cluster
+      - name: set up kube manifests
+        run: |
+          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/experimental-install.yaml
           kubectl apply -f junction-python/samples/routing-and-load-balancing/latest_ezbake.yml
-          docker build --tag jct_http_server:latest --file junction-python/samples/routing-and-load-balancing/Dockerfile-server .
-          k3d image import jct_http_server:latest -c test-cluster-1
           kubectl apply -f junction-python/samples/routing-and-load-balancing/jct_http_server.yml
           kubectl apply -f junction-python/samples/routing-and-load-balancing/jct_http_server_feature_1.yml
-      - name: build test docker
+      - name: wait for rollouts
         run: |
-          docker build --tag jct_client:latest --file ./junction-python/samples/routing-and-load-balancing/Dockerfile-client .
-          k3d image import jct_client:latest -c test-cluster-1
+          kubectl rollout status --watch -n default deploy/jct-http-server
+          kubectl rollout status --watch -n default deploy/jct-http-server-feature-1
+          kubectl rollout status --watch -n junction deploy/ezbake
+          sleep 5 # this is a load-bearing sleep, we're waiting for ezbake to settle down
       - name: run test
         run: |
-          kubectl run jct-client --image=jct_client:latest --image-pull-policy=IfNotPresent --env="JUNCTION_ADS_SERVER=grpc://ezbake.junction.svc.cluster.local:8008" --restart=Never --attach
-      - name: Debug State
+          kubectl run jct-client --image=jct_http_client:latest --image-pull-policy=IfNotPresent --env="JUNCTION_ADS_SERVER=grpc://ezbake.junction.svc.cluster.local:8008" --restart=Never --attach
+      - name: debug state
         if: ${{ ! cancelled() }}
         run: |
             docker images -a
             docker ps -a
-            kubectl get pods -o wide
+            kubectl get pods -o wide --all-namespaces
+            kubectl get svc -o wide --all-namespaces
+            kubectl get po -n junction -o jsonpath='{.items[].metadata.name}' | xargs -IQ kubectl logs -n junction Q

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ for a simple server that lets you save Junction config using the
 
 ### Project status
 
-Junction is alpha software, developed in the open. We're
-still iterating rapidly on core code and APIs. At this stage you should expect
-occasional breaking changes as the library evolves. At the moment, Junction only
-supports talking to Kubernetes services, with support for routing to any
-existing DNS name coming very soon.
+Junction is alpha software, developed in the open. We're still iterating rapidly
+on core code and APIs. At this stage you should expect occasional breaking
+changes as the library evolves. At the moment, Junction only supports talking to
+Kubernetes services, with support for routing to any existing DNS name coming
+very soon.
 
 ### Features
 

--- a/README_ALPHA_TESTERS.md
+++ b/README_ALPHA_TESTERS.md
@@ -55,12 +55,6 @@ We're still early enough that we don't want to push packaged versions of our cod
 to PyPi and crates.io yet. For the meantime, we're going to ask you to build and
 install Junction and a simple control plane from source.
 
-### Rust and Python
-
-To get going on Junction, you need a working Rust toolchain and a system Python
-that you can use to bootstrap a virtualenv. If you don't have Rust installed,
-use [rustup](https://rustup.rs/) to get started.
-
 ### Kubernetes
 
 To do anything interesting with Junction, you currently need a running
@@ -78,18 +72,19 @@ instructions in [its README][ezbake-readme].
 
 ## Using Junction in Python
 
-To install `junction` into a virtualenv in this directory (`.venv`), run:
+Even though Junction is not installable through pypi, it's installable through
+our GitHub releases through `pip` or your favorite python dependency management
+tool. Head on over [to the `Python Tip` release] and find the appropriate
+package for your architecture, and use that URL as your package name.
+
+For example, to install `junction` on Apple Silicon with `pip`, run:
 
 ```shell
-cargo xtask python-build
+pip install --upgrade https://github.com/junction-labs/junction-client/releases/download/tip-python/junction-0.1.0-cp38-abi3-macosx_11_0_arm64.whl
 ```
 
-That's it! After you're done, run `source .venv/bin/activate` to activate your
-virtualenv and get started with `import junction`. Head back to the `README` and
-our samples and see what you can cook up.
-
-> **ADVANCED TIP**: To install `junction` into any other virtualenv, set your
-`VIRTUAL_ENV` environment variable and run `cargo xtask python-build`
+That's it! If you run into installation issues or would like to build from
+source, please let us know.
 
 ### Using Junction in Rust
 

--- a/junction-python/samples/routing-and-load-balancing/Dockerfile-client
+++ b/junction-python/samples/routing-and-load-balancing/Dockerfile-client
@@ -1,28 +1,18 @@
-## We don't do any of the clever incremtal stuff as it makes
-## the initial build take 1 minute longer, and the major purpose
-## of this container is in a github action where its always an 
-## initial build
+FROM python:3.12
 
-FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
-WORKDIR /app
-RUN apt update
-RUN apt install -y python3 python3-pip python3.11-venv python-is-python3
-RUN apt install -y 
+# the name of the junction package to install with pip this can be either a pypi
+# package name, a wheel URL, or a local path to a wheel.
+#
+# NOTE: If you're using this as a local path to a wheel, you may have to mount
+# the wheel into the container with Docker's --volume arg.
+ARG junction_wheel
 
-FROM chef AS builder 
-COPY ./junction-python ./junction-python
-COPY ./xtask ./xtask
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./crates ./crates
-COPY ./.cargo ./.cargo
-RUN cargo xtask python-build --maturin build
+WORKDIR /client
 
-FROM debian:bookworm-slim AS runtime
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip python-is-python3
-WORKDIR /app
-COPY --from=builder /app/target/wheels/junction-*.whl .
-RUN pip install ./*.whl --break-system-packages
+ADD ${junction_wheel} .
+
+RUN python -m venv .venv
+RUN .venv/bin/pip install --upgrade pip
+RUN .venv/bin/pip install *.whl
 ADD junction-python/samples/routing-and-load-balancing/client.py .
-CMD ["python", "./client.py"]
+CMD [".venv/bin/python", "./client.py"]


### PR DESCRIPTION
Use the maturin action (see #69 ) to build a wheel and test that in our smoke tests, instead of copying the wheel into our containers manually. This gives us a slightly more realistic test of what folks will install/run and means we can maybe re-use this in the `python-ci` action as well. That probably involves combining workflows in a bit of an unpleasant way or dealing with cross-workflow dependencies so I'm holding off on it for now.

This also changes the client Docker example to require a `junction_wheel` build arg. The only place that seems to get used is in this test.