### PR TITLE
Add an optional, human-readable name to RouteRules

### DIFF
--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -201,6 +201,14 @@ impl Route {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct RouteRule {
+    /// A human-readable name for this rule.
+    ///
+    /// This name is compeltely optional, and will only be used in diagnostics
+    /// to make it easier to debug. Diagnostics that don't have a name will be
+    /// referred to by their index in a Route's list of rules.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<Name>,
+
     /// A list of match rules applied to an outgoing request.  Each match is
     /// independent; this rule will be matched if **any** of the listed matches
     /// is satsified.
@@ -941,6 +949,7 @@ mod test {
                 ports: vec![],
                 tags: Default::default(),
                 rules: vec![RouteRule {
+                    name: None,
                     matches: vec![],
                     filters: vec![],
                     timeouts: None,


### PR DESCRIPTION
Add optional names to RouteRules so we can start to use them for debugging matches when producing request traces. This doesn't do anything yet, but as we go make request traces a thing it will help readability.