### PR TITLE
Begin rate limiting impl

### DIFF
--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -379,6 +379,11 @@ pub enum HeaderMatch {
     )]
     RegularExpression { name: String, value: Regex },
 
+    Present {
+        name: String,
+        value: bool,
+    },
+
     #[serde(untagged)]
     Exact { name: String, value: String },
 }
@@ -388,6 +393,7 @@ impl HeaderMatch {
         match self {
             HeaderMatch::RegularExpression { name, .. } => name,
             HeaderMatch::Exact { name, .. } => name,
+            HeaderMatch::Present { name, .. } => name,
         }
     }
 
@@ -395,6 +401,7 @@ impl HeaderMatch {
         match self {
             HeaderMatch::RegularExpression { value, .. } => value.is_match(header_value),
             HeaderMatch::Exact { value, .. } => value == header_value,
+            HeaderMatch::Present { value, .. } => *value,
         }
     }
 }
@@ -409,10 +416,21 @@ pub enum QueryParamMatch {
         alias = "regular_expression",
         alias = "regularExpression"
     )]
-    RegularExpression { name: String, value: Regex },
+    RegularExpression {
+        name: String,
+        value: Regex,
+    },
+
+    Present {
+        name: String,
+        value: bool,
+    },
 
     #[serde(untagged)]
-    Exact { name: String, value: String },
+    Exact {
+        name: String,
+        value: String,
+    },
 }
 
 impl QueryParamMatch {
@@ -420,6 +438,7 @@ impl QueryParamMatch {
         match self {
             QueryParamMatch::RegularExpression { name, .. } => name,
             QueryParamMatch::Exact { name, .. } => name,
+            QueryParamMatch::Present { name, .. } => name,
         }
     }
 
@@ -427,6 +446,7 @@ impl QueryParamMatch {
         match self {
             QueryParamMatch::RegularExpression { value, .. } => value.is_match(param_value),
             QueryParamMatch::Exact { value, .. } => value == param_value,
+            QueryParamMatch::Present { value, .. } => *value,
         }
     }
 }

--- a/crates/junction-api/src/kube/http.rs
+++ b/crates/junction-api/src/kube/http.rs
@@ -120,7 +120,12 @@ impl TryFrom<&HTTPRoute> for crate::http::Route {
         let tags = read_tags(route.annotations());
         let rules = vec_from_gateway!(route.spec.rules).with_fields("spec", "rules")?;
 
-        Ok(Self { vhost, tags, rules })
+        Ok(Self {
+            vhost,
+            tags,
+            rules,
+            rate_limits: vec![],
+        })
     }
 }
 
@@ -139,6 +144,7 @@ impl TryFrom<&HTTPRouteRules> for crate::http::RouteRule {
             filters,
             timeouts,
             retry,
+            rate_limits: vec![],
             backends,
         })
     }
@@ -728,6 +734,7 @@ spec:
                 }],
                 ..Default::default()
             }],
+            rate_limits: vec![],
         };
 
         assert_eq!(
@@ -772,6 +779,7 @@ spec:
                     .into_vhost(None),
                 tags: Default::default(),
                 rules: vec![],
+                rate_limits: vec![],
             }
         );
     }
@@ -810,6 +818,7 @@ spec:
                 }],
                 ..Default::default()
             }],
+            rate_limits: vec![],
         };
 
         assert_eq!(

--- a/crates/junction-api/src/kube/http.rs
+++ b/crates/junction-api/src/kube/http.rs
@@ -519,6 +519,8 @@ impl TryFrom<&crate::http::QueryParamMatch> for HTTPRouteRulesMatchesQueryParams
                     value: value.clone(),
                 }
             }
+            // TODO: Should this be handled?
+            _ => unimplemented!(),
         })
     }
 }
@@ -566,6 +568,8 @@ impl TryFrom<&crate::http::HeaderMatch> for HTTPRouteRulesMatchesHeaders {
                 r#type: Some(HTTPRouteRulesMatchesHeadersType::Exact),
                 value: value.clone(),
             },
+            // TODO: Should this be handled?
+            _ => unimplemented!(),
         })
     }
 }

