### PR TITLE
Resolve DNS targets

### DIFF
--- a/crates/junction-core/examples/dns-backend.rs
+++ b/crates/junction-core/examples/dns-backend.rs
@@ -1,0 +1,69 @@
+use std::{collections::BTreeMap, env, time::Duration};
+
+use http::Method;
+use junction_api::{
+    backend::{Backend, LbPolicy},
+    http::Route,
+    Target,
+};
+use junction_core::Client;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let server_addr =
+        env::var("JUNCTION_ADS_SERVER").unwrap_or("http://127.0.0.1:8008".to_string());
+
+    let client = Client::build(
+        server_addr,
+        "example-client".to_string(),
+        "example-cluster".to_string(),
+    )
+    .await
+    .unwrap();
+
+    let httpbin = Target::dns("httpbin.org").unwrap();
+
+    let default_route = Route {
+        vhost: httpbin.clone().into_vhost(None),
+        tags: BTreeMap::new(),
+        rules: vec![],
+    };
+    let http_backend = Backend {
+        id: httpbin.clone().into_backend(80),
+        lb: LbPolicy::RoundRobin,
+    };
+    let https_backend = Backend {
+        id: httpbin.clone().into_backend(443),
+        lb: LbPolicy::RoundRobin,
+    };
+
+    let mut client = client
+        .with_defaults(vec![default_route], vec![http_backend, https_backend])
+        .unwrap();
+
+    let http_url: junction_core::Url = "http://httpbin.org".parse().unwrap();
+    let https_url: junction_core::Url = "https://httpbin.org".parse().unwrap();
+    let headers = http::HeaderMap::new();
+
+    loop {
+        match client.resolve_http(&Method::GET, &http_url, &headers) {
+            Ok(endpoints) => {
+                eprintln!("http: {}", &endpoints[0].address);
+            }
+            Err(e) => eprintln!("oops, something went wrong: {e:?}"),
+        }
+        match client.resolve_http(&Method::GET, &https_url, &headers) {
+            Ok(endpoints) => {
+                eprintln!("https: {}", &endpoints[0].address);
+            }
+            Err(e) => eprintln!("oops, something went wrong: {e:?}"),
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}

--- a/crates/junction-core/src/dns.rs
+++ b/crates/junction-core/src/dns.rs
@@ -1,0 +1,578 @@
+use std::{
+    collections::{btree_map, BTreeMap, BTreeSet},
+    io,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Condvar, Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+use junction_api::Hostname;
+use rand::Rng;
+
+use crate::load_balancer::EndpointGroup;
+
+/// A blocking resolver that uses the stdlib to resolve hostnames to addresses.
+///
+/// Names are resolved regularly in the background. If the addresses behind a
+/// name change, or a resolution error occurs, the results are broadcast over
+/// a channel (see the `subscribe` method) to all subscribers.
+///
+/// Behind the scenes, this resolver uses a fixed pool of threads to
+/// periodically resolve all of the addresses for a name. On every resolution,
+/// the returned set of IP addresses is treated as the entire set of addresses
+/// that make up a name and overwrites any previous addreses.  This roughly
+/// corresponds to Envoy's [STRICT_DNS] approach to resolution.
+///
+/// A StdlibResolver spawns its own pool of worker threads in the background
+/// that exit when the resolver is dropped.
+///
+/// [STRICT_DNS]: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/service_discovery#strict-dns
+#[derive(Clone, Debug)]
+pub(crate) struct StdlibResolver {
+    inner: Arc<StdlibResolverInner>,
+}
+
+// internal state for a stdlib resolver, shared between all of its workers. the
+// internal ResolverTasks functions as a work queue, and worker threads use a
+// mutex/condvar pair to wait for the next task or to chill until a new task
+// is added to the queue.
+#[derive(Debug)]
+struct StdlibResolverInner {
+    lookup_interval: Duration,
+    lookup_jitter: Duration,
+
+    cond: Condvar,
+    tasks: Mutex<ResolverState>,
+    shutdown: Arc<AtomicBool>,
+}
+
+macro_rules! no_poison {
+    ($guard:expr) => {
+        $guard.expect("SystemResolver was poisoned: this is a bug in Junction")
+    };
+}
+
+impl Drop for StdlibResolver {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl StdlibResolver {
+    pub(crate) fn new_with(
+        lookup_interval: Duration,
+        lookup_jitter: Duration,
+        threads: usize,
+    ) -> Self {
+        let inner = StdlibResolverInner {
+            lookup_interval,
+            lookup_jitter,
+            tasks: Mutex::new(ResolverState::default()),
+            cond: Condvar::new(),
+            shutdown: Arc::new(AtomicBool::new(false)),
+        };
+        let resolver = StdlibResolver {
+            inner: Arc::new(inner),
+        };
+
+        for _ in 0..=threads {
+            let resolver = resolver.clone();
+            std::thread::spawn(move || resolver.run());
+        }
+
+        resolver
+    }
+
+    pub(crate) fn get_endpoints(
+        &self,
+        hostname: &Hostname,
+        port: u16,
+    ) -> Option<Arc<EndpointGroup>> {
+        let tasks = no_poison!(self.inner.tasks.lock());
+        tasks.get_endpoints(hostname, port)
+    }
+
+    fn shutdown(&self) {
+        self.inner.shutdown.store(true, Ordering::Release);
+    }
+
+    fn is_shutdown(&self) -> bool {
+        self.inner.shutdown.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn subscribe(&self, name: Hostname, port: u16) {
+        let mut tasks = no_poison!(self.inner.tasks.lock());
+        tasks.pin(name, port);
+        self.inner.cond.notify_all();
+    }
+
+    pub(crate) fn unsubscribe(&self, name: &Hostname, port: u16) {
+        let mut tasks = no_poison!(self.inner.tasks.lock());
+        tasks.remove(name, port);
+        self.inner.cond.notify_all();
+    }
+
+    pub(crate) fn set_names(&self, new_names: impl IntoIterator<Item = (Hostname, u16)>) {
+        let new_names = new_names.into_iter();
+
+        let mut tasks = no_poison!(self.inner.tasks.lock());
+        if tasks.update_all(new_names) {
+            self.inner.cond.notify_all();
+        }
+    }
+
+    pub(crate) fn run(&self) {
+        tracing::trace!("thread starting");
+        loop {
+            // grab the next name
+            tracing::trace!("waiting for next name");
+            let Some(name) = self.next_name() else {
+                tracing::trace!("thread exiting");
+                return;
+            };
+
+            // do the DNS lookup
+            //
+            // this always uses 80 and then immediately discards the port. we
+            // don't actually care about what the port is here.
+            tracing::trace!(%name, "starting lookup");
+            let addr = (&name[..], 80);
+            let answer = std::net::ToSocketAddrs::to_socket_addrs(&addr).map(|answer| {
+                // TODO: we're filtering out every v6 address here. this isn't
+                // corect long term - we need to define how we want to control
+                // v4/v6 at the api level.
+                answer.filter(|a| a.is_ipv4()).collect()
+            });
+
+            // save the answer
+            tracing::trace!(
+                %name,
+                ?answer,
+                "saving answer",
+            );
+            self.insert_answer(name, Instant::now(), answer);
+        }
+    }
+
+    fn next_name(&self) -> Option<Hostname> {
+        let mut tasks = no_poison!(self.inner.tasks.lock());
+
+        loop {
+            if self.is_shutdown() {
+                return None;
+            }
+
+            // claim a name older than the cutoff
+            let before = Instant::now() - self.inner.lookup_interval;
+            if let Some(name) = tasks.next_name(before) {
+                tracing::trace!(%name, "claimed name");
+                return Some(name.clone());
+            }
+
+            // if there's nothing to do, sleep until there is. add a little
+            // bit of jitter here to spread out the load this puts on upstream
+            // dns servers.
+            //
+            // if there's no task, just sleep until notified
+            let wait_time = tasks.min_resolved_at().map(|t| {
+                let d = t.saturating_duration_since(Instant::now());
+                d + self.inner.lookup_interval + rng_jitter(self.inner.lookup_jitter)
+            });
+
+            tracing::trace!(?wait_time, "waiting for new name");
+            match wait_time {
+                Some(wait_time) => {
+                    (tasks, _) = no_poison!(self.inner.cond.wait_timeout(tasks, wait_time));
+                }
+                None => tasks = no_poison!(self.inner.cond.wait(tasks)),
+            }
+        }
+    }
+
+    fn insert_answer(
+        &self,
+        name: Hostname,
+        resolved_at: Instant,
+        answer: io::Result<Vec<SocketAddr>>,
+    ) {
+        let mut tasks = no_poison!(self.inner.tasks.lock());
+        tasks.insert_answer(&name, resolved_at, answer);
+    }
+}
+
+fn rng_jitter(max: Duration) -> Duration {
+    let secs = crate::rand::with_thread_rng(|rng| rng.gen_range(0.0..max.as_secs_f64()));
+
+    Duration::from_secs_f64(secs)
+}
+
+#[derive(Debug, Default)]
+struct ResolverState(BTreeMap<Hostname, NameInfo>);
+
+#[derive(Debug, Default)]
+struct NameInfo {
+    ports: BTreeMap<u16, PortInfo>,
+    in_flight: bool,
+    resolved_at: Option<Instant>,
+    last_addrs: Option<Vec<SocketAddr>>,
+    last_error: Option<io::Error>,
+}
+
+#[derive(Debug, Default)]
+struct PortInfo {
+    pinned: bool,
+    endpoint_group: Arc<EndpointGroup>,
+}
+
+impl NameInfo {
+    fn merge_answer(&mut self, now: Instant, answer: io::Result<Vec<SocketAddr>>) {
+        // always update time
+        self.resolved_at = Some(now);
+
+        // update eitehr the endpoints or error based on the answer
+        match answer {
+            Ok(mut addrs) => {
+                self.last_error = None;
+
+                // normalize addrs
+                addrs.sort();
+
+                // if the addrs have changed, update both the raw addrs and the
+                // EndpointGroup for each port.
+                if Some(&addrs) != self.last_addrs.as_ref() {
+                    for (port, port_info) in self.ports.iter_mut() {
+                        let addrs = addrs.iter().cloned().map(|mut addr| {
+                            addr.set_port(*port);
+                            addr
+                        });
+                        port_info.endpoint_group = Arc::new(EndpointGroup::from_dns_addrs(addrs))
+                    }
+                    self.last_addrs = Some(addrs);
+                }
+            }
+            Err(e) => self.last_error = Some(e),
+        }
+    }
+
+    fn resolved_before(&self, t: Instant) -> bool {
+        match self.resolved_at {
+            Some(resolved_at) => resolved_at < t,
+            None => true,
+        }
+    }
+}
+
+impl ResolverState {
+    fn next_name(&mut self, before: Instant) -> Option<&Hostname> {
+        let mut min: Option<(_, &mut NameInfo)> = None;
+
+        for (name, state) in &mut self.0 {
+            if state.in_flight {
+                continue;
+            }
+
+            match state.resolved_at {
+                Some(t) => {
+                    if t <= before && min.as_ref().map_or(true, |(_, s)| s.resolved_before(t)) {
+                        min = Some((name, state))
+                    }
+                }
+                None => {
+                    state.in_flight = true;
+                    return Some(name);
+                }
+            }
+        }
+
+        min.map(|(name, state)| {
+            state.in_flight = true;
+            name
+        })
+    }
+
+    fn min_resolved_at(&self) -> Option<Instant> {
+        self.0.values().filter_map(|state| state.resolved_at).min()
+    }
+
+    fn get_endpoints(&self, hostname: &Hostname, port: u16) -> Option<Arc<EndpointGroup>> {
+        let name_info = self.0.get(hostname)?;
+        let port_info = name_info.ports.get(&port)?;
+        Some(port_info.endpoint_group.clone())
+    }
+
+    fn insert_answer(
+        &mut self,
+        hostname: &Hostname,
+        resolved_at: Instant,
+        answer: io::Result<Vec<SocketAddr>>,
+    ) {
+        // only update if there's still state for this name.
+        //
+        // if there's no state for this name it's because the set of target
+        // names changed and we're not interested anymore.
+        if let Some(state) = self.0.get_mut(hostname) {
+            state.in_flight = false;
+            state.merge_answer(resolved_at, answer);
+        }
+    }
+
+    fn pin(&mut self, hostname: Hostname, port: u16) {
+        let name_info = self.0.entry(hostname).or_default();
+        let port_info = name_info.ports.entry(port).or_default();
+        port_info.pinned = true;
+    }
+
+    fn remove(&mut self, hostname: &Hostname, port: u16) {
+        let mut remove = false;
+        if let Some(entry) = self.0.get_mut(hostname) {
+            entry.ports.remove(&port);
+            remove = entry.ports.is_empty();
+        };
+
+        if remove {
+            self.0.remove(hostname);
+        }
+    }
+
+    fn update_all(&mut self, new_names: impl IntoIterator<Item = (Hostname, u16)>) -> bool {
+        // build an index of name -> [port] for the union of all names in the
+        // new set of names and the old set of names.
+        //
+        // this currently involves recloning every key in this map, but that
+        // should be ok since we expect hostname clones to be (relatively)
+        // cheap.
+        let mut names: BTreeMap<_, Vec<_>> = BTreeMap::new();
+        for name in self.0.keys() {
+            names.insert(name.clone(), Vec::new());
+        }
+        for (name, port) in new_names {
+            names.entry(name).or_default().push(port);
+        }
+
+        // iterate through the names index, for every set of ports, modify the
+        // name info so it only contains the listed ports or any existing pinned
+        // ports. the APIs for removing an entry we've already creatd here are not
+        // good, so don't actually do removal in this step.
+        let mut changed = false;
+        for (name, new_ports) in &names {
+            let name_info = self.0.entry(name.clone()).or_default();
+
+            let mut to_remove = BTreeSet::new();
+            for (port, port_info) in &name_info.ports {
+                if port_info.pinned {
+                    continue;
+                }
+                to_remove.insert(*port);
+            }
+
+            for port in new_ports {
+                to_remove.remove(port);
+                if let btree_map::Entry::Vacant(e) = name_info.ports.entry(*port) {
+                    changed = true;
+                    e.insert(PortInfo::default());
+                }
+            }
+
+            for port in to_remove {
+                changed |= name_info.ports.remove(&port).is_some();
+            }
+        }
+
+        // take another pass through to remove every (k, v) pair where v
+        // doesn't actually have any ports to keep track of.
+        self.0.retain(|_, info| !info.ports.is_empty());
+
+        changed
+    }
+
+    #[cfg(test)]
+    fn names_and_ports(&self) -> Vec<(&str, Vec<u16>)> {
+        self.0
+            .iter()
+            .map(|(name, info)| {
+                let name = name.as_ref();
+                let ports = info.ports.keys().cloned().collect();
+                (name, ports)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    #[inline]
+    fn update_all(
+        resolver: &mut ResolverState,
+        names: impl IntoIterator<Item = (&'static str, u16)>,
+    ) {
+        resolver.update_all(
+            names
+                .into_iter()
+                .map(|(name, port)| (Hostname::from_static(name), port)),
+        );
+    }
+
+    #[test]
+    fn test_answers() {
+        let mut resolver = ResolverState::default();
+
+        update_all(
+            &mut resolver,
+            [("www.junctionlabs.io", 80), ("www.junctionlabs.io", 443)],
+        );
+
+        resolver.insert_answer(
+            &Hostname::from_static("www.junctionlabs.io"),
+            Instant::now(),
+            // the port here shouldn't matter
+            Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234)]),
+        );
+
+        assert_eq!(
+            resolver
+                .get_endpoints(&Hostname::from_static("www.junctionlabs.io"), 80)
+                .as_deref(),
+            Some(&EndpointGroup::from_dns_addrs(vec![SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                80,
+            )])),
+        );
+        assert_eq!(
+            resolver
+                .get_endpoints(&Hostname::from_static("www.junctionlabs.io"), 443)
+                .as_deref(),
+            Some(&EndpointGroup::from_dns_addrs(vec![SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                443,
+            )])),
+        );
+        assert_eq!(
+            resolver
+                .get_endpoints(&Hostname::from_static("www.junctionlabs.io"), 1234)
+                .as_deref(),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_resolver_tasks_next() {
+        let mut resolver = ResolverState::default();
+
+        update_all(
+            &mut resolver,
+            [
+                ("doesnotexistihopereallybad.com", 80),
+                ("www.junctionlabs.io", 80),
+                ("www.junctionlabs.io", 443),
+            ],
+        );
+
+        let now = Instant::now();
+        // there should be two tasks available, the fourth next_name should
+        // return nothing.
+        assert!(resolver.next_name(now).is_some());
+        assert!(resolver.next_name(now).is_some());
+        assert!(resolver.next_name(now).is_none());
+
+        assert_eq!(
+            resolver.names_and_ports(),
+            &[
+                ("doesnotexistihopereallybad.com", vec![80]),
+                ("www.junctionlabs.io", vec![80, 443]),
+            ]
+        );
+
+        // resolve one name.
+        resolver.insert_answer(
+            &Hostname::from_static("www.junctionlabs.io"),
+            now,
+            Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80)]),
+        );
+        // with a timestamp in the past, there should be no name available
+        assert!(resolver.next_name(now - Duration::from_millis(1)).is_none());
+        // with a timestamp in the future, there should be one name available
+        assert!(resolver.next_name(now + Duration::from_millis(1)).is_some());
+        assert!(resolver.next_name(now + Duration::from_millis(1)).is_none());
+
+        assert_eq!(
+            resolver.names_and_ports(),
+            &[
+                ("doesnotexistihopereallybad.com", vec![80]),
+                ("www.junctionlabs.io", vec![80, 443]),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_pinned_name() {
+        let mut resolver = ResolverState::default();
+
+        resolver.pin(Hostname::from_static("important.com"), 1234);
+
+        update_all(&mut resolver, [("www.example.com", 80)]);
+        assert_eq!(
+            resolver.names_and_ports(),
+            &[("important.com", vec![1234]), ("www.example.com", vec![80]),]
+        );
+
+        update_all(&mut resolver, [("www.newthing.com", 80)]);
+        assert_eq!(
+            resolver.names_and_ports(),
+            &[
+                ("important.com", vec![1234]),
+                ("www.newthing.com", vec![80]),
+            ]
+        );
+
+        update_all(&mut resolver, [("www.newthing.com", 443)]);
+        assert_eq!(
+            resolver.names_and_ports(),
+            &[
+                ("important.com", vec![1234]),
+                ("www.newthing.com", vec![443]),
+            ]
+        );
+
+        resolver.remove(&Hostname::from_static("important.com"), 1234);
+        update_all(&mut resolver, [("www.newthing.com", 443)]);
+        assert_eq!(
+            resolver.names_and_ports(),
+            &[("www.newthing.com", vec![443]),]
+        );
+    }
+
+    #[test]
+    fn test_reset_drops_inflight() {
+        let mut resolver = ResolverState::default();
+
+        update_all(&mut resolver, [("www.example.com", 8910)]);
+
+        let now = Instant::now();
+
+        // take one name
+        assert!(resolver.next_name(now).is_some());
+
+        // reset while the name is in-flight. should have one more name to take.
+        update_all(&mut resolver, [("www.junctionlabs.io", 8910)]);
+        assert!(resolver.next_name(now).is_some());
+        assert!(resolver.next_name(now).is_none());
+
+        // inserting the old answer shouldn't do anything
+        resolver.insert_answer(
+            &Hostname::from_static("www.example.com"),
+            now,
+            Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80)]),
+        );
+        assert_eq!(
+            resolver.names_and_ports(),
+            &[("www.junctionlabs.io", vec![8910])]
+        );
+    }
+}

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -19,7 +19,7 @@ pub struct Endpoint {
 ///
 /// Depending on the type of endpoint, addresses may need to be further resolved by
 /// a client implementation.
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum EndpointAddress {
     /// A resolved IP address and port. This address can be used for a request
     /// without any further resolution.
@@ -30,6 +30,15 @@ pub enum EndpointAddress {
     ///
     /// This name may be different than the hostname part of an [Endpoint]'s `url`.
     DnsName(String, u32),
+}
+
+impl<T> From<T> for EndpointAddress
+where
+    T: Into<SocketAddr>,
+{
+    fn from(t: T) -> Self {
+        Self::SocketAddr(t.into())
+    }
 }
 
 impl std::fmt::Display for EndpointAddress {

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -11,6 +11,7 @@ mod endpoints;
 pub use endpoints::{Endpoint, EndpointAddress};
 
 mod client;
+mod dns;
 mod load_balancer;
 mod xds;
 

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -59,10 +59,8 @@ pub fn check_route(
 
 pub(crate) trait ConfigCache {
     fn get_route(&self, target: &VirtualHost) -> Option<Arc<Route>>;
-    fn get_backend(
-        &self,
-        target: &BackendId,
-    ) -> (Option<Arc<BackendLb>>, Option<Arc<EndpointGroup>>);
+    fn get_backend(&self, target: &BackendId) -> Option<Arc<BackendLb>>;
+    fn get_endpoints(&self, backend: &BackendId) -> Option<Arc<EndpointGroup>>;
 
     fn get_route_with_fallbacks(&self, targets: &[VirtualHost]) -> Option<Arc<Route>> {
         for target in targets {
@@ -111,10 +109,11 @@ impl ConfigCache for StaticConfig {
         self.routes.get(target).cloned()
     }
 
-    fn get_backend(
-        &self,
-        target: &BackendId,
-    ) -> (Option<Arc<BackendLb>>, Option<Arc<EndpointGroup>>) {
-        (self.backends.get(target).cloned(), None)
+    fn get_backend(&self, target: &BackendId) -> Option<Arc<BackendLb>> {
+        self.backends.get(target).cloned()
+    }
+
+    fn get_endpoints(&self, _: &BackendId) -> Option<Arc<EndpointGroup>> {
+        None
     }
 }

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -138,7 +138,7 @@ impl std::fmt::Display for ShutdownError {
 
 macro_rules! trace_xds_request {
     ($request:expr) => {
-        tracing::trace!(
+        tracing::debug!(
             nack = $request.error_detail.is_some(),
             "DiscoveryRequest(v={:?}, n={:?}, ty={:?}, r={:?})",
             $request.version_info,
@@ -151,7 +151,7 @@ macro_rules! trace_xds_request {
 
 macro_rules! trace_xds_response {
     ($response:expr) => {
-        tracing::trace!(
+        tracing::debug!(
             "DiscoveryResponse(v={:?}, n={:?}, ty={:?}, r_count={:?})",
             $response.version_info,
             $response.nonce,

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -112,7 +112,7 @@ impl AdsClient {
 
     pub fn subscribe(&self, resource_type: ResourceType, name: String) -> Result<(), ()> {
         self.subscriptions
-            .blocking_send(SubscriptionUpdate::Add(resource_type, name))
+            .try_send(SubscriptionUpdate::Add(resource_type, name))
             .map_err(|_| ())?;
 
         Ok(())

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -229,6 +229,10 @@ impl ResourceTypeSet {
     pub(crate) fn insert(&mut self, resource_type: ResourceType) {
         self.0[resource_type] = true
     }
+
+    pub(crate) fn contains(&self, resource_type: ResourceType) -> bool {
+        self.0[resource_type]
+    }
 }
 
 /// A typed reference to another resource.
@@ -432,11 +436,10 @@ impl RouteConfig {
     }
 }
 
-// TODO: Figure out wtf to do to support logical_dns clusters.
 #[derive(Clone, Debug)]
 pub(crate) struct Cluster {
-    pub xds: xds_cluster::Cluster,
-    pub backend_lb: Arc<BackendLb>,
+    pub(crate) xds: xds_cluster::Cluster,
+    pub(crate) backend_lb: Arc<BackendLb>,
 }
 
 impl Cluster {
@@ -446,6 +449,7 @@ impl Cluster {
     ) -> Result<Self, ResourceError> {
         let backend = Backend::from_xds(&xds, default_action)?;
         let load_balancer = LoadBalancer::from_config(&backend.lb);
+
         let backend_lb = Arc::new(BackendLb {
             config: backend,
             load_balancer,

--- a/crates/junction-core/src/xds/test.rs
+++ b/crates/junction-core/src/xds/test.rs
@@ -51,11 +51,11 @@ macro_rules! vhost {
 pub(crate) use vhost;
 
 macro_rules! cluster {
-    (eds $cluster_name:expr) => {{
-        crate::xds::test::cluster_eds($cluster_name, None)
+    ($cluster_name:expr) => {{
+        crate::xds::test::cluster_from_name($cluster_name, None)
     }};
-    (ring_hash eds $cluster_name:expr) => {{
-        crate::xds::test::cluster_eds($cluster_name, Some(xds_cluster::cluster::LbPolicy::RingHash))
+    (ring_hash $cluster_name:expr) => {{
+        crate::xds::test::cluster_from_name($cluster_name, Some(xds_cluster::cluster::LbPolicy::RingHash))
     }};
     (inline $cluster_name:expr => { $($region:expr => [$($addr:expr),*]),* }) => {{
         let cla = crate::xds::test::cluster_load_assignment($cluster_name, vec![$(
@@ -296,7 +296,7 @@ pub fn virtual_host(
     }
 }
 
-pub fn cluster_eds(
+pub fn cluster_from_name(
     name: &'static str,
     lb_policy: Option<xds_cluster::cluster::LbPolicy>,
 ) -> xds_cluster::Cluster {


### PR DESCRIPTION
This was originally going to be a branch for just some prep-work, but one thing kind of led to another and the changes are all kind of in one large commit. There's a few small prep commits that are potentially worth reviewing on their own, and then a big one for DNS.

### xDS Cluster repr changes (01e584c)

Originally we hadn't been strict about how Backends became clusters, but now that we're taking DNS seriously it seemed like the right time to do so. We now follow the gRPC representation, where DNS clusters use a single in-line ClusterLoadAssignment to represent the DNS name they target and always use an EDS ClusterLoadAssignment for EDS clusters (any other kind of Junction Backend). 

### Oops (f7ba194)

Apparently we've been parsing IP addresses as DNS names this whole time. It hasn't yet mattered - we have endpoint support for hostnames, since we weren't sure where DNS resolution would happen and are passing things into urrlib3 in a way that things just work out. It's fixed, and I should probably remove that code when we think about what an endpoint actually means.

### DNS Resolution (51fb26e)

This is the one. Getting DNS resolution in was both bigger and smaller than I expected. We now have a fairly clean separation between `junction_core::Client`, which does things with `Route`s and `Backend`s and the xDS parts. The DNS resolver is entirely hidden in the xDS parts. As the xDS client sees resources come in, either through client subscriptions or through xDS dynamically, it starts telling an embedded resolver to look up names.

I tried to keep the core of every connection sans-io and use something effect-shaped to decide when to actually make DNS changes. This lets us write real tests for when we should be resolving DNS and what names we should be interested in. Doing that also made it easy to separate out a resolver - as long as we can throw hostnames at a DNS resolver and use it as a cache for `EndpointGroup`s, we can swap out any implementation.

The big commit introduces a `StdlibResolver` that just uses the [stdlib's ToSocketAddrs trait](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html) to resolve names. This in turn uses the system resolver, which is good, but gives us no ability to see record TTLs or set timeouts, or anything, which is bad. This isn't a good long-term choice for us but it lets us get going without adopting a new dependency. 

Long term, we should be using c-ares FFI bindings and figuring out how to statically bundle that lib with the client, or should pull in Hickory. I don't have a sense for how mature Hickory is yet, but the 0.25 release looks promising and has a lot of ISRG attention.

#### Strict vs Logical DNS

While implementing this, it became really unclear how we should move forward with STRICT_DNS vs LOGICAL_DNS. The current code uses LOGICAL_DNS for all xDS, but resolves as if we were using STRICT_DNS. This is a hack - it means that we don't have to think about load-balancing DNS backends differently in this PR and delay any choice on whether or how we expose this via the API while maintaining gRPC compatible xDS (See [proposal A37](https://github.com/grpc/proposal/blob/master/A37-xds-aggregate-and-logical-dns-clusters.md) for details).

Longer term we should decide whether or not we want to expose the choice in the Junction API and whether or not it makes sense to stick to the gRPC standard. For now, this seems fine.