### PR TITLE
junction-core: fix overload, make timeouts better

### DIFF
--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -179,11 +179,10 @@ impl Error {
 impl Error {
     // timeouts
 
-    // FIXME: needs a trace?
-    pub(crate) fn timed_out(message: &'static str) -> Self {
+    pub(crate) fn timed_out(message: &'static str, trace: Trace) -> Self {
         let inner = ErrorImpl::TimedOut(Cow::from(message));
         Self {
-            trace: None,
+            trace: Some(trace),
             inner: Box::new(inner),
         }
     }

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -58,7 +58,7 @@ pub fn check_route(
     // resolve_routes is async but we know that with StaticConfig, fetching
     // config should NEVER block. now-or-never just calls Poll with a noop
     // waker and unwraps the result ASAP.
-    client::resolve_routes(&config, request, Trace::new())
+    client::resolve_routes(&config, Trace::new(), request, None)
         .now_or_never()
         .expect("check_route yielded unexpectedly. this is a bug in Junction, please file an issue")
 }

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -17,9 +17,7 @@ mod dns;
 mod load_balancer;
 mod xds;
 
-pub use client::{
-    Client, HttpRequest, HttpResult, LbContext, ResolveMode, ResolvedRoute, SelectedEndpoint,
-};
+pub use client::{Client, HttpRequest, HttpResult, LbContext, ResolvedRoute, SelectedEndpoint};
 use error::Trace;
 use futures::FutureExt;
 use junction_api::Name;
@@ -170,29 +168,6 @@ impl StaticConfig {
         backends.extend(inferred_backends);
 
         Self { routes, backends }
-    }
-
-    pub(crate) fn backends(&self) -> Vec<BackendId> {
-        let mut backends = Vec::with_capacity(self.routes.len() + self.backends.len());
-
-        // backends
-        backends.extend(self.backends.keys().cloned());
-
-        // all of the route targets
-        for route in &self.routes {
-            for rule in &route.rules {
-                for backend_ref in &rule.backends {
-                    if let Some(port) = backend_ref.port {
-                        backends.push(backend_ref.service.as_backend_id(port));
-                    }
-                }
-            }
-        }
-
-        backends.sort();
-        backends.dedup();
-
-        backends
     }
 }
 


### PR DESCRIPTION
Fixes the occasional panic we had by actually making subscribing to a hostname/backend async. Moves it into the client to simplify the interface as well.

This gets rid of `ResolveMode`, which we hadn't really been using. There's no convenient way to pass that through without making caches fully aware of it. This makes the client simpler, but also means that testing route resolution with a client's currently fetched set of routes takes an extra step. That seems like an ok tradeoff.

There's also a commit in here that rejiggers timeout handling so that we can see individual timeouts for fetching backends and requests. Callers can now also pass a deadline when calling `resolve_route` and `select_endpoint`.