--- a/crates/junction-api/src/xds/http.rs
+++ b/crates/junction-api/src/xds/http.rs
@@ -754,6 +754,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![RouteRule {
                 backends: vec![WeightedBackend {
@@ -773,6 +774,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![RouteRule {
                 matches: vec![RouteMatch {
@@ -798,6 +800,7 @@ mod test {
 
         let original = Route {
             vhost: web.clone().into_vhost(None),
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![RouteRule {
                 ..Default::default()
@@ -810,6 +813,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![RouteRule {
                 matches: vec![RouteMatch {
@@ -831,6 +835,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: BTreeMap::from_iter([("foo".to_string(), "bar".to_string())]),
             rules: vec![RouteRule {
                 matches: vec![RouteMatch {
@@ -862,6 +867,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![
                 RouteRule {
@@ -914,6 +920,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![
                 RouteRule {
@@ -961,6 +968,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![
                 RouteRule {
@@ -1014,6 +1022,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![
                 RouteRule {
@@ -1060,6 +1069,7 @@ mod test {
                     target: web.clone(),
                     port: None,
                 },
+                rate_limits: Default::default(),
                 tags: Default::default(),
                 rules: vec![RouteRule {
                     matches: vec![
@@ -1098,6 +1108,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![RouteRule {
                 matches: vec![
@@ -1142,6 +1153,7 @@ mod test {
                 target: web.clone(),
                 port: None,
             },
+            rate_limits: Default::default(),
             tags: Default::default(),
             rules: vec![RouteRule {
                 matches: vec![RouteMatch {

--- a/crates/junction-api/src/xds/http.rs
+++ b/crates/junction-api/src/xds/http.rs
@@ -1196,6 +1196,29 @@ mod test {
     }
 
     #[test]
+    fn test_rate_limit_roundtrip() {
+        let web = Target::kube_service("prod", "web").unwrap();
+
+        assert_roundtrip::<_, xds_route::RouteConfiguration>(Route {
+            vhost: VirtualHost {
+                target: web.clone(),
+                port: None,
+            },
+            rate_limits: vec![RateLimit {
+                interval: Duration::from_secs(1),
+                refill_rate: 1,
+                capacity: 1,
+                bucket_by: vec![RateLimitBucket::Header(HeaderMatch::Present {
+                    name: "foo".to_string(),
+                    value: true,
+                })],
+            }],
+            tags: Default::default(),
+            rules: vec![],
+        });
+    }
+
+    #[test]
     fn test_multiple_rules_roundtrip() {
         let web = Target::kube_service("prod", "web").unwrap();
         let staging = Target::kube_service("staging", "web").unwrap();

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -137,6 +137,27 @@ class RouteRetry(typing.TypedDict):
     retries."""
 
 
+class HeaderRateLimitFilter(typing.TypedDict):
+    type: typing.Literal["header"]
+    name: str
+    value: str
+
+
+class QueryParamRateLimitFilter(typing.TypedDict):
+    type: typing.Literal["query_param"]
+    name: str
+    value: str
+
+
+RateLimitFilter = HeaderRateLimitFilter | QueryParamRateLimitFilter
+
+
+class RateLimit(typing.TypedDict):
+    """Configure client rate limit policy."""
+
+    filter: typing.List[RateLimitFilter]
+
+
 class HeaderValue(typing.TypedDict):
     name: str
     """The name of the HTTP Header. Note header names are case insensitive. (See

--- a/junction-python/samples/routing-and-load-balancing/client.py
+++ b/junction-python/samples/routing-and-load-balancing/client.py
@@ -40,6 +40,15 @@ def retry_sample(args):
     default_routes: List[junction.config.Route] = [
         {
             "vhost": default_target,
+            "rate-limit": junction.config.RouteLimit(
+                interval=10,
+                refill_rate=10,
+                capacity=100,
+                bucket_by=[
+                    {"header": "X-User-Id"},
+                    {"query_param": "limited"},
+                ],
+            ),
             "rules": [
                 {
                     "matches": [
@@ -49,6 +58,14 @@ def retry_sample(args):
                             ]
                         }
                     ],
+                    "rate-limit": junction.config.RateLimit(
+                        bucket_by=[{
+                            "header": "X-User-Id",
+                        }],
+                        interval=10,
+                        refill_rate=10,
+                        capacity=100,
+                    ),
                     "retry": junction.config.RouteRetry(
                         codes=[502],
                         attempts=2,


### PR DESCRIPTION
This is a rough start to introducing rate limiting. This work is incomplete. The progress so far sets up the basic data structure and implements the xDS plumbing. 

During in person design discussions the rough shape of the API would look something like this

```python
default_routes: List[junction.config.Route] = [
        {
            "vhost": default_target,
            "rate-limit": junction.config.RouteLimit(
                interval=10,
                refill_rate=10,
                capacity=100,
                bucket_by=[
                    {"header": "X-User-Id"},
                    {"query_param": "limited"},
                ],
            ),
            "rules": [
                {
                    "matches": [
                        ...
                    ],
                    "rate-limit": junction.config.RateLimit(
                        bucket_by=[{
                            "header": "X-User-Id",
                        }],
                        interval=10,
                        refill_rate=10,
                        capacity=100,
                    ),
                    ...,
                },
            ],
        }
    ]
```

Note that there are rate limits defined at two levels:

1. As a sibling of the vhost
2. Directly in a rule

This [configuration example](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter#id4) helped drive a lot of the design. It's important to note that envoy allows local rate-limits at both the virtual host and route level. The aforementioned config example only shows route specific rate-limits. There's also rate limit specifications that can happen as http filters (which appear as siblings to the listener), but this PR avoids that.  

## TODO

- [ ] Implement the kubernetes mapping
- [ ] Update the python client
- [ ] Add more tests