### PR TITLE
junction-api: Add a QueryParam hash policy to RingHash load balancing.

### DIFF
--- a/crates/junction-api-gen/src/main.rs
+++ b/crates/junction-api-gen/src/main.rs
@@ -30,8 +30,7 @@ fn main() {
         junction_api::http::RouteRule::item(),
         junction_api::http::Route::item(),
         junction_api::backend::BackendId::item(),
-        junction_api::backend::SessionAffinityHashParam::item(),
-        junction_api::backend::SessionAffinity::item(),
+        junction_api::backend::RequestHashPolicy::item(),
         junction_api::backend::LbPolicy::item(),
         junction_api::backend::Backend::item(),
     ];

--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -222,10 +222,6 @@ pub struct RouteRule {
     #[doc(hidden)]
     pub filters: Vec<RouteFilter>,
 
-    // FIXME(persistence): enable session persistence as per the Gateway API #[serde(default,
-    // skip_serializing_if = "Option::is_none")]
-    // pub session_persistence: Option<SessionPersistence>,
-
     // The timeouts set on any request that matches route.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeouts: Option<RouteTimeouts>,

--- a/crates/junction-api/src/kube/backend.rs
+++ b/crates/junction-api/src/kube/backend.rs
@@ -186,7 +186,7 @@ mod test {
     use k8s_openapi::api::core::v1 as core_v1;
     use kube::api::ObjectMeta;
 
-    use crate::backend::{RingHashParams, SessionAffinityHashParam, SessionAffinityHashParamType};
+    use crate::backend::{RequestHashPolicy, RequestHasher, RingHashParams};
 
     use super::*;
 
@@ -350,9 +350,9 @@ mod test {
                     id: Service::kube("bar", "foo").unwrap().as_backend_id(443),
                     lb: LbPolicy::RingHash(RingHashParams {
                         min_ring_size: 1024,
-                        hash_params: vec![SessionAffinityHashParam {
+                        hash_params: vec![RequestHashPolicy {
                             terminal: false,
-                            matcher: SessionAffinityHashParamType::Header {
+                            hasher: RequestHasher::Header {
                                 name: "x-user".to_string()
                             }
                         }]

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -252,21 +252,17 @@ class BackendId(typing.TypedDict):
     """The port backend traffic is sent on."""
 
 
-class SessionAffinityHashParam(typing.TypedDict):
+class RequestHashPolicy(typing.TypedDict):
     terminal: bool
     """Whether to stop immediately after hashing this value.
 
-    This is useful if you want to try to hash a value, and then fall back to another as a
-    default if it wasn't set."""
+    This is useful if you want to try to hash a value, and then fall back to
+    another as a default if it wasn't set."""
 
     name: str
     """The name of the header to use as hash input."""
 
-    type: typing.Literal["Header"]
-
-
-class SessionAffinity(typing.TypedDict):
-    hash_params: typing.List[SessionAffinityHashParam]
+    type: typing.Literal["Header"] | typing.Literal["QueryParam"]
 
 
 class LbPolicyRoundRobin(typing.TypedDict):
@@ -278,7 +274,7 @@ class LbPolicyRingHash(typing.TypedDict):
     min_ring_size: int
     """The minimum size of the hash ring"""
 
-    hash_params: typing.List[SessionAffinityHashParam]
+    hash_params: typing.List[RequestHashPolicy]
     """How to hash an outgoing request into the ring.
 
     Hash parameters are applied in order. If the request is missing an input, it has no effect


### PR DESCRIPTION
Add a QueryParam hash policy to RingHash that takes query parameters as inputs. the hash policy works exactly as the Header hash policy, except on HTTP query parameters.

```
(.venv) [21:01:08] benl@booger ~/s/j/junction-client (benl/query-param-ringhash *) $ python example.py
load balancer
         {'type': 'RingHash', 'hash_params': [{'type': 'QueryParam', 'name': 'q'}]}
results:
         {'q': 'hello'} target:jct-http-server,server_id:26
         {'q': 'hello'} target:jct-http-server,server_id:26
         {'q': 'hello'} target:jct-http-server,server_id:26
         {'q': 'goodbye'} target:jct-http-server,server_id:20
         {'q': 'goodbye'} target:jct-http-server,server_id:20
         {'q': 'goodbye'} target:jct-http-server,server_id:20
```

Also removes an unused SessionAffinity struct that would have had to update.