### PR TITLE
junction-api: add an ordering to RouteRule and RouteMatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "once_cell",
+ "rand",
  "regex",
  "serde",
  "serde_json",

--- a/crates/junction-api/Cargo.toml
+++ b/crates/junction-api/Cargo.toml
@@ -37,6 +37,7 @@ kube = { version = "0.96", optional = true }
 serde_yml = "0.0.12"
 arbtest = "0.3"
 arbitrary = "1.3"
+rand = "0.8"
 
 [features]
 default = []

--- a/crates/junction-api/src/shared.rs
+++ b/crates/junction-api/src/shared.rs
@@ -10,7 +10,7 @@ use std::time::Duration as StdDuration;
 use junction_typeinfo::TypeInfo;
 
 /// A fraction, expressed as a numerator and a denominator.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "typeinfo", derive(TypeInfo))]
 pub struct Fraction {
     pub numerator: i32,
@@ -24,6 +24,14 @@ pub struct Fraction {
 /// `Regex` has same syntax and semantics as Rust's [`regex` crate](https://docs.rs/regex/latest/regex/).
 #[derive(Clone)]
 pub struct Regex(regex::Regex);
+
+impl PartialEq for Regex {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Eq for Regex {}
 
 impl std::fmt::Debug for Regex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -97,12 +105,6 @@ impl<'de> Deserialize<'de> for Regex {
             }
         }
         deserializer.deserialize_string(RegexVisitor)
-    }
-}
-
-impl PartialEq for Regex {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_str() == other.0.as_str()
     }
 }
 


### PR DESCRIPTION
Add an ordering to RouteRule and RouteMatch that complies with the Gateway API's rules for match precedence. 

https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule

Sorting ahead of time won't guarantee compliance with the Gateway API's tiebreaking rules. It's possible to have a scenario where a rule R1 has matches A and C, and a rule R2 has a match B that means A > B > C, but R1 > R2. If a request matches B and C, evaluating rules in-order won't comply with the Gateway API's tie-breaking rules.

This seems like an extreme corner case, and not something we can find tested in the gateway conformance tests at this point - the closest thing we can see in conformance is [this test](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-method-matching.yaml) - so we're going to ignore this part of the spec for now.