### PR TITLE
junction-core: make resolution async, make defaults easier to reason about

### DIFF
--- a/crates/junction-api/src/shared.rs
+++ b/crates/junction-api/src/shared.rs
@@ -72,31 +72,30 @@ impl serde::Serialize for Regex {
     }
 }
 
-struct RegexVisitor;
-
-impl<'de> Visitor<'de> for RegexVisitor {
-    type Value = Regex;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a Regex")
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        match Regex::from_str(value) {
-            Ok(s) => Ok(s),
-            Err(e) => Err(E::custom(format!("could not parse {}: {}", value, e))),
-        }
-    }
-}
-
 impl<'de> Deserialize<'de> for Regex {
     fn deserialize<D>(deserializer: D) -> Result<Regex, D::Error>
     where
         D: Deserializer<'de>,
     {
+        struct RegexVisitor;
+
+        impl Visitor<'_> for RegexVisitor {
+            type Value = Regex;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a Regex")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                match Regex::from_str(value) {
+                    Ok(s) => Ok(s),
+                    Err(e) => Err(E::custom(format!("could not parse {}: {}", value, e))),
+                }
+            }
+        }
         deserializer.deserialize_string(RegexVisitor)
     }
 }
@@ -218,7 +217,7 @@ impl<'de> Deserialize<'de> for Duration {
         // https://serde.rs/string-or-struct.html
         struct DurationVisitor;
 
-        impl<'de> Visitor<'de> for DurationVisitor {
+        impl Visitor<'_> for DurationVisitor {
             type Value = Duration;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -2,15 +2,16 @@ use crate::{
     endpoints::EndpointIter, load_balancer::BackendLb, xds::AdsClient, ConfigCache, Endpoint,
     Error, StaticConfig,
 };
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use junction_api::{
     backend::Backend,
     http::{HeaderMatch, PathMatch, QueryParamMatch, Route, RouteMatch, RouteRule},
     BackendId, Target, VirtualHost,
 };
 use rand::distributions::WeightedError;
-use std::time::Duration;
-use std::{collections::BTreeSet, sync::Arc};
-use std::{future::Future, str::FromStr};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 /// A view into an HTTP Request before any rewrites or modifications have been
 /// made. It includes the potential [VirtualHost]s that this request may match.
@@ -58,316 +59,6 @@ impl<'a> HttpRequest<'a> {
     }
 }
 
-/// A service discovery client that looks up URL information based on URLs,
-/// headers, and methods.
-///
-/// Clients use a shared in-memory cache to keep data warm so that a request
-/// never has to block on a remote service.
-///
-/// Clients are cheaply cloneable, and should be cloned to create multiple
-/// clients that share the same in-memory cache.
-#[derive(Clone)]
-pub struct Client {
-    ads: AdsClient,
-    _ads_task: Arc<tokio::task::JoinHandle<()>>,
-    defaults: StaticConfig,
-}
-
-// NOTE: we've largely been ignoring this and trying to make Route and Backend
-// correct-by-construction. the hook is still here as a reminder to check back
-// on whether this is true before we release a stable version.
-fn validate_defaults(_: &[Route], _: &[Backend]) -> crate::Result<()> {
-    Ok(())
-}
-
-// FIXME: Vec<Endpoints> is probably the wrong thing to return from all our
-// resolve methods. We probably need a struct that has something like a list
-// of primary endpoints to cycle through on retries, and a seprate list of
-// endpoints to mirror traffic to. Figure that out once we support mirroring.
-
-/// How to resolve routes and endpoints.
-///
-/// See [Client::resolve_routes].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ConfigMode {
-    /// Resolve configuration with only existing routes and backends, do not
-    /// request new ones over the network.
-    ///
-    /// This mode does not disable push-based updates to existing routes or
-    /// backends. For example, the addresses that are part of a backend or its
-    /// load balancing configuration may still change during resolution.
-    Static,
-
-    /// Update configuration dynamically as part of making this request. New
-    /// routes, backends, and addresses may fetched to make this request.
-    Dynamic,
-}
-
-impl Client {
-    /// Build a new client, spawning a new ADS client in the background.
-    ///
-    /// This method creates a new ADS client and ADS connection. Data fetched
-    /// over ADS won't be shared with existing clients. To create a client that
-    /// shares with an existing cache, call [Client::clone] on an existing
-    /// client.
-    ///
-    /// This function assumes that you're currently running the context of a
-    /// `tokio` runtime and spawns background tasks.
-    pub async fn build(
-        address: String,
-        node_id: String,
-        cluster: String,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let (ads, mut ads_task) = AdsClient::build(address, node_id, cluster).unwrap();
-
-        // try to start the ADS connection while blocking. if it fails, fail
-        // fast here instead of letting the client start.
-        //
-        // once it's started, hand off the task to the executor in the
-        // background.
-        ads_task.connect().await?;
-        let handle = tokio::spawn(async move {
-            ads_task.connect().await.expect("xds: connection failed");
-            match ads_task.run().await {
-                Ok(()) => (),
-                Err(e) => panic!("xds: ads client exited: unxpected error: {e}"),
-            }
-        });
-
-        let client = Self {
-            ads,
-            _ads_task: Arc::new(handle),
-            defaults: StaticConfig::default(),
-        };
-
-        Ok(client)
-    }
-
-    /// Set default `routes` and `backends` for this client.
-    ///
-    /// The client will continue to use the same dynamic configuration cache it
-    /// previously used.
-    pub fn with_defaults(
-        self,
-        default_routes: Vec<Route>,
-        default_backends: Vec<Backend>,
-    ) -> crate::Result<Client> {
-        validate_defaults(&default_routes, &default_backends)?;
-        let defaults = StaticConfig::new(default_routes, default_backends);
-        self.subscribe_to_defaults(&defaults);
-
-        Ok(Client { defaults, ..self })
-    }
-
-    fn subscribe_to_defaults(&self, defaults: &StaticConfig) {
-        let mut vhosts = Vec::with_capacity(defaults.routes.len());
-        let mut backends = Vec::with_capacity(defaults.routes.len());
-        for (target, route) in &defaults.routes {
-            vhosts.push(target.clone());
-
-            for rule in &route.rules {
-                for backend in &rule.backends {
-                    backends.push(backend.backend.clone());
-                }
-            }
-        }
-
-        self.ads.subscribe_to_vhosts(vhosts).unwrap();
-
-        let default_backends = defaults.backends.keys().cloned();
-        self.ads
-            .subscribe_to_backends(backends.into_iter().chain(default_backends))
-            .unwrap();
-    }
-
-    /// Start a gRPC CSDS server on the given port.
-    ///
-    /// To run the server, you must `await` this future.
-    pub fn csds_server(
-        &self,
-        port: u16,
-    ) -> impl Future<Output = Result<(), tonic::transport::Error>> {
-        self.ads.csds_server(port)
-    }
-
-    /// Dump the client's current cache of xDS resources, as fetched from the
-    /// config server.
-    ///
-    /// This is a programmatic view of the same data that you can fetch over
-    /// gRPC by starting a [Client::csds_server].
-    pub fn dump_xds(&self) -> impl Iterator<Item = crate::XdsConfig> + '_ {
-        self.ads.iter_xds()
-    }
-
-    /// Dump the Client's current table of [Route]s, merging together any
-    /// default routes and remotely fetched routes the same way the client would
-    /// when resolving endpoints.
-    pub fn dump_routes(&self) -> Vec<Arc<Route>> {
-        let mut routes = vec![];
-        let mut defaults: BTreeSet<_> = self.defaults.routes.keys().collect();
-
-        for route in self.ads.iter_routes() {
-            let route = if is_generated_route(&route) {
-                self.defaults
-                    .routes
-                    .get(&route.vhost)
-                    .cloned()
-                    .unwrap_or(route)
-            } else {
-                route
-            };
-            defaults.remove(&route.vhost);
-            routes.push(route);
-        }
-
-        for route_name in defaults {
-            // safety: this started as the key set of default_routes
-            routes.push(self.defaults.routes.get(route_name).unwrap().clone());
-        }
-
-        routes
-    }
-
-    /// Dump the Client's current table of [BackendLb]s, merging together any
-    /// default configuration and remotely fetched config the same way the
-    /// client would when resolving endpoints.
-    pub fn dump_backends(&self) -> Vec<Arc<BackendLb>> {
-        let mut backends = vec![];
-        let mut defaults: BTreeSet<_> = self.defaults.backends.keys().collect();
-
-        for backend in self.ads.iter_backends() {
-            let backend = if backend.config.lb.is_unspecified() {
-                self.defaults
-                    .backends
-                    .get(&backend.config.id)
-                    .cloned()
-                    .unwrap_or(backend)
-            } else {
-                backend
-            };
-
-            defaults.remove(&backend.config.id);
-            backends.push(backend);
-        }
-
-        for backend_name in defaults {
-            backends.push(self.defaults.backends.get(backend_name).unwrap().clone());
-        }
-
-        backends
-    }
-
-    /// Resolve an HTTP method, URL, and headers to a target backend, returning
-    /// the Route that matched, the index of the rule that matched, and the
-    /// backend that was chosen - to make backend choice determinstic with
-    /// multiple backends, set the `JUNCTION_SEED` environment variable.
-    ///
-    /// This is a lower-level method that only performs the Route matching half
-    /// of resolution. It's intended for debugging or querying a client for
-    /// specific information. For everyday use, prefer [Client::resolve_http].
-    /// [Client::resolve_http].
-    pub fn resolve_routes(
-        &self,
-        config_mode: ConfigMode,
-        request: HttpRequest<'_>,
-    ) -> crate::Result<ResolvedRoute> {
-        if ConfigMode::Dynamic == config_mode {
-            self.ads
-                .subscribe_to_vhosts(request.vhosts().iter().cloned())
-                .expect("ads client overloaded, this is a bug in Junction");
-        }
-
-        resolve_routes(&self.ads, &self.defaults, request)
-    }
-
-    /// Use a resolved Route and Backend to select an endpoint for a request.
-    ///
-    /// This is a lower level method that only performs the Backend
-    /// load-balancing half of resolution. It's intended for debugging or
-    /// querying a client for specific information. For everday
-    /// use, prefer [Client::resolve_http].
-    pub fn resolve_endpoint(
-        &self,
-        config_mode: ConfigMode,
-        resolved: ResolvedRoute,
-        request: HttpRequest<'_>,
-    ) -> crate::Result<Vec<Endpoint>> {
-        if ConfigMode::Dynamic == config_mode {
-            self.ads
-                .subscribe_to_backends([resolved.backend.clone()])
-                .expect("ads client overloaded, this is a bug in Junction");
-        }
-
-        resolve_endpoint(&self.ads, &self.defaults, resolved, request)
-    }
-
-    /// Return the endpoints currently in cache for this backend.
-    ///
-    /// The returned endpoints are a snapshot of what is currently in cache and
-    /// will not update as new discovery information is pushed.
-    pub fn get_endpoints(&self, backend: &BackendId) -> Option<EndpointIter> {
-        self.ads.get_endpoints(backend).map(EndpointIter::from)
-    }
-
-    /// Resolve an HTTP method, URL, and headers into a set of [Endpoint]s.
-    ///
-    /// When multiple endpoints are returned, a client should send traffic to
-    /// ALL of the returned endpoints because the routing policy specified
-    /// that traffic should be mirrored.
-    pub fn resolve_http(
-        &mut self,
-        method: &http::Method,
-        url: &crate::Url,
-        headers: &http::HeaderMap,
-    ) -> crate::Result<Vec<crate::Endpoint>> {
-        let request = HttpRequest::from_parts(method, url, headers)?;
-
-        // FIXME: this is deeply janky, manual exponential backoff. it should be
-        // possible for the ADS client to signal when a cache entry is
-        // available/pending a request/not found instead of just there/not.
-        //
-        // make that happen, and figure out if there is a way to notify when
-        // that happens.
-        const RESOLVE_BACKOFF: &[Duration] = &[
-            Duration::from_millis(1),
-            Duration::from_millis(4),
-            Duration::from_millis(16),
-            Duration::from_millis(64),
-            Duration::from_millis(256),
-        ];
-
-        for backoff in RESOLVE_BACKOFF {
-            match self.resolve(ConfigMode::Dynamic, request.clone()) {
-                Ok(endpoints) => return Ok(endpoints),
-                Err(e) => {
-                    if !e.is_temporary() {
-                        return Err(e);
-                    }
-                    std::thread::sleep(*backoff);
-                }
-            }
-        }
-        self.resolve(ConfigMode::Dynamic, request)
-    }
-
-    #[inline]
-    fn resolve(
-        &self,
-        config_mode: ConfigMode,
-        request: HttpRequest<'_>,
-    ) -> crate::Result<Vec<crate::Endpoint>> {
-        let resolved = self.resolve_routes(config_mode, request.clone())?;
-        self.resolve_endpoint(config_mode, resolved, request)
-    }
-}
-
-fn is_generated_route(route: &Route) -> bool {
-    route
-        .tags
-        .contains_key(junction_api::http::tags::GENERATED_BY)
-}
-
 /// Generate the list of Targets that this URL maps to, taking into account the
 /// URL's `port` and any search path rules. The list of targets will be returned
 /// in the most-to-least specific order.
