### PR TITLE
Set up for status reporting and re-resolving hosts on retries

### DIFF
--- a/crates/junction-core/examples/dns-backend.rs
+++ b/crates/junction-core/examples/dns-backend.rs
@@ -48,8 +48,8 @@ async fn main() {
 
     loop {
         match client.resolve_http(&Method::GET, &http_url, &headers).await {
-            Ok(endpoints) => {
-                eprintln!(" http: {:>15}", &endpoints[0].address);
+            Ok(endpoint) => {
+                eprintln!(" http: {:>15}", &endpoint.address);
             }
             Err(e) => eprintln!("http: something went wrong: {e}"),
         }
@@ -57,8 +57,8 @@ async fn main() {
             .resolve_http(&Method::GET, &https_url, &headers)
             .await
         {
-            Ok(endpoints) => {
-                eprintln!("https: {:>15}", &endpoints[0].address);
+            Ok(endpoint) => {
+                eprintln!("https: {:>15}", &endpoint.address);
             }
             Err(e) => eprintln!("https: something went wrong: {e}"),
         }

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -106,11 +106,8 @@ async fn main() {
             continue;
         }
 
-        let prod_endpoints = prod_endpoints.unwrap();
-        let staging_endpoints = staging_endpoints.unwrap();
-        let prod = prod_endpoints.first().unwrap();
-        let staging = staging_endpoints.first().unwrap();
-
+        let prod = prod_endpoints.unwrap();
+        let staging = staging_endpoints.unwrap();
         println!("prod={:<20} staging={:<20}", prod.address, staging.address);
 
         tokio::time::sleep(Duration::from_millis(1500)).await;

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    endpoints::EndpointIter, load_balancer::BackendLb, xds::AdsClient, ConfigCache, Endpoint,
+    endpoints::{EndpointGroup, EndpointIter}, load_balancer::BackendLb, xds::AdsClient, ConfigCache, Endpoint,
     Error, StaticConfig,
 };
 use futures::FutureExt;
@@ -132,7 +132,7 @@ impl ConfigCache for Config {
     async fn get_endpoints(
         &self,
         backend: &BackendId,
-    ) -> Option<Arc<crate::load_balancer::EndpointGroup>> {
+    ) -> Option<Arc<EndpointGroup>> {
         match &self {
             Config::Static(s) => s.get_endpoints(backend).await,
             Config::DynamicEndpoints(_, d) => d.ads_client.get_endpoints(backend).await,

--- a/crates/junction-core/src/dns.rs
+++ b/crates/junction-core/src/dns.rs
@@ -10,7 +10,7 @@ use junction_api::Hostname;
 use rand::Rng;
 use tokio::sync::Notify;
 
-use crate::load_balancer::EndpointGroup;
+use crate::endpoints::EndpointGroup;
 
 /// A blocking resolver that uses the stdlib to resolve hostnames to addresses.
 ///
@@ -652,10 +652,7 @@ mod test {
             .collect();
         assert_eq!(
             endpoints,
-            vec![crate::EndpointAddress::SocketAddr(SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
-                7777,
-            ))]
+            vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7777,)]
         );
     }
 

--- a/crates/junction-core/src/hash.rs
+++ b/crates/junction-core/src/hash.rs
@@ -1,0 +1,41 @@
+/// Convenience functions for doing things with a thread-local Xxhash hasher.
+pub(crate) mod thread_local_xxhash {
+    use std::cell::RefCell;
+    use xxhash_rust::xxh64::Xxh64;
+
+    // gRPC and Envoy use a zero seed. gRPC does this by definition, Envoy by
+    // default.
+    //
+    // https://github.com/grpc/proposal/blob/master/A42-xds-ring-hash-lb-policy.md#xdsconfigselector-changes
+    // https://github.com/envoyproxy/envoy/blob/main/source/common/common/hash.h#L22-L30
+    // https://github.com/envoyproxy/envoy/blob/main/source/common/http/hash_policy.cc#L69
+    const SEED: u64 = 0;
+
+    thread_local! {
+        static HASHER: RefCell<Xxh64> = const { RefCell::new(Xxh64::new(SEED)) };
+    }
+
+    /// Hash a single item using a thread-local [xx64 Hasher][Xxh64].
+    pub(crate) fn hash<H: std::hash::Hash>(h: &H) -> u64 {
+        HASHER.with_borrow_mut(|hasher| {
+            hasher.reset(SEED);
+            h.hash(hasher);
+            hasher.digest()
+        })
+    }
+
+    /// Hash an iterable of hashable items using a thread-local
+    /// [xx64 Hasher][Xxh64].
+    ///
+    /// *Note*: Tuples implement [std::hash::Hash], so if you need to hash a
+    /// sequence of items of different types, try passing a tuple to [hash].
+    pub(crate) fn hash_iter<I: IntoIterator<Item = H>, H: std::hash::Hash>(iter: I) -> u64 {
+        HASHER.with_borrow_mut(|hasher| {
+            hasher.reset(SEED);
+            for h in iter {
+                h.hash(hasher)
+            }
+            hasher.digest()
+        })
+    }
+}

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -5,10 +5,12 @@ mod url;
 pub use crate::error::{Error, Result};
 pub use crate::url::Url;
 
+pub(crate) mod hash;
 pub(crate) mod rand;
 
 mod endpoints;
-pub use endpoints::{Endpoint, EndpointAddress};
+pub use endpoints::Endpoint;
+use endpoints::EndpointGroup;
 
 mod client;
 mod dns;
@@ -26,9 +28,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
 
-pub use crate::load_balancer::BackendLb;
-use crate::load_balancer::EndpointGroup;
-pub use crate::load_balancer::LoadBalancer;
+pub use crate::load_balancer::{BackendLb, LoadBalancer};
 use junction_api::backend::{Backend, LbPolicy};
 
 /// Check route resolution.

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -238,7 +238,7 @@ impl ConfigCache for AdsClient {
     async fn get_endpoints(
         &self,
         backend: &junction_api::backend::BackendId,
-    ) -> Option<std::sync::Arc<crate::load_balancer::EndpointGroup>> {
+    ) -> Option<std::sync::Arc<crate::EndpointGroup>> {
         match &backend.service {
             junction_api::Service::Dns(dns) => {
                 self.dns

--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -1,6 +1,9 @@
 import typing
+
 from junction.junction import (
     Junction,
+    Endpoint,
+    RetryPolicy,
     default_client,
     check_route,
     dump_kube_backend,
@@ -38,6 +41,8 @@ def _default_client(
 
 __all__ = (
     Junction,
+    Endpoint,
+    RetryPolicy,
     config,
     urllib3,
     requests,

--- a/junction-python/junction/requests.py
+++ b/junction-python/junction/requests.py
@@ -163,34 +163,34 @@ class HTTPAdapter(requests.adapters.HTTPAdapter):
             if isinstance(e.reason, ConnectTimeoutError):
                 # TODO: Remove this in 3.0.0: see #2811
                 if not isinstance(e.reason, NewConnectionError):
-                    raise ConnectTimeout(e, request=request)
+                    raise ConnectTimeout(e, request=request) from e
 
             if isinstance(e.reason, ResponseError):
-                raise RetryError(e, request=request)
+                raise RetryError(e, request=request) from e
 
             if isinstance(e.reason, _ProxyError):
-                raise ProxyError(e, request=request)
+                raise ProxyError(e, request=request) from e
 
             if isinstance(e.reason, _SSLError):
                 # This branch is for urllib3 v1.22 and later.
-                raise SSLError(e, request=request)
+                raise SSLError(e, request=request) from e
 
-            raise ConnectionError(e, request=request)
+            raise ConnectionError(e, request=request) from e
 
         except ClosedPoolError as e:
-            raise ConnectionError(e, request=request)
+            raise ConnectionError(e, request=request) from e
 
         except _ProxyError as e:
-            raise ProxyError(e)
+            raise ProxyError(e) from e
 
         except (_SSLError, _HTTPError) as e:
             if isinstance(e, _SSLError):
                 # This branch is for urllib3 versions earlier than v1.22
-                raise SSLError(e, request=request)
+                raise SSLError(e, request=request) from e
             elif isinstance(e, ReadTimeoutError):
-                raise ReadTimeout(e, request=request)
+                raise ReadTimeout(e, request=request) from e
             elif isinstance(e, _InvalidHeader):
-                raise InvalidHeader(e, request=request)
+                raise InvalidHeader(e, request=request) from e
             else:
                 raise
 

--- a/junction-python/junction/urllib3.py
+++ b/junction-python/junction/urllib3.py
@@ -138,12 +138,8 @@ class PoolManager(urllib3.PoolManager):
     ) -> HTTPConnectionPool:
         request_context = self._merge_pool_kwargs(overrrides)
         request_context["scheme"] = endpoint.scheme
-        request_context["port"] = endpoint.addr.port
-
-        if isinstance(endpoint.addr, endpoint.addr.SocketAddr):
-            request_context["host"] = str(endpoint.addr.addr)
-        elif isinstance(endpoint.addr, endpoint.addr.DnsName):
-            request_context["host"] = str(endpoint.addr.name)
+        request_context["host"] = str(endpoint.addr)
+        request_context["port"] = endpoint.port
 
         if endpoint.scheme == "https":
             request_context["assert_hostname"] = endpoint.host

--- a/junction-python/junction/urllib3.py
+++ b/junction-python/junction/urllib3.py
@@ -1,11 +1,18 @@
+import time
 import typing
 
 import urllib3
 from urllib3 import BaseHTTPResponse
 from urllib3.connectionpool import HTTPConnectionPool
+from urllib3.exceptions import (
+    TimeoutError,
+    MaxRetryError,
+    ResponseError,
+)
 
 import junction
-import junction.junction as jct_core
+
+from junction import Endpoint, RetryPolicy
 
 # When integrating with urllib3, it makes the most sense to provide a drop-in
 # replacement for PoolManager - HTTPConnectionPool and friends are pools of
@@ -27,6 +34,49 @@ import junction.junction as jct_core
 # to make it easier to support requests.
 
 # TODO: add a junction.urllib3.request(..) fn helper, just like urllib3.request
+
+
+def _is_redirect_err(e: MaxRetryError) -> bool:
+    if not isinstance(e.reason, ResponseError):
+        return False
+    return "too many redirects" in e.reason.args
+
+
+def _configure_retries(
+    retries: urllib3.Retry | None, policy: RetryPolicy
+) -> typing.Tuple[urllib3.Retry, int | bool]:
+    """
+    Merge Junction retries with callsite specific urilib3.Retry objects.
+
+    Always removes redirect-based retries so that they can be handled
+    directly by urllib3 instead of in the Junction wrapper.
+    """
+    # if nothing got specified at the callsite, use the junction policy
+    #
+    # unfortunately requests always creates an object, so testing whether
+    # its a default means assuming a count of 0 is a default, although we
+    # add a check on the read value being false as a way to workaround when
+    # you really dont want 0 to be overridden
+    if (not retries or not retries.total) and policy:
+        retries = urllib3.Retry(
+            total=policy.attempts - 1,
+            backoff_factor=policy.backoff,
+            status_forcelist=policy.codes,
+        )
+    # if there's no junction policy, use urllib3's default
+    if not isinstance(retries, urllib3.Retry):
+        retries = urllib3.Retry.from_int(retries)
+
+    # strip out redirect retries now that there's a guaranteed policy
+    #
+    # the default of 10 was chosen extremely arbitrarily - it's the Go stdlib's
+    # default and the Go authors tend to know what they're doing.
+    redirect_retries = 10
+    if retries.redirect is not None:
+        redirect_retries = retries.redirect
+        retries.redirect = None
+
+    return retries, redirect_retries
 
 
 class PoolManager(urllib3.PoolManager):
@@ -60,77 +110,111 @@ class PoolManager(urllib3.PoolManager):
         self,
         method: str,
         url: str,
-        # NOTE: redirect is ignored
-        redirect: bool = True,
-        **kw: typing.Any,
+        **kwargs: typing.Any,
     ) -> BaseHTTPResponse:
-        if "headers" not in kw:
-            kw["headers"] = self.headers
+        # grab defaults from self
+        if "headers" not in kwargs:
+            kwargs["headers"] = self.headers
 
-        # TODO: pass in defaults here - timeouts, routing rules, etc.
+        # resolve the endpoint with junction-core
         endpoint = self.junction.resolve_http(
             method,
             url,
-            kw["headers"],
+            kwargs["headers"],
         )
 
-        kw["assert_same_host"] = False
-        kw["redirect"] = False
-
+        # prep for making a request by setting up kwargs once and grabbing a
+        # single-ip connection pool before we do retries. retries get done
+        # at this level so we can call back into junction-core without patching
+        # the guts of urllib3.
+        #
         # requests has an insane API for setting TLS settings, so the junction
         # HTTP adapter has to smuggle TLS connection keys through on every
         # request instead of configuring this pool manager upfront. unsmuggle
         # them here.
-        jct_tls_args = kw.pop("jct_tls_args", {})
+        jct_tls_args = kwargs.pop("jct_tls_args", {})
+        kwargs["assert_same_host"] = False
+        pool = self.connection_from_endpoint(endpoint, **jct_tls_args)
 
+        # set the host header correctly
         if endpoint.host:
-            kw["headers"]["Host"] = endpoint.host
+            kwargs["headers"]["Host"] = endpoint.host
 
-        if endpoint.retry_policy:
-            # unfortunately requests always creates an object, so testing
-            # whether its a default means assuming a count of 0 is a
-            # default, although we add a check on the read value being false
-            # as a way to workaround when you really dont want 0 to be
-            # overridden
-            current = kw.get("retries")
-            is_default = not current or (current.total == 0 and not current.read)
-            if is_default:
-                kw["retries"] = urllib3.Retry(
-                    total=endpoint.retry_policy.attempts - 1,
-                    backoff_factor=endpoint.retry_policy.backoff,
-                    status_forcelist=endpoint.retry_policy.codes,
-                )
-
-        if (
-            not kw.get("timeout")
-            and endpoint.timeout_policy
-            and endpoint.timeout_policy.backend_request != 0
-        ):
-            kw["timeout"] = urllib3.Timeout(
-                total=endpoint.timeout_policy.backend_request
-            )
-        elif (
-            not kw.get("timeout")
-            and endpoint.timeout_policy
-            and endpoint.timeout_policy.request != 0
-        ):
-            kw["timeout"] = urllib3.Timeout(
-                ## FIXME: this is obviously not right, but urllib3 does not
-                ## give us more options. To implement properly, we would
-                ## have to implement retries ourselves.
-                total=endpoint.timeout_policy.request
-            )
-
-        conn = self.connection_from_endpoint(endpoint, **jct_tls_args)
-        return conn.urlopen(
-            method,
-            endpoint.request_uri,
-            **kw,
+        # build the retry policy we'll use to make this request
+        retries, redirect_retries = _configure_retries(
+            kwargs.get("retries"), endpoint.retry_policy
         )
+
+        # set a per-request timeout (don't clobber an existing one) if there's a
+        # Junction timeout.
+        if not kwargs.get("timeout") and endpoint.timeout_policy:
+            request_timeout = min(
+                endpoint.timeout_policy.backend_request, endpoint.timeout_policy.request
+            )
+            if request_timeout > 0:
+                kwargs["timeout"] = urllib3.Timeout(total=request_timeout)
+
+        # set up an overall deadline based on the endpoint's timeout policy
+        deadline = None
+        if endpoint.timeout_policy and endpoint.timeout_policy.request:
+            deadline = time.time() + endpoint.timeout_policy.request
+
+        while True:
+            if deadline and time.time() > deadline:
+                # TODO: should this be a Junction timeout error instead of the
+                # more general urllib3 one?
+                raise TimeoutError("request timeout exceeded")
+
+            # make a copy of request kwargs and ovewrite retries to only allow
+            # redirect handling.
+            #
+            # only setting `total=None` does weird things here
+            kwargs = dict(kwargs)
+            kwargs["retries"] = urllib3.Retry(
+                redirect=redirect_retries,
+                other=0,
+                read=0,
+                connect=0,
+                status=0,
+            )
+
+            try:
+                response = pool.urlopen(method=method, url=url, **kwargs)
+            except MaxRetryError as e:
+                if _is_redirect_err(e):
+                    raise e
+
+                # anything urllib3 thinks is worth retrying gets wrapped in
+                # a MaxRetryError, even when you don't allow retries. all we
+                # do here is pass that the cause of that error to our own
+                # urllib3.Retry
+                retries = retries.increment(
+                    method, url, error=e.reason, _pool=pool, _stacktrace=e.__traceback__
+                )
+                retries.sleep()
+                continue
+
+            has_retry_after = bool(response.headers.get("Retry-After"))
+            if retries.is_retry(method, response.status, has_retry_after):
+                try:
+                    retries = retries.increment(
+                        method, url, response=response, _pool=pool
+                    )
+                except MaxRetryError:
+                    if retries.raise_on_status:
+                        response.drain_conn()
+                        raise
+                    return response
+
+                response.drain_conn()
+                retries.sleep(response)
+                continue
+
+            return response
 
     def connection_from_endpoint(
         self,
-        endpoint: "jct_core.Endpoint",
+        endpoint: Endpoint,
         **overrrides: typing.Any,
     ) -> HTTPConnectionPool:
         request_context = self._merge_pool_kwargs(overrrides)

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -463,6 +463,19 @@ impl Junction {
         Ok(endpoints)
     }
 
+    #[pyo3(signature = (*, endpoint, status_code=None, error=None))]
+    fn report_status(
+        &mut self,
+        endpoint: Endpoint,
+        status_code: Option<u16>,
+        error: Option<Bound<PyAny>>,
+    ) -> PyResult<Endpoint> {
+        // TODO: actually implement/call this in the core client.
+        let _ = status_code;
+        let _ = error;
+        Ok(endpoint)
+    }
+
     /// Spawn a new CSDS server on the given port. Spawning the server will not
     /// block the current thread.
     fn run_csds_server(&self, port: u16) -> PyResult<()> {

--- a/junction-python/tests/test_urllib3.py
+++ b/junction-python/tests/test_urllib3.py
@@ -1,16 +1,58 @@
-import typing
+from urllib3 import Retry
 
-from urllib3 import BaseHTTPResponse
-from urllib3 import PoolManager as Urllib3PoolManager
-
-from junction.urllib3 import PoolManager as JunctionPoolManger
-
-POOL_CLASSES = [Urllib3PoolManager, JunctionPoolManger]
+from junction.urllib3 import _configure_retries
+from junction import RetryPolicy
 
 
-def _responses_equal(a: BaseHTTPResponse, b: BaseHTTPResponse):
-    return (a.url == b.url) and (a.headers == b.headers) and (a.data == b.data)
+def retry_equals(r1: Retry, r2: Retry):
+    return (r1 is r2) or (r1.__dict__ == r2.__dict__)
 
 
-def _pool_managers(url: str, **kwargs) -> typing.List[Urllib3PoolManager]:
-    return [pool_cls() for pool_cls in POOL_CLASSES]
+def test_retry_policy_only():
+    expected = Retry(total=1, status_forcelist=[501, 503], backoff_factor=0.5)
+    (actual, redirect_retries) = _configure_retries(
+        retries=None, policy=RetryPolicy(codes=[501, 503], attempts=2, backoff=0.5)
+    )
+
+    assert retry_equals(expected, actual)
+    assert redirect_retries == 10
+
+
+def test_retries_only():
+    expected = Retry(total=123, redirect=789, connect=123)
+    (actual, redirect_retries) = _configure_retries(
+        retries=expected,
+        policy=None,
+    )
+
+    assert retry_equals(expected, actual)
+    assert redirect_retries == 789
+
+
+def test_merge_retries_and_policy():
+    expected = Retry(total=123, redirect=789, connect=123)
+    policy = RetryPolicy(codes=[501, 503], attempts=2, backoff=0.5)
+
+    (actual, redirect_retries) = _configure_retries(
+        retries=expected,
+        policy=policy,
+    )
+
+    assert retry_equals(expected, actual)
+    assert redirect_retries == 789
+
+
+def test_merge_default_retries_and_policy():
+    default_retry = Retry.from_int(0)
+    policy = RetryPolicy(codes=[501, 503], attempts=2, backoff=0.5)
+
+    (actual, redirect_retries) = _configure_retries(
+        retries=default_retry,
+        policy=policy,
+    )
+
+    assert retry_equals(
+        Retry(total=1, status_forcelist=[501, 503], backoff_factor=0.5),
+        actual,
+    )
+    assert redirect_retries == 10


### PR DESCRIPTION
This is prep-work for status reporting on requests (both failed and successful) and for re-resolving addresses on retries, but involved a bunch of refactoring I wanted to land before it went on too long.

### Changing `Endpoints`

It hasn't ever made sense to return a `Vec<Endpoint>` but it was always something we could work around for the moment. The time has come to stop working around it and think more deeply about what we're returning. This PR trims down the vec to a single struct we're returning with basic info about what to connect to.

We'll end up adding to this over time (we'll almost certainly include resolution info and a list of mirroring addresses) but this is the basic struct we need for now.

### Doing retries ourselves

We've ben handing off retries entirely to urllib3 but had to stop to hit two goals: setting an overall timeout on an entire request, and changing IPs when resolving. Pooling at the individual IP level is still the right thing, but the code got much a bit more complicated than setting up individual policies and letting things rip.

### More To Come

This PR also adds some status reporting hooks for complete requests, but they don't do anything yet. I started on some basic reporting and it's going to involve some deeper changes to junction-core, so I'm going to put them in their own PR.