### PR TITLE
Fix some names, disambiguate LB config from actual routes

### DIFF
--- a/crates/junction-api/src/lib.rs
+++ b/crates/junction-api/src/lib.rs
@@ -451,13 +451,13 @@ impl Target {
     }
 
     #[doc(hidden)]
-    pub fn passthrough_route_name(&self) -> String {
+    pub fn lb_config_route_name(&self) -> String {
         let mut buf = String::new();
-        self.write_passthrough_route_name(&mut buf).unwrap();
+        self.write_lb_config_route_name(&mut buf).unwrap();
         buf
     }
 
-    fn write_passthrough_route_name(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+    fn write_lb_config_route_name(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
         match self {
             Target::Dns(dns) => {
                 write!(w, "{}{}", dns.hostname, Target::BACKEND_SUBDOMAIN)?;
@@ -478,7 +478,7 @@ impl Target {
     }
 
     #[doc(hidden)]
-    pub fn from_passthrough_route_name(name: &str) -> Result<Self, Error> {
+    pub fn from_lb_config_route_name(name: &str) -> Result<Self, Error> {
         let hostname = Hostname::from_str(name)?;
 
         let Some(hostname) = hostname.strip_suffix(Target::BACKEND_SUBDOMAIN) else {
@@ -664,25 +664,25 @@ impl BackendId {
     }
 
     #[doc(hidden)]
-    pub fn passthrough_route_name(&self) -> String {
+    pub fn lb_config_route_name(&self) -> String {
         let mut buf = String::new();
-        self.write_passthrough_route_name(&mut buf).unwrap();
+        self.write_lb_config_route_name(&mut buf).unwrap();
         buf
     }
 
-    fn write_passthrough_route_name(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
-        self.target.write_passthrough_route_name(w)?;
+    fn write_lb_config_route_name(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        self.target.write_lb_config_route_name(w)?;
         write!(w, ":{port}", port = self.port)?;
         Ok(())
     }
 
     #[doc(hidden)]
-    pub fn from_passthrough_route_name(name: &str) -> Result<Self, Error> {
+    pub fn from_lb_config_route_name(name: &str) -> Result<Self, Error> {
         let (name, port) = parse_port(name)?;
         let port =
             port.ok_or_else(|| Error::new_static("expected a fully qualified name with a port"))?;
 
-        let target = Target::from_passthrough_route_name(name)?;
+        let target = Target::from_lb_config_route_name(name)?;
 
         Ok(Self { target, port })
     }
@@ -840,22 +840,22 @@ mod test {
     }
 
     #[test]
-    fn test_target_passthrough_name() {
-        assert_passthrough_name(
+    fn test_target_lb_config_name() {
+        assert_lb_config_name(
             Target::kube_service("production", "potato").unwrap(),
             "potato.production.svc.cluster.local.lb.jct",
         );
 
-        assert_passthrough_name(
+        assert_lb_config_name(
             Target::dns("cool-stuff.example.com").unwrap(),
             "cool-stuff.example.com.lb.jct",
         );
     }
 
     #[track_caller]
-    fn assert_passthrough_name(target: Target, str: &'static str) {
-        assert_eq!(&target.passthrough_route_name(), str);
-        let parsed = Target::from_passthrough_route_name(str).unwrap();
+    fn assert_lb_config_name(target: Target, str: &'static str) {
+        assert_eq!(&target.lb_config_route_name(), str);
+        let parsed = Target::from_lb_config_route_name(str).unwrap();
         assert_eq!(parsed, target);
     }
 

--- a/crates/junction-api/src/xds/http.rs
+++ b/crates/junction-api/src/xds/http.rs
@@ -42,13 +42,7 @@ impl From<&Route> for xds_route::RouteConfiguration {
 
 impl Route {
     pub fn from_xds(xds: &xds_route::RouteConfiguration) -> Result<Self, Error> {
-        // try to parse the target as a backend name in case it's an lb config
-        // route, and then try parsing it as a regular target.
-        let route_vhost = BackendId::from_lb_config_route_name(&xds.name)
-            .map(BackendId::into_vhost)
-            .or_else(|_| VirtualHost::from_str(&xds.name))
-            .with_field("name")?;
-
+        let route_vhost = VirtualHost::from_str(&xds.name).with_field("name")?;
         let tags = tags_from_xds(&xds.metadata)?;
 
         let mut rules = vec![];

--- a/crates/junction-api/src/xds/http.rs
+++ b/crates/junction-api/src/xds/http.rs
@@ -42,9 +42,9 @@ impl From<&Route> for xds_route::RouteConfiguration {
 
 impl Route {
     pub fn from_xds(xds: &xds_route::RouteConfiguration) -> Result<Self, Error> {
-        // try to parse the target as a backend name in case it's a passthrough
+        // try to parse the target as a backend name in case it's an lb config
         // route, and then try parsing it as a regular target.
-        let route_vhost = BackendId::from_passthrough_route_name(&xds.name)
+        let route_vhost = BackendId::from_lb_config_route_name(&xds.name)
             .map(BackendId::into_vhost)
             .or_else(|_| VirtualHost::from_str(&xds.name))
             .with_field("name")?;

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -349,8 +349,8 @@ impl ApiListener {
             Some(RouteSpecifier::RouteConfig(route_config)) => {
                 let clusters = RouteConfig::cluster_names(route_config);
                 let route = Arc::new(Route::from_xds(route_config)?);
-                // TODO: stop parsing lb_policy_action if this isn't tagged as a
-                // policy passthrough listener/route.
+                // TODO: stop parsing lb_policy_action if this isn't tagged as
+                // an lb policy listener/route.
                 let lb_action = RouteConfig::lb_policy_action(route_config);
                 ApiListenerData::Inlined {
                     clusters,
@@ -387,8 +387,8 @@ impl RouteConfig {
     ) -> Result<Self, junction_api::Error> {
         let clusters = RouteConfig::cluster_names(&xds);
         let route = Arc::new(Route::from_xds(&xds)?);
-        // TODO: stop parsing lb_policy_action if this isn't tagged as a
-        // policy passthrough listener/route.
+        // TODO: stop parsing lb_policy_action if this isn't tagged as an lb
+        // policy listener/route.
         let lb_action = RouteConfig::lb_policy_action(&xds);
 
         Ok(Self {

--- a/crates/junction-core/src/xds/test.rs
+++ b/crates/junction-core/src/xds/test.rs
@@ -305,7 +305,7 @@ pub fn cluster_from_name(
         lb: LbPolicy::Unspecified,
     };
 
-    let mut cluster = backend.to_xds_cluster();
+    let mut cluster = backend.to_xds();
     if let Some(lb_policy) = lb_policy {
         cluster.lb_policy = lb_policy.into();
     }


### PR DESCRIPTION
LB Config routes have been polluting the actual set of Routes we generate. they haven't affected matches yet, for whatever reason, but I think that's us getting lucky with the order of operations.

This CR makes it explicit that an xDS listener can either be LB config or a Junction Route, and that a RouteConfig shouldn't be both. It also inspired some long-overdue cleanup: LB config routes are now creatively called `lb_config` wherever they show up, and not called `passthrough` routes anymore, to distinguish them from actual no backend pass-through routes.