@@ -385,6 +76,337 @@ pub(crate) fn vhosts_for_url(url: &crate::Url) -> crate::Result<Vec<VirtualHost>
     ])
 }
 
+/// The strategy for udpating Routes, Backends, and Endpoints while resolving.
+///
+/// Resolution mode is orthogonal to client configuration mode - it's possible
+/// to have a dynamic client, but to resolve an individual route by only using
+/// data currently in cache.
+///
+/// See [Client::resolve_routes] and [Client::resolve_endpoint].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ResolveMode {
+    /// Resolve configuration with only existing routes and backends, do not
+    /// request new ones over the network.
+    ///
+    /// This mode does not disable push-based updates to existing routes or
+    /// backends. For example, the addresses that are part of a backend or its
+    /// load balancing configuration may still change during resolution.
+    Static,
+
+    /// Update configuration dynamically as part of making this request. New
+    /// routes, backends, and addresses may fetched to make this request.
+    Dynamic,
+}
+
+/// A service discovery client that looks up URL information based on URLs,
+/// headers, and methods.
+///
+/// Clients use a shared in-memory cache to keep data warm so that a request
+/// never has to block on a remote service.
+///
+/// Clients are cheaply cloneable, and should be cloned to create multiple
+/// clients that share the same in-memory cache.
+#[derive(Clone)]
+pub struct Client {
+    // resolve options
+    //
+    // TODO: make configurable with a builder or something, not sure if they
+    // will survive.
+    resolve_timeout: Duration,
+    resolve_mode: ResolveMode,
+
+    config: Config,
+}
+
+#[derive(Clone)]
+enum Config {
+    Static(Arc<StaticConfig>),
+    DynamicEndpoints(Arc<StaticConfig>, Arc<DynamicConfig>),
+    Dynamic(Arc<DynamicConfig>),
+}
+
+struct DynamicConfig {
+    ads_client: AdsClient,
+
+    /// a the shared handle to the task that's actually running the client in
+    /// the background. should not drop until every active client drops.
+    ///
+    /// TOODO: should this get bundled into AdsClient? shrug emoji?
+    #[allow(unused)]
+    ads_task: tokio::task::JoinHandle<()>,
+}
+
+impl Config {
+    fn ads(&self) -> Option<&AdsClient> {
+        match self {
+            Config::Static(_) => None,
+            Config::DynamicEndpoints(_, d) | Config::Dynamic(d) => Some(&d.ads_client),
+        }
+    }
+}
+
+impl ConfigCache for Config {
+    async fn get_route(&self, target: &VirtualHost) -> Option<Arc<Route>> {
+        match &self {
+            Config::Static(s) => s.get_route(target).await,
+            Config::DynamicEndpoints(s, _) => s.get_route(target).await,
+            Config::Dynamic(d) => d.ads_client.get_route(target).await,
+        }
+    }
+
+    async fn get_backend(&self, target: &BackendId) -> Option<Arc<BackendLb>> {
+        match &self {
+            Config::Static(s) => s.get_backend(target).await,
+            Config::DynamicEndpoints(s, _) => s.get_backend(target).await,
+            Config::Dynamic(d) => d.ads_client.get_backend(target).await,
+        }
+    }
+
+    async fn get_endpoints(
+        &self,
+        backend: &BackendId,
+    ) -> Option<Arc<crate::load_balancer::EndpointGroup>> {
+        match &self {
+            Config::Static(s) => s.get_endpoints(backend).await,
+            Config::DynamicEndpoints(_, d) => d.ads_client.get_endpoints(backend).await,
+            Config::Dynamic(d) => d.ads_client.get_endpoints(backend).await,
+        }
+    }
+}
+
+// FIXME: Vec<Endpoints> is probably the wrong thing to return from all our
+// resolve methods. We probably need a struct that has something like a list
+// of primary endpoints to cycle through on retries, and a seprate list of
+// endpoints to mirror traffic to. Figure that out once we support mirroring.
+
+impl Client {
+    /// Build a new dynamic client, spawning a new ADS client in the background.
+    ///
+    ///This method creates a new ADS client and ADS connection. Dynamic data
+    ///will not be shared with existing clients. To create a client that shares
+    ///data with existing clients, [clone][Client::clone] an existing client.
+    ///
+    /// This function assumes that you're currently running the context of a
+    /// `tokio` runtime and spawns background work on a tokio executor.
+    pub async fn build(
+        address: String,
+        node_id: String,
+        cluster: String,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let (ads_client, mut ads_task) = AdsClient::build(address, node_id, cluster).unwrap();
+
+        // try to start the ADS connection while blocking. if it fails, fail
+        // fast here instead of letting the client start.
+        //
+        // once it's started, hand off the task to the executor in the
+        // background.
+        ads_task.connect().await?;
+        let handle = tokio::spawn(async move {
+            ads_task.connect().await.expect("xds: connection failed");
+            match ads_task.run().await {
+                Ok(()) => (),
+                Err(e) => panic!("xds: ads client exited: unxpected error: {e}"),
+            }
+        });
+
+        let dyn_config = Arc::new(DynamicConfig {
+            ads_client,
+            ads_task: handle,
+        });
+
+        let client = Self {
+            resolve_timeout: Duration::from_secs(5),
+            resolve_mode: ResolveMode::Dynamic,
+            config: Config::Dynamic(dyn_config),
+        };
+
+        Ok(client)
+    }
+
+    /// Build a client with static configuration. This client will use the
+    /// passed configuration to resolve routes and backends, but will still
+    /// fetch endpoints dynamically.
+    ///
+    /// This method will panic if the client being cloned is fully static. To
+    /// convert a static client to a client that uses dynamic config, create a
+    /// new client.
+    pub fn with_static_config(self, routes: Vec<Route>, backends: Vec<Backend>) -> Client {
+        let static_config = Arc::new(StaticConfig::with_inferred(routes, backends));
+
+        let dyn_config = match &self.config {
+            Config::Static(_) => panic!("can't use dynamic endpoints with a fully static client"),
+            Config::DynamicEndpoints(_, d) => Arc::clone(d),
+            Config::Dynamic(d) => Arc::clone(d),
+        };
+
+        dyn_config
+            .ads_client
+            .subscribe_to_backends(static_config.backends())
+            // FIXME: don't panic here
+            .expect("ads is overloaded. this is a bug in Junction");
+
+        let config = Config::DynamicEndpoints(static_config, dyn_config);
+        Client { config, ..self }
+    }
+
+    /// Construct a client that uses fully static configuration and does not
+    /// connect to a control plane at all.
+    ///
+    /// This is intended to be used to test configuration in controlled settings
+    /// or to use Junction an offline mode. Once a client has been converted to
+    /// fully static, it's not possible to convert it back to using dynamic
+    /// discovery data.
+    pub fn with_static_endpoints(self, routes: Vec<Route>, backends: Vec<Backend>) -> Client {
+        let static_config = Arc::new(StaticConfig::with_inferred(routes, backends));
+
+        let config = Config::Static(static_config);
+        Client { config, ..self }
+    }
+
+    /// Start a gRPC CSDS server on the given port. To run the server, you must
+    /// `await` this future.
+    ///
+    /// For static clients, this does nothing.
+    pub async fn csds_server(self, port: u16) -> Result<(), tonic::transport::Error> {
+        match self.config.ads() {
+            Some(ads) => ads.csds_server(port).await,
+            None => std::future::pending().await,
+        }
+    }
+
+    /// Dump the client's current cache of xDS resources, as fetched from the
+    /// config server.
+    ///
+    /// This is a programmatic view of the same data that you can fetch over
+    /// gRPC by starting a [Client::csds_server].
+    pub fn dump_xds(&self) -> Vec<crate::XdsConfig> {
+        match self.config.ads() {
+            Some(ads) => ads.iter_xds().collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Dump the Client's current table of [Route]s, merging together any
+    /// default routes and remotely fetched routes the same way the client would
+    /// when resolving endpoints.
+    pub fn dump_routes(&self) -> Vec<Arc<Route>> {
+        match &self.config {
+            Config::Static(c) | Config::DynamicEndpoints(c, _) => {
+                c.routes.values().cloned().collect()
+            }
+            Config::Dynamic(d) => d.ads_client.iter_routes().collect(),
+        }
+    }
+
+    /// Dump the Client's current table of [BackendLb]s, merging together any
+    /// default configuration and remotely fetched config the same way the
+    /// client would when resolving endpoints.
+    pub fn dump_backends(&self) -> Vec<Arc<BackendLb>> {
+        match &self.config {
+            Config::Static(c) | Config::DynamicEndpoints(c, _) => {
+                c.backends.values().cloned().collect()
+            }
+            Config::Dynamic(d) => d.ads_client.iter_backends().collect(),
+        }
+    }
+
+    /// Resolve an HTTP method, URL, and headers to a target backend, returning
+    /// the Route that matched, the index of the rule that matched, and the
+    /// backend that was chosen - to make backend choice determinstic with
+    /// multiple backends, set the `JUNCTION_SEED` environment variable.
+    ///
+    /// This is a lower-level method that only performs the Route matching half
+    /// of resolution. It's intended for debugging or querying a client for
+    /// specific information. For everyday use, prefer [Client::resolve_http].
+    /// [Client::resolve_http].
+    pub async fn resolve_routes(
+        &self,
+        config_mode: ResolveMode,
+        request: HttpRequest<'_>,
+    ) -> crate::Result<ResolvedRoute> {
+        // only subscribe to vhosts in fully dynamic mode
+        if let (ResolveMode::Dynamic, Config::Dynamic(d)) = (config_mode, &self.config) {
+            d.ads_client
+                .subscribe_to_vhosts(request.vhosts().iter().cloned())
+                // FIXME: shouldn't be a panic, should be async
+                .expect("ads client overloaded, this is a bug in Junction");
+        }
+
+        resolve_routes(&self.config, request).await
+    }
+
+    /// Use a resolved Route and Backend to select an endpoint for a request.
+    ///
+    /// This is a lower level method that only performs the Backend
+    /// load-balancing half of resolution. It's intended for debugging or
+    /// querying a client for specific information. For everday
+    /// use, prefer [Client::resolve_http].
+    pub async fn resolve_endpoint(
+        &self,
+        config_mode: ResolveMode,
+        resolved: ResolvedRoute,
+        request: HttpRequest<'_>,
+    ) -> crate::Result<Vec<Endpoint>> {
+        // subscribe to backends with either dynamic endpoints or full
+        // dynamic mode, since this is how we'll fetch endpoints.
+        //
+        // TODO: should there be a way to subscribe to endpoints here as well?
+        // TODO: should we just get rid of the subscribe here and move it into
+        //       the get_routes/get_backends/get_endpoints calls???
+        if let (ResolveMode::Dynamic, Config::DynamicEndpoints(_, d)) = (config_mode, &self.config)
+        {
+            d.ads_client
+                .subscribe_to_backends([resolved.backend.clone()])
+                // FIXME: shouldn't be a panic, should be async
+                .expect("ads client overloaded, this is a bug in Junction");
+        }
+
+        resolve_endpoint(&self.config, resolved, request).await
+    }
+
+    /// Return the endpoints currently in cache for this backend.
+    ///
+    /// The returned endpoints are a snapshot of what is currently in cache and
+    /// will not update as new discovery information is pushed.
+    pub fn get_endpoints(&self, backend: &BackendId) -> Option<EndpointIter> {
+        self.config
+            .get_endpoints(backend)
+            .now_or_never()
+            .flatten()
+            .map(EndpointIter::from)
+    }
+
+    /// Resolve an HTTP method, URL, and headers into a set of [Endpoint]s.
+    ///
+    /// When multiple endpoints are returned, a client should send traffic to
+    /// ALL of the returned endpoints because the routing policy specified
+    /// that traffic should be mirrored.
+    pub async fn resolve_http(
+        &mut self,
+        method: &http::Method,
+        url: &crate::Url,
+        headers: &http::HeaderMap,
+    ) -> crate::Result<Vec<crate::Endpoint>> {
+        let request = HttpRequest::from_parts(method, url, headers)?;
+        let deadline = Instant::now() + self.resolve_timeout;
+
+        let resolve_routes = self.resolve_routes(self.resolve_mode, request.clone());
+        let resolved = match tokio::time::timeout_at(deadline.into(), resolve_routes).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Err(Error::timed_out("timed out fetching routes")),
+        };
+
+        let resolve_endpoint = self.resolve_endpoint(self.resolve_mode, resolved, request);
+        match tokio::time::timeout_at(deadline.into(), resolve_endpoint).await {
+            Ok(Ok(r)) => Ok(r),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(Error::timed_out("timed out fetching backends")),
+        }
+    }
+}
+
 /// The result of [resolving a route][Client::resolve_routes].
 #[derive(Debug, Clone)]
 pub struct ResolvedRoute {
@@ -400,31 +422,16 @@ pub struct ResolvedRoute {
     pub backend: BackendId,
 }
 
-pub(crate) fn resolve_routes(
+pub(crate) async fn resolve_routes(
     cache: &impl ConfigCache,
-    defaults: &impl ConfigCache,
     request: HttpRequest<'_>,
 ) -> crate::Result<ResolvedRoute> {
     use rand::seq::SliceRandom;
 
-    let default_route = defaults.get_route_with_fallbacks(request.vhosts());
-    let configured_route = cache.get_route_with_fallbacks(request.vhosts());
-
-    // FIXME: for now, the default routes are only looked up if there is no
-    // route coming from XDS. Whereas in reality we likely want to merge the
-    // values. However that requires some thinking about what it means at
-    // the rule equivalence level and is so left for later.
-    let matching_route = match (default_route, configured_route) {
-        (Some(default_route), Some(configured_route)) => {
-            if is_generated_route(&configured_route) {
-                default_route.clone()
-            } else {
-                configured_route
-            }
-        }
-        (None, Some(configured_route)) => configured_route,
-        (Some(default_route), None) => default_route.clone(),
-        _ => return Err(Error::no_route_matched(request.vhosts().to_vec())),
+    // look up the route, grabbing the first route that returns from cache.
+    let matching_route = match get_any(cache, request.vhosts()).await {
+        Some(route) => route,
+        None => return Err(Error::no_route_matched(request.vhosts().to_vec())),
     };
 
     // if this is the trivial route, match it immediately and return
@@ -481,35 +488,32 @@ pub(crate) fn resolve_routes(
     })
 }
 
-fn resolve_endpoint(
+async fn get_any(cache: &impl ConfigCache, targets: &[VirtualHost]) -> Option<Arc<Route>> {
+    let mut futs: FuturesUnordered<_> = targets.iter().map(|t| cache.get_route(t)).collect();
+
+    while let Some(lookup) = futs.next().await {
+        if let Some(route) = lookup {
+            return Some(route);
+        }
+    }
+
+    None
+}
+
+async fn resolve_endpoint(
     cache: &impl ConfigCache,
-    defaults: &impl ConfigCache,
     resolved: ResolvedRoute,
     request: HttpRequest<'_>,
 ) -> crate::Result<Vec<Endpoint>> {
-    // pull the backend out of cache.
-    let backend = match (
-        cache.get_backend(&resolved.backend),
-        defaults.get_backend(&resolved.backend),
-    ) {
-        // if there's a backend in both the cache and defaults, pick the cached
-        // backend unless it's unspecified
-        (Some(cache), Some(default)) if cache.config.lb.is_unspecified() => default,
-        // otherwise pick the cached backend if it's available and the default
-        // if it's not.
-        (Some(backend), _) | (None, Some(backend)) => backend,
-        // if there's nothign available, that's a paddlin
-        (None, None) => {
-            return Err(Error::no_backend(
-                resolved.route.vhost.clone(),
-                resolved.rule,
-                resolved.backend,
-            ))
-        }
+    let Some(backend) = cache.get_backend(&resolved.backend).await else {
+        return Err(Error::no_backend(
+            resolved.route.vhost.clone(),
+            resolved.rule,
+            resolved.backend,
+        ));
     };
 
-    // there's no notion of defaults for endpoints (yet?).
-    let Some(endpoints) = cache.get_endpoints(&resolved.backend) else {
+    let Some(endpoints) = cache.get_endpoints(&resolved.backend).await else {
         return Err(Error::no_reachable_endpoints(
             resolved.route.vhost.clone(),
             backend.config.id.clone(),
@@ -644,6 +648,14 @@ mod test {
         assert_sync::<HttpRequest<'_>>();
     }
 
+    #[track_caller]
+    fn assert_resolve_routes(cache: &impl ConfigCache, request: HttpRequest<'_>) -> ResolvedRoute {
+        resolve_routes(cache, request)
+            .now_or_never()
+            .unwrap()
+            .unwrap()
+    }
+
     #[test]
     fn test_resolve_passthrough_route() {
         let target = Target::dns("example.com").unwrap();
@@ -651,13 +663,12 @@ mod test {
             vec![Route::passthrough_route(target.clone().into_vhost(None))],
             vec![],
         );
-        let defaults = StaticConfig::default();
 
         let url = Url::from_str("http://example.com/test-path").unwrap();
         let headers = http::HeaderMap::default();
         let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
 
-        let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+        let resolved = assert_resolve_routes(&routes, request);
         assert_eq!(resolved.backend, target.into_backend(80));
     }
 
@@ -670,13 +681,12 @@ mod test {
         };
 
         let routes = StaticConfig::new(vec![route], vec![]);
-        let defaults = StaticConfig::default();
 
         let url = Url::from_str("http://example.com:3214/users/123").unwrap();
         let headers = http::HeaderMap::default();
         let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
 
-        let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+        let resolved = assert_resolve_routes(&routes, request);
         assert_eq!(resolved.rule, None);
         assert_eq!(
             resolved.backend,
@@ -701,7 +711,6 @@ mod test {
         };
 
         let routes = StaticConfig::new(vec![route], vec![]);
-        let defaults = StaticConfig::default();
 
         for port in [80, 7887] {
             let method = &http::Method::GET;
@@ -709,7 +718,7 @@ mod test {
             let headers = &http::HeaderMap::default();
             let request = HttpRequest::from_parts(method, url, headers).unwrap();
 
-            let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+            let resolved = assert_resolve_routes(&routes, request);
 
             assert_eq!(
                 resolved.backend,
@@ -755,12 +764,11 @@ mod test {
         };
 
         let routes = StaticConfig::new(vec![route], vec![]);
-        let defaults = StaticConfig::default();
 
         let url = &Url::from_str("http://example.com/test-path").unwrap();
         let headers = &http::HeaderMap::default();
         let request = HttpRequest::from_parts(&http::Method::GET, url, headers).unwrap();
-        let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+        let resolved = assert_resolve_routes(&routes, request);
 
         // should match the fallthrough rule
         assert_eq!(resolved.rule, Some(1));
@@ -769,7 +777,7 @@ mod test {
         let url = Url::from_str("http://example.com/users/123").unwrap();
         let headers = &http::HeaderMap::default();
         let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
-        let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+        let resolved = assert_resolve_routes(&routes, request);
 
         // should match the first rule, with the path match
         assert_eq!(resolved.backend, backend_one);
@@ -781,7 +789,7 @@ mod test {
         let headers = &http::HeaderMap::default();
         let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-        let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+        let resolved = assert_resolve_routes(&routes, request);
         // should match the first rule, with the path match
         assert_eq!(resolved.rule, Some(0));
         assert_eq!(resolved.backend, backend_one);
@@ -831,7 +839,6 @@ mod test {
         };
 
         let routes = StaticConfig::new(vec![route], vec![]);
-        let defaults = StaticConfig::default();
 
         let wont_match = [
             "http://example.com?qp1=tomato",
@@ -847,7 +854,7 @@ mod test {
             let headers = &http::HeaderMap::default();
             let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-            let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+            let resolved = assert_resolve_routes(&routes, request);
             // should match the fallthrough rule
             assert_eq!(resolved.rule, Some(1));
             assert_eq!(resolved.backend, backend_two);
@@ -864,7 +871,7 @@ mod test {
             let headers = &http::HeaderMap::default();
             let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-            let resolved = resolve_routes(&routes, &defaults, request).unwrap();
+            let resolved = assert_resolve_routes(&routes, request);
             // should match one of the query matches
             assert_eq!(
                 (resolved.rule, &resolved.backend),

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -1,5 +1,7 @@
 use junction_api::http::{RouteRetry, RouteTimeouts};
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
+
+use crate::load_balancer::EndpointGroup;
 
 /// An HTTP endpoint to make a request to.
 ///
@@ -47,5 +49,26 @@ impl std::fmt::Display for EndpointAddress {
             EndpointAddress::SocketAddr(addr) => addr.fmt(f),
             EndpointAddress::DnsName(name, port) => write!(f, "{name}:{port}"),
         }
+    }
+}
+
+/// A snapshot of endpoint data.
+pub struct EndpointIter {
+    endpoint_group: Arc<EndpointGroup>,
+}
+
+impl From<Arc<EndpointGroup>> for EndpointIter {
+    fn from(endpoint_group: Arc<EndpointGroup>) -> Self {
+        Self { endpoint_group }
+    }
+}
+
+// TODO: add a way to see endpoints grouped by locality. have to decide how
+// to publicy expose Locality.
+impl EndpointIter {
+    /// Iterate over all of the addresses in this group, discarding any locality
+    /// information.
+    pub fn addrs(&self) -> impl Iterator<Item = &EndpointAddress> {
+        self.endpoint_group.iter()
     }
 }

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -35,6 +35,15 @@ impl Error {
 }
 
 impl Error {
+    // timeouts
+
+    pub(crate) fn timed_out(message: &'static str) -> Self {
+        let inner = ErrorImpl::TimedOut(Cow::from(message));
+        Self {
+            inner: Box::new(inner),
+        }
+    }
+
     // url problems
 
     pub(crate) fn into_invalid_url(message: String) -> Self {
@@ -92,12 +101,13 @@ impl Error {
             inner: Box::new(ErrorImpl::NoReachableEndpoints { vhost, backend }),
         }
     }
-
-    // methods
 }
 
 #[derive(Debug, thiserror::Error)]
 enum ErrorImpl {
+    #[error("timed out: {0}")]
+    TimedOut(Cow<'static, str>),
+
     #[error("invalid url: {0}")]
     InvalidUrl(Cow<'static, str>),
 

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -43,19 +43,14 @@ pub fn check_route(
     url: &crate::Url,
     headers: &http::HeaderMap,
 ) -> Result<ResolvedRoute> {
-    let request = client::HttpRequest {
-        method,
-        url,
-        headers,
-    };
-
+    let request = client::HttpRequest::from_parts(method, url, headers)?;
     // resolve with an empty cache and the passed config used as defaults and a
     // no-op subscribe fn.
     //
     // TODO: do we actually want that or do we want to treat the passed routes
     // as the primary config?
     let config = StaticConfig::new(routes, Vec::new());
-    client::resolve_routes(&StaticConfig::default(), &config, request, |_| {})
+    client::resolve_routes(&StaticConfig::default(), &config, request)
 }
 
 pub(crate) trait ConfigCache {

--- a/crates/junction-core/src/rand.rs
+++ b/crates/junction-core/src/rand.rs
@@ -1,9 +1,9 @@
 //! Controlled randomness.
 //!
 //! This module implements PRNGs that can all be deterministically seeded from a
-//! single env variable, falling back to system entropy when ncessary. Using only
-//! PRNG values seeded from this package allows using a seed to do deterministic
-//! testing.
+//! the `JUNCTION_SEED` env variable, falling back to system entropy when
+//! ncessary. Using only PRNG values seeded from this package allows
+//! deterministic testing.
 //!
 //! This module is currently implemented using a two-stage strategy. A single
 //! global PRNG wrapped in a `Mutex`` is used to lazily initialize thread local

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -576,7 +576,7 @@ impl<'a> AdsConnection<'a> {
     }
 }
 
-impl<'a> AdsConnection<'a> {
+impl AdsConnection<'_> {
     // inputs
 
     fn handle_subscription_update(&mut self, reg: SubscriptionUpdate) -> Vec<DiscoveryRequest> {
@@ -735,7 +735,7 @@ fn xds_unknown_type(discovery_response: DiscoveryResponse) -> DiscoveryRequest {
     }
 }
 
-impl<'a> AdsConnection<'a> {
+impl AdsConnection<'_> {
     fn xds_ack(
         &self,
         version: String,

--- a/crates/junction-core/src/xds/cache.rs
+++ b/crates/junction-core/src/xds/cache.rs
@@ -302,7 +302,7 @@ where
 
 struct ResourceEntry<'a, T>(crossbeam_skiplist::map::Entry<'a, String, CacheEntry<T>>);
 
-impl<'a, T> ResourceEntry<'a, T> {
+impl<T> ResourceEntry<'_, T> {
     fn name(&self) -> &str {
         self.0.key()
     }

--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -11,8 +11,8 @@ from . import config, requests, urllib3
 
 
 def _default_client(
-    default_routes: typing.List[config.Route] | None,
-    default_backends: typing.List[config.Backend] | None,
+    static_routes: typing.List[config.Route] | None,
+    static_backends: typing.List[config.Backend] | None,
 ) -> Junction:
     """
     Return a Junction client with default Routes and Backends.
@@ -21,18 +21,18 @@ def _default_client(
     and Backends.
     """
     client_kwargs = {}
-    if default_routes:
+    if static_routes:
         # This check is just in case the user does something dumb as otherwise
         # the error on the return line is pretty ambiguous
-        if not isinstance(default_routes, typing.List):
-            raise ValueError("default_routes must be a list of routes")
-        client_kwargs["default_routes"] = default_routes
-    if default_backends:
+        if not isinstance(static_routes, typing.List):
+            raise ValueError("static_routes must be a list of routes")
+        client_kwargs["static_routes"] = static_routes
+    if static_backends:
         # This check is just in case the user does something dumb as otherwise
         # the error on the return line is pretty ambiguous
-        if not isinstance(default_backends, typing.List):
-            raise ValueError("default_backends must be a list of backends")
-        client_kwargs["default_backends"] = default_backends
+        if not isinstance(static_backends, typing.List):
+            raise ValueError("static_backends must be a list of backends")
+        client_kwargs["static_backends"] = static_backends
     return default_client(**client_kwargs)
 
 

--- a/junction-python/junction/requests.py
+++ b/junction-python/junction/requests.py
@@ -205,8 +205,8 @@ class Session(requests.Session):
 
     def __init__(
         self,
-        default_routes: List[junction.config.Route] | None = None,
-        default_backends: List[junction.config.Backend] | None = None,
+        static_routes: List[junction.config.Route] | None = None,
+        static_backends: List[junction.config.Backend] | None = None,
         junction_client: junction.Junction | None = None,
     ) -> None:
         super().__init__()
@@ -215,7 +215,7 @@ class Session(requests.Session):
             self.junction = junction_client
         else:
             self.junction = junction._default_client(
-                default_routes=default_routes, default_backends=default_backends
+                static_routes=static_routes, static_backends=static_backends
             )
 
         self.mount("https://", HTTPAdapter(junction_client=self.junction))

--- a/junction-python/junction/urllib3.py
+++ b/junction-python/junction/urllib3.py
@@ -41,8 +41,8 @@ class PoolManager(urllib3.PoolManager):
         num_pools: int = 10,
         headers: typing.Mapping[str, str] | None = None,
         # junction
-        default_routes: typing.List[junction.config.Route] | None = None,
-        default_backends: typing.List[junction.config.Backend] | None = None,
+        static_routes: typing.List[junction.config.Route] | None = None,
+        static_backends: typing.List[junction.config.Backend] | None = None,
         junction_client: junction.Junction | None = None,
         # kwargs
         **kwargs: typing.Any,
@@ -51,7 +51,7 @@ class PoolManager(urllib3.PoolManager):
             self.junction = junction_client
         else:
             self.junction = junction._default_client(
-                default_routes=default_routes, default_backends=default_backends
+                static_routes=static_routes, static_backends=static_backends
             )
 
         super().__init__(num_pools, headers, **kwargs)


### PR DESCRIPTION
All of our `resolve_*` methods now block until data is available in cache until there's data available. This is still a real rough cut at that behavior, and we have some client configuring/tuning to make available, but it involves significant enough changes that I want to land it now and iterate instead of continuing to block this.

### Everything is async now

The big surface-level change is that everything we're doing is async now. Route resolution is async because it's allowed to yield while waiting for results in the cache, which touches all of the cache internals. That touches everything upstream and downstream - including the DNS resolver. This notably *doesn't* touch our unit-test style methods, which is great - we can use static config and [now_or_never](https://docs.rs/futures/latest/futures/future/trait.FutureExt.html#method.now_or_never) to immediately resolve.

Waiting on cache changes felt surprisingly straightforward with `Notify` from tokio. I'd like some eyes on that to make sure we don't have a race there.

### Defaults 

After talking IRL, we decided to stop doing our weird heuristic inference thing with defaults. The client is now either in `Static`, `DynamicEndpoints`, or `Dynamic` mode. In the first, it's fully static. In the second, it's allowed to use xDS for endpoints and nothing else, and for the third all config is dynamic.

This made blocking on route resolution much easier, since doing that required answering a bunch of questions we were handwaving away by just immediately failing to find endpoints and retrying after a delay. We still have one more major source of non-determinism in resolution - generating multiple virtualhosts per URL - but that should be going away in a future PR.