### PR TITLE
junction-python: docs, dump_xds_errors, and ctrl-c handling

### DIFF
--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -514,6 +514,19 @@ impl Client {
         }
     }
 
+    /// Dump xDS resources that failed to update. This is a view of the data
+    /// returned by [Client::dump_xds] that only contains resources with
+    /// errors.
+    pub fn dump_xds_errors(&self) -> Vec<crate::XdsConfig> {
+        match self.config.ads() {
+            Some(ads) => ads
+                .iter_xds()
+                .filter(|xds| xds.last_error.is_some())
+                .collect(),
+            None => Vec::new(),
+        }
+    }
+
     /// Dump the Client's current table of [Route]s, merging together any
     /// default routes and remotely fetched routes the same way the client would
     /// when resolving endpoints.

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -17,7 +17,9 @@ mod dns;
 mod load_balancer;
 mod xds;
 
-pub use client::{Client, HttpRequest, HttpResult, ResolveMode, ResolvedRoute};
+pub use client::{
+    Client, HttpRequest, HttpResult, LbContext, ResolveMode, ResolvedRoute, SelectedEndpoint,
+};
 use error::Trace;
 use futures::FutureExt;
 use junction_api::Name;

--- a/crates/junction-core/src/load_balancer.rs
+++ b/crates/junction-core/src/load_balancer.rs
@@ -9,7 +9,8 @@ use std::{
     },
 };
 
-/// A [Backend] and the [LoadBalancer] it's configured with.
+/// A [Backend][junction_api::backend::Backend] and the [LoadBalancer] it's
+/// configured with.
 #[derive(Debug)]
 pub struct BackendLb {
     pub config: Backend,

--- a/crates/junction-core/src/url.rs
+++ b/crates/junction-core/src/url.rs
@@ -2,8 +2,7 @@ use std::{borrow::Cow, str::FromStr};
 
 use crate::Error;
 
-/// An [http::Uri] that has an `http` or `https` scheme and a non-empty
-/// `authority`.
+/// An Uri with an `http` or `https` scheme and a non-empty `authority`.
 ///
 /// The `authority` section of a `Url` must contains a hostname and may contain
 /// a port, but must not contain a username or password.

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -547,6 +547,22 @@ impl Junction {
 
         Ok(values)
     }
+
+    /// Dump the client's current xDS errors as a pbjson dict.
+    ///
+    /// This is the same as dumping config with dump_xds and filtering to only
+    /// xds with a `last_error` message set.
+    fn dump_xds_erorrs(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+        let mut values = vec![];
+
+        for config in self.core.dump_xds_errors() {
+            let config: XdsConfig = config.into();
+            let as_py = pythonize::pythonize(py, &config)?;
+            values.push(as_py);
+        }
+
+        Ok(values)
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/junction-python/src/runtime.rs
+++ b/junction-python/src/runtime.rs
@@ -1,0 +1,90 @@
+use std::{future::Future, time::Duration};
+
+use once_cell::sync::Lazy;
+use pyo3::{exceptions::PyRuntimeError, PyErr, PyResult, Python};
+
+static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .thread_name("junction")
+        .build()
+        .expect("Junction failed to initialize its async runtime. this is a bug in Junction");
+
+    rt
+});
+
+/// Spawn a task on a static/lazy tokio runtime.
+///
+/// Python and Bound are !Send. Do not try to work around this - holding the GIL
+/// in a background task WILL cause deadlocks.
+pub(crate) fn spawn<F, T>(fut: F) -> tokio::task::JoinHandle<T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    RUNTIME.spawn(fut)
+}
+
+/// Acquire a static/lazy tokio Runtime and `block_on` a future while
+/// occasionally allowing the interpreter to check for signals.
+///
+/// This fn always converts the error type of the future to a PyRuntimeError by
+/// calling `PyRuntimeError::new_err(e.to_string())`
+///
+/// # You're on main
+///
+/// Checking for signals is done on the current thread, as guaranteed by
+/// [tokio::runtime::Runtime::block_on], HOWEVER, checking for signals from any
+/// thread but the main thread will do nothing. Calling this fn on any thread
+/// but the main fn will do nothing but incur the overhead of running an
+/// unnecessary future.
+///
+/// Checking signals requires holding the GIL, which would be a bad thing to do
+/// across an await point - instead of taking a `Python<'_>` token, it
+/// periodically calls [Python::with_gil] and briefly holds the GIL to check on
+/// signals. See the [Python] docs for more about the GIL and deadlocks.
+///
+/// # (Not) Holding the GIL
+///
+/// In addition to the signal check not holding the GIL, you should ALSO not be
+/// holding the GIL while calling this fn. The future passed to this fn and its
+/// outputs must be Send, which means the compiler will keep you from passing a
+/// Python or a Bound here.
+///
+/// HOWEVER, the caller might implicitly have a Python or a Bound in scope, so
+/// before calling block_on this function (re)acquires the GIL so that it can
+/// temporarily suspend it while `block_on` runs.
+///
+/// The Pyo3 authors recommend a slightly different, finer-grained which will
+/// appears to release the GIL while a future is being Polled but not while it
+/// is suspended waiting for its next poll.
+///
+/// https://pyo3.rs/v0.23.3/async-await.html#release-the-gil-across-await
+pub(crate) fn block_and_check_signals<F, T, E>(fut: F) -> PyResult<T>
+where
+    F: Future<Output = Result<T, E>> + Send,
+    T: Send,
+    E: Send + std::fmt::Display,
+{
+    async fn check_signals() -> PyErr {
+        loop {
+            if let Err(e) = Python::with_gil(|py| py.check_signals()) {
+                return e;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    Python::with_gil(|py| {
+        py.allow_threads(|| {
+            RUNTIME.block_on(async {
+                tokio::select! {
+                    biased;
+                    res = fut => res.map_err(|e| PyRuntimeError::new_err(e.to_string())),
+                    e = check_signals() => Err(e),
+                }
+            })
+        })
+    })
+}


### PR DESCRIPTION
This is a grab bag of two small commits and one small but detailed one.

3195757 fixes up some documentation. Easy.

da9e837 adds a helper method to dump xDS errors to make it easy to quickly introspect a client. Easy.

2799ad5 adds ctrl-c handling, and makes sure we release the GIL while blocking on Futures from sync Python. This is a bit hairy, because the GIL is reentrant but Futures may run on other threads. The change hides the tokio runtime behind a `spawn` wrapper that prevents holding the GIL by requiring that Futures are `Send` and a `block_on` wrapper that releases the GIL while the runtime blocks the thread on the `Future`.