### PR TITLE
junction-core: Select new endpoints on retries, add Traces

### DIFF
--- a/crates/junction-api/src/http.rs
+++ b/crates/junction-api/src/http.rs
@@ -680,7 +680,7 @@ pub struct RouteRetry {
     //
     // TODO: should this be http::StatusCode?
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub codes: Vec<u32>,
+    pub codes: Vec<u16>,
 
     /// The total number of attempts to make when retrying this request.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/junction-api/src/kube/http.rs
+++ b/crates/junction-api/src/kube/http.rs
@@ -377,7 +377,7 @@ impl RouteRetry {
     fn from_gateway(retry: &gateway_http::HTTPRouteRulesRetry) -> Result<Self, Error> {
         let mut codes = Vec::with_capacity(retry.codes.as_ref().map_or(0, |c| c.len()));
         for (i, &code) in retry.codes.iter().flatten().enumerate() {
-            let code: u32 = code
+            let code: u16 = code
                 .try_into()
                 .map_err(|_| Error::new_static("invalid response code"))
                 .with_field_index("codes", i)?;

--- a/crates/junction-core/examples/dns-backend.rs
+++ b/crates/junction-core/examples/dns-backend.rs
@@ -49,7 +49,7 @@ async fn main() {
     loop {
         match client.resolve_http(&Method::GET, &http_url, &headers).await {
             Ok(endpoint) => {
-                eprintln!(" http: {:>15}", &endpoint.address);
+                eprintln!(" http: {:>15}", &endpoint.addr());
             }
             Err(e) => eprintln!("http: something went wrong: {e}"),
         }
@@ -58,7 +58,7 @@ async fn main() {
             .await
         {
             Ok(endpoint) => {
-                eprintln!("https: {:>15}", &endpoint.address);
+                eprintln!("https: {:>15}", &endpoint.addr());
             }
             Err(e) => eprintln!("https: something went wrong: {e}"),
         }

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -108,7 +108,7 @@ async fn main() {
 
         let prod = prod_endpoints.unwrap();
         let staging = staging_endpoints.unwrap();
-        println!("prod={:<20} staging={:<20}", prod.address, staging.address);
+        println!("prod={:<20} staging={:<20}", prod.addr(), staging.addr());
 
         tokio::time::sleep(Duration::from_millis(1500)).await;
     }

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -1,6 +1,151 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, net::SocketAddr, time::Instant};
 
-use junction_api::{backend::BackendId, Name};
+use junction_api::{backend::BackendId, http::Route, Name};
+use smol_str::{SmolStr, ToSmolStr};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Trace {
+    start: Instant,
+    phase: TracePhase,
+    events: Vec<TraceEvent>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TraceEvent {
+    pub(crate) phase: TracePhase,
+    pub(crate) kind: TraceEventKind,
+    pub(crate) at: Instant,
+    pub(crate) kv: Vec<TraceData>,
+}
+
+type TraceData = (&'static str, SmolStr);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TracePhase {
+    RouteResolution,
+    EndpointSelection(u8),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TraceEventKind {
+    RouteLookup,
+    RouteRuleMatched,
+    BackendSelected,
+    BackendLookup,
+    EndpointsLookup,
+    SelectAddr,
+}
+
+impl Trace {
+    pub(crate) fn new() -> Self {
+        Trace {
+            start: Instant::now(),
+            phase: TracePhase::RouteResolution,
+            events: Vec::new(),
+        }
+    }
+
+    pub(crate) fn events(&self) -> impl Iterator<Item = &TraceEvent> {
+        self.events.iter()
+    }
+
+    pub(crate) fn start(&self) -> Instant {
+        self.start
+    }
+
+    pub(crate) fn lookup_route(&mut self, route: &Route) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::RouteLookup,
+            phase: TracePhase::RouteResolution,
+            at: Instant::now(),
+            kv: vec![("route", route.id.to_smolstr())],
+        })
+    }
+
+    pub(crate) fn matched_rule(&mut self, rule: usize, rule_name: Option<&Name>) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        let kv = match rule_name {
+            Some(name) => vec![("rule-name", name.to_smolstr())],
+            None => vec![("rule-idx", rule.to_smolstr())],
+        };
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::RouteRuleMatched,
+            phase: TracePhase::RouteResolution,
+            at: Instant::now(),
+            kv,
+        })
+    }
+
+    pub(crate) fn select_backend(&mut self, backend: &BackendId) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        self.events.push(TraceEvent {
+            phase: self.phase,
+            kind: TraceEventKind::BackendSelected,
+            at: Instant::now(),
+            kv: vec![("name", backend.to_smolstr())],
+        });
+    }
+
+    pub(crate) fn start_endpoint_selection(&mut self) {
+        let next_phase = match self.phase {
+            TracePhase::RouteResolution => TracePhase::EndpointSelection(0),
+            TracePhase::EndpointSelection(n) => TracePhase::EndpointSelection(n + 1),
+        };
+        self.phase = next_phase;
+    }
+
+    pub(crate) fn lookup_backend(&mut self, backend: &BackendId) {
+        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::BackendLookup,
+            phase: self.phase,
+            at: Instant::now(),
+            kv: vec![("backend-id", backend.to_smolstr())],
+        })
+    }
+
+    pub(crate) fn lookup_endpoints(&mut self, backend: &BackendId) {
+        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::EndpointsLookup,
+            phase: self.phase,
+            at: Instant::now(),
+            kv: vec![("backend-id", backend.to_smolstr())],
+        })
+    }
+
+    pub(crate) fn load_balance(
+        &mut self,
+        lb_name: &'static str,
+        addr: Option<&SocketAddr>,
+        extra: Vec<TraceData>,
+    ) {
+        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
+
+        let mut kv = Vec::with_capacity(extra.len() + 2);
+        kv.push(("type", lb_name.to_smolstr()));
+        kv.push((
+            "addr",
+            addr.map(|a| a.to_smolstr())
+                .unwrap_or_else(|| "-".to_smolstr()),
+        ));
+        kv.extend(extra);
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::SelectAddr,
+            phase: self.phase,
+            at: Instant::now(),
+            kv,
+        });
+    }
+}
 
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -9,6 +154,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 #[error("{inner}")]
 pub struct Error {
+    // a trace of what's happened so far
+    trace: Option<Trace>,
+
     // boxed to keep the size of the error down. this apparently has a large
     // effect on the performance of calls to functions that return
     // Result<_, Error>.
@@ -31,18 +179,23 @@ impl Error {
 impl Error {
     // timeouts
 
+    // FIXME: needs a trace?
     pub(crate) fn timed_out(message: &'static str) -> Self {
         let inner = ErrorImpl::TimedOut(Cow::from(message));
         Self {
+            trace: None,
             inner: Box::new(inner),
         }
     }
 
     // url problems
+    //
+    // TODO: should this be a separate type? thye don't need a Trace or anything
 
     pub(crate) fn into_invalid_url(message: String) -> Self {
         let inner = ErrorImpl::InvalidUrl(Cow::Owned(message));
         Self {
+            trace: None,
             inner: Box::new(inner),
         }
     }
@@ -50,45 +203,52 @@ impl Error {
     pub(crate) fn invalid_url(message: &'static str) -> Self {
         let inner = ErrorImpl::InvalidUrl(Cow::Borrowed(message));
         Self {
+            trace: None,
             inner: Box::new(inner),
         }
     }
 
     // route problems
 
-    pub(crate) fn no_route_matched(authority: String) -> Self {
+    pub(crate) fn no_route_matched(authority: String, trace: Trace) -> Self {
         Self {
+            trace: Some(trace),
             inner: Box::new(ErrorImpl::NoRouteMatched { authority }),
         }
     }
 
-    pub(crate) fn no_rule_matched(route: Name) -> Self {
+    pub(crate) fn no_rule_matched(route: Name, trace: Trace) -> Self {
         Self {
+            trace: Some(trace),
             inner: Box::new(ErrorImpl::NoRuleMatched { route }),
         }
     }
 
-    pub(crate) fn invalid_route(message: &'static str, id: Name, rule: usize) -> Self {
+    pub(crate) fn invalid_route(
+        message: &'static str,
+        id: Name,
+        rule: usize,
+        trace: Trace,
+    ) -> Self {
         Self {
+            trace: Some(trace),
             inner: Box::new(ErrorImpl::InvalidRoute { id, message, rule }),
         }
     }
 
     // backend problems
 
-    pub(crate) fn no_backend(route: Name, rule: Option<usize>, backend: BackendId) -> Self {
+    pub(crate) fn no_backend(backend: BackendId, trace: Trace) -> Self {
         Self {
-            inner: Box::new(ErrorImpl::NoBackend {
-                route,
-                rule,
-                backend,
-            }),
+            trace: Some(trace),
+            inner: Box::new(ErrorImpl::NoBackend { backend }),
         }
     }
 
-    pub(crate) fn no_reachable_endpoints(route: Name, backend: BackendId) -> Self {
+    pub(crate) fn no_reachable_endpoints(backend: BackendId, trace: Trace) -> Self {
         Self {
-            inner: Box::new(ErrorImpl::NoReachableEndpoints { route, backend }),
+            trace: Some(trace),
+            inner: Box::new(ErrorImpl::NoReachableEndpoints { backend }),
         }
     }
 }
@@ -111,16 +271,12 @@ enum ErrorImpl {
     #[error("no route matched: '{authority}'")]
     NoRouteMatched { authority: String },
 
-    #[error("using route '{route}': no routing rules matched the request")]
+    #[error("{route}: no rules matched the request")]
     NoRuleMatched { route: Name },
 
-    #[error("{route}: backend not found: {backend}")]
-    NoBackend {
-        route: Name,
-        rule: Option<usize>,
-        backend: BackendId,
-    },
+    #[error("{backend}: backend not found")]
+    NoBackend { backend: BackendId },
 
     #[error("{backend}: no reachable endpoints")]
-    NoReachableEndpoints { route: Name, backend: BackendId },
+    NoReachableEndpoints { backend: BackendId },
 }

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -17,7 +17,8 @@ mod dns;
 mod load_balancer;
 mod xds;
 
-pub use client::{Client, HttpRequest, ResolveMode, ResolvedRoute};
+pub use client::{Client, HttpRequest, HttpResult, ResolveMode, ResolvedRoute};
+use error::Trace;
 use futures::FutureExt;
 use junction_api::Name;
 pub use xds::{ResourceVersion, XdsConfig};
@@ -57,7 +58,7 @@ pub fn check_route(
     // resolve_routes is async but we know that with StaticConfig, fetching
     // config should NEVER block. now-or-never just calls Poll with a noop
     // waker and unwraps the result ASAP.
-    client::resolve_routes(&config, request)
+    client::resolve_routes(&config, request, Trace::new())
         .now_or_never()
         .expect("check_route yielded unexpectedly. this is a bug in Junction, please file an issue")
 }

--- a/crates/junction-core/src/url.rs
+++ b/crates/junction-core/src/url.rs
@@ -26,6 +26,8 @@ pub struct Url {
     path_and_query: http::uri::PathAndQuery,
 }
 
+// TODO: own error type here?
+
 impl std::fmt::Display for Url {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(


### PR DESCRIPTION
## Endpoints

`report_status` actually does something now - it's not tracking status though! We're now re-selecting endpoints from the load balancer if the request needs to be retried. Since Endpoints carry around the entire RetryPolicy and the history of addresses tried (not unique addresses!), each Endpoint contains enough information to decide whether or not a new address should be selected.

That change is fairly minor, but required a bunch of interface changes and hiding the internals of Endpoint from public callers so we can smuggle enough data through, but still be relatively sure callers aren't mucking with Endpoint internals too much in a way that would mess with retries. 

There are two big choices in this PR worth calling out:

1) Endpoint has an opinion about how retries are done and determines whether or not the address should be reselected based on the response. We could have done this externally in every language client, but centralizing cleans that up and should help expose any weird inconsistencies between clients as we go.

2) We're not doing anything to avoid re-using addresses in RoundRobin policies yet. Envoy has an infinitely configurable knob here, which we don't want to replicate. Rather than picking a default policy, I opted to avoid the problem for now, since there are a million edge cases, but none that I can see really complicating our API.

## Traces

Endpoints now also smuggle around a full trace of what actually happened during a request. A `Trace` is a [passport](https://www.youtube.com/watch?v=_1rh_s1WmRA) style struct that gets passed in everywhere and marked by callees as they see fit. The interface should eventually be public, but right now it's there just as an internal thing we can experiment with.
