### PR TITLE
wait for xDS subscriptions

### DIFF
--- a/crates/junction-api-gen/Cargo.toml
+++ b/crates/junction-api-gen/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 description = """
 cross-language API generation for Junction
-""""
+"""
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -68,6 +68,7 @@ async fn main() {
     ];
     let mut client = client
         .with_defaults(default_routes, default_backends)
+        .await
         .unwrap();
 
     let url: junction_core::Url = "https://nginx.default.svc.cluster.local".parse().unwrap();
@@ -79,8 +80,12 @@ async fn main() {
     };
 
     loop {
-        let prod_endpoints = client.resolve_http(&http::Method::GET, &url, &prod_headers);
-        let staging_endpoints = client.resolve_http(&http::Method::GET, &url, &staging_headers);
+        let prod_endpoints = client
+            .resolve_http(&http::Method::GET, &url, &prod_headers)
+            .await;
+        let staging_endpoints = client
+            .resolve_http(&http::Method::GET, &url, &staging_headers)
+            .await;
 
         let mut error = false;
         if let Err(e) = &prod_endpoints {

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -42,11 +42,7 @@ pub fn check_route(
     url: &crate::Url,
     headers: &http::HeaderMap,
 ) -> Result<ResolvedRoute> {
-    let request = client::HttpRequest {
-        method,
-        url,
-        headers,
-    };
+    let request = client::HttpRequest::from_parts(method, url, headers)?;
 
     // resolve with an empty cache and the passed config used as defaults and a
     // no-op subscribe fn.
@@ -54,7 +50,7 @@ pub fn check_route(
     // TODO: do we actually want that or do we want to treat the passed routes
     // as the primary config?
     let config = StaticConfig::new(routes, Vec::new());
-    client::resolve_routes(&StaticConfig::default(), &config, request, |_| {})
+    client::resolve_routes(&StaticConfig::default(), &config, request)
 }
 
 pub(crate) trait ConfigCache {

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -28,6 +28,9 @@ use crate::BackendLb;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub(crate) enum ResourceError {
+    #[error("timed out")]
+    TimedOut,
+
     #[error("{0}")]
     InvalidResource(#[from] junction_api::Error),
 


### PR DESCRIPTION
To prep for handling DNS names, I wanted to go clean up route resolution and wire up the ability to wait for an xDS subscription. This is going to get more complicated as we add DNS names, as we'll have another data source to wait for, so having this in first felt useful.

### Waiting for xDS subscriptions

Notifications are a bit odd in xDS client land - we really only care about the _first_ time we request data for a resource. If we're looking for a Listener, for example, we only want to wait until it appears in cache. There is no reason to wait for any kind of pending update - after an ACK it could be minutes (or days!) until we get an update for that Listener. This is straightforward to handle in the cache - if there's data already in cache when a subscription request comes in from the client, notify it immediately. The cache only has to let the client wait for resources that have no data.

It turns out the client also doesn't want to wait for every resource it requests. It doesn't have prior knowledge about what xDS names exist or not, and it needs to be able to proceed without figuring that out. Rather than doing something ndots like here, I had the client wait only for the first set of its names to come back from the server. This is a bit racy, and we may have to split this into waiting per-resource-type, but I don't want to that until we're actually waiting on endpoints, which I expect we'll have to do when adding DNS support.

### Timeouts

Only waiting for _some_ notifications to complete means we have to either wait forever or give up on some of our notifications. This felt like a reasonable time and place to go tackle timeouts on resources.

The cache now tracks the time a client subscription was added. The actual timing-out is pushed to each individual xDS connection, which sets a timer on message send. After that timer fires, we walk the cache to find any resources that are "too old" and still haven't gotten data, set them as having a timeout error, and immediately notify any waiting clients.

### Spelling the cache correctly

At the end of all of this, I realized I had a bunch of mixed metaphors and bad names in the cache. Those are all cleaned up in a separate commit, along with some tending to the documentation.

### This is still incomplete

This is all still incomplete until we go back in to do the work for DNS backends. Right now, nothing in the client knows about or waits for anything that looks like an endpoint, so there's no reasonable place to wait on the cache. [c085532](https://github.com/junction-labs/junction-client/pull/83/commits/c085532947806a1b1ebb592561e3f40f5e2a7c56) adds back in the janky retry loop to hide it.