### PR TITLE
Add an action to deploy to NPM

### DIFF
--- a/.github/workflows/release-node.yaml
+++ b/.github/workflows/release-node.yaml
@@ -1,0 +1,154 @@
+name: Release Node
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Git Commit SHA. Use the latest commit on main if left blank.
+        type: string
+      dry-run:
+        description: Dry run. Defaults to true. Won't release to NPM by default.
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  rust_stable: stable
+  node_lts: 20.x
+
+jobs:
+  # build the ts-only package.
+  #
+  # does not install a Rust toolchain
+  ts-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node_lts }}
+          cache: npm
+          cache-dependency-path: junction-node/package-lock.json
+
+      - name: package
+        run: |
+          mkdir -p ./junction-node/dist
+          npm --prefix ./junction-node ci
+          npm --prefix ./junction-node pack ./junction-node --pack-destination ./junction-node/dist
+        env:
+          JUNCTION_CLIENT_SKIP_POSTINSTALL: "true"
+
+      - name: upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: "javascript"
+          path: junction-node/dist/*.tgz
+
+  # build a platform specific package on each platform we support
+  #
+  # hard codes every platform we support and its Neon platform string so we can
+  # make sure we don't accidentally lose a platform if the output of
+  # `neon show platforms` changes.
+  native-packages:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            neon_platform: win32-x64-msvc
+            target: x86_64-pc-windows-msvc
+          - runner: macos-latest
+            neon_platform: darwin-x64
+            target: x86_64-apple-darwin
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            neon_platform: darwin-arm64
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            neon_platform: linux-x64-gnu
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            neon_platform: linux-arm64-gnu
+            neon_build: cross-release
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: "Install Rust @ ${{ env.rust_stable }}"
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+          targets: ${{ matrix.platform.target }}
+      - name: "install cross"
+        if: ${{ startsWith(matrix.platform.neon_build, 'cross') }}
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node_lts }}
+
+      - name: build
+        shell: bash
+        run: |
+          npm --prefix ./junction-node ci --fund=false
+          npm --prefix ./junction-node run ${{ matrix.platform.neon_build || 'build-release' }}
+          mkdir -p ./junction-node/dist
+          npm --prefix ./junction-node pack ./junction-node/platforms/${{ matrix.platform.neon_platform }} --pack-destination ./junction-node/dist
+        env:
+          CARGO_BUILD_TARGET: ${{ matrix.platform.target }}
+          NEON_BUILD_PLATFORM: ${{ matrix.platform.neon_platform }}
+          JUNCTION_CLIENT_SKIP_POSTINSTALL: "true"
+
+      - name: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform.neon_platform }}
+          path: junction-node/dist/*.tgz
+
+  npm-publish:
+    name: publish-to-npm
+    needs: [ts-package, native-packages]
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release-node
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node_lts }}
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: junction-node/package-lock.json
+      - name: download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: show artifacts
+        run: ls -lah dist/*
+      - name: publish
+        if: inputs.dry-run == false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          for package in ./dist/*.tgz; do
+            npm publish --provenance --access public $package
+          done

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -30,6 +30,9 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -38,7 +41,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path junction-python/Cargo.toml
-          sccache: 'true'
+          sccache: "true"
           # cargo culted from Polars. this is probably this ring issue:
           #
           # https://github.com/pola-rs/polars/blob/abe5139f471f7b63104490813d316fc8497373c1/.github/workflows/release-python.yml#L200
@@ -69,7 +72,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path junction-python/Cargo.toml
-          sccache: 'true'
+          sccache: "true"
           manylinux: musllinux_1_2
       - name: upload wheels
         uses: actions/upload-artifact@v4
@@ -95,7 +98,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path junction-python/Cargo.toml
-          sccache: 'true'
+          sccache: "true"
       - name: upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -121,7 +124,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path junction-python/Cargo.toml
-          sccache: 'true'
+          sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/junction-node/package-lock.json
+++ b/junction-node/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@junction-labs/client",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@junction-labs/client",
-      "version": "0.1.0",
+      "version": "0.2.2",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@neon-rs/load": "^0.1.82",
@@ -20,11 +21,11 @@
         "typescript": "^5.3.3"
       },
       "optionalDependencies": {
-        "@junction-labs/client-darwin-arm64": "0.1.0",
-        "@junction-labs/client-darwin-x64": "0.1.0",
-        "@junction-labs/client-linux-arm64-gnu": "0.1.0",
-        "@junction-labs/client-linux-x64-gnu": "0.1.0",
-        "@junction-labs/client-win32-x64-msvc": "0.1.0"
+        "@junction-labs/client-darwin-arm64": "0.2.2",
+        "@junction-labs/client-darwin-x64": "0.2.2",
+        "@junction-labs/client-linux-arm64-gnu": "0.2.2",
+        "@junction-labs/client-linux-x64-gnu": "0.2.2",
+        "@junction-labs/client-win32-x64-msvc": "0.2.2"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -326,6 +327,71 @@
       ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@junction-labs/client-darwin-arm64": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-arm64/-/client-darwin-arm64-0.2.2.tgz",
+      "integrity": "sha512-9Wf9w0sLy3heOF+TsMrrFUWDQSc3rsxCfppb6BqK4OTcN9jf6ngcAQfCM46PwjkqPjIjy/0g4IocmuJDpl781A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@junction-labs/client-darwin-x64": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-x64/-/client-darwin-x64-0.2.2.tgz",
+      "integrity": "sha512-gjjAhELHgIo9nM5Ikrpa+5AVGILC1B9l9yiHG88hzWWaPII9NmGlNrtMc585qqrZhF9VY/8zAIee5b0IWuKjlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@junction-labs/client-linux-arm64-gnu": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-arm64-gnu/-/client-linux-arm64-gnu-0.2.2.tgz",
+      "integrity": "sha512-QYMpPgJu37szcKZC6eVwk+glVSudtb0QZheeAYwS6MZYTMX+NoYu4KYTS5RE/hoX7TZAIl5eoUXNUiK9pPxCZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@junction-labs/client-linux-x64-gnu": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-x64-gnu/-/client-linux-x64-gnu-0.2.2.tgz",
+      "integrity": "sha512-lU4fPQKpKvPuQzz5d4cLu7FjMCBftDUN1Nb3rb2vYP+9WQz2t7uOf4YPSsiGCoWLNcbrJ1FNjRm7FNtadlS+ng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@junction-labs/client-win32-x64-msvc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-win32-x64-msvc/-/client-win32-x64-msvc-0.2.2.tgz",
+      "integrity": "sha512-stbBpxJ9caegReYXBpfK/sZffsogCZkO8LsLQRDI8Ks3ANpI5c7R8reO4p+nGD1sjgJpwQRhb6aD4NRyp9gzYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"

--- a/junction-node/package.json
+++ b/junction-node/package.json
@@ -1,18 +1,20 @@
 {
   "name": "@junction-labs/client",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {
-    "test": "tsc &&cargo test",
-    "prepack": "tsc && neon update",
-    "version": "neon bump --binaries platforms && git add .",
+    "test": "tsc && cargo test",
+    "prepack": "tsc",
     "build": "tsc && cargo build --message-format=json-render-diagnostics > cargo.log",
     "postbuild": "neon dist < cargo.log",
     "build-release": "tsc && cargo build --release --message-format=json-render-diagnostics > cargo.log",
     "postbuild-release": "neon dist < cargo.log",
+    "cross-release": "tsc && cross build --release --message-format=json-render-diagnostics > cargo.log",
+    "postcross-release": "neon dist -m /target < cargo.log",
     "lint": "biome check",
-    "fix": "biome check --write"
+    "fix": "biome check --write",
+    "postinstall": "node scripts/postinstall.js"
   },
   "author": "",
   "license": "Apache-2.0",
@@ -29,7 +31,7 @@
     }
   },
   "types": "./lib/index.d.cts",
-  "files": ["lib/**/*.?({c,m}){t,j}s"],
+  "files": ["scripts/postinstall.js", "lib/**/*.?({c,m}){t,j}s"],
   "neon": {
     "type": "library",
     "org": "@junction-node/",
@@ -49,13 +51,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/junction-labs/junction-client"
+    "url": "https://github.com/junction-labs/junction-client"
   },
   "optionalDependencies": {
-    "@junction-labs/client-darwin-arm64": "0.1.0",
-    "@junction-labs/client-darwin-x64": "0.1.0",
-    "@junction-labs/client-linux-arm64-gnu": "0.1.0",
-    "@junction-labs/client-linux-x64-gnu": "0.1.0",
-    "@junction-labs/client-win32-x64-msvc": "0.1.0"
+    "@junction-labs/client-darwin-arm64": "0.2.2",
+    "@junction-labs/client-darwin-x64": "0.2.2",
+    "@junction-labs/client-linux-arm64-gnu": "0.2.2",
+    "@junction-labs/client-linux-x64-gnu": "0.2.2",
+    "@junction-labs/client-win32-x64-msvc": "0.2.2"
   }
 }

--- a/junction-node/platforms/darwin-arm64/package.json
+++ b/junction-node/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-darwin-arm64",
   "description": "Prebuilt binary package for `@junction-labs/client` on `darwin-arm64`.",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "index.node",
@@ -17,7 +17,7 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "github.com/junction-labs/junction-client"
+    "url": "https://github.com/junction-labs/junction-client"
   },
   "license": "Apache-2.0"
 }

--- a/junction-node/platforms/darwin-x64/package.json
+++ b/junction-node/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-darwin-x64",
   "description": "Prebuilt binary package for `@junction-labs/client` on `darwin-x64`.",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "os": ["darwin"],
   "cpu": ["x64"],
   "main": "index.node",
@@ -17,7 +17,7 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "github.com/junction-labs/junction-client"
+    "url": "https://github.com/junction-labs/junction-client"
   },
   "license": "Apache-2.0"
 }

--- a/junction-node/platforms/linux-arm64-gnu/package.json
+++ b/junction-node/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@junction-labs/client` on `linux-arm64-gnu`.",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "index.node",
@@ -17,7 +17,7 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "github.com/junction-labs/junction-client"
+    "url": "https://github.com/junction-labs/junction-client"
   },
   "license": "Apache-2.0"
 }

--- a/junction-node/platforms/linux-x64-gnu/package.json
+++ b/junction-node/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-linux-x64-gnu",
   "description": "Prebuilt binary package for `@junction-labs/client` on `linux-x64-gnu`.",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "index.node",
@@ -17,7 +17,7 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "github.com/junction-labs/junction-client"
+    "url": "https://github.com/junction-labs/junction-client"
   },
   "license": "Apache-2.0"
 }

--- a/junction-node/platforms/win32-x64-msvc/package.json
+++ b/junction-node/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-win32-x64-msvc",
   "description": "Prebuilt binary package for `@junction-labs/client` on `win32-x64-msvc`.",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "index.node",
@@ -17,7 +17,7 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "github.com/junction-labs/junction-client"
+    "url": "https://github.com/junction-labs/junction-client"
   },
   "license": "Apache-2.0"
 }

--- a/junction-node/scripts/postinstall.js
+++ b/junction-node/scripts/postinstall.js
@@ -1,0 +1,52 @@
+// Run a post-install check to see that a) we actually support the current
+// platform and b) the native lib was installed.  There's nothing fancy about
+// the check - we're just running `require` to make sure the library can be
+// loaded.
+//
+// This script assums its run from an install into `node_modules` where the
+// platform-specific binary has already been installed. In local dev, `npm
+// install` or `npm ci` will try to install the package but the platform
+// specific binaries won't be installed - there's no graceful way to avoid
+// failing this check so if you set JUNCTION_CLIENT_SKIP_POSTINSTALL we'll
+// just not run.
+if (process.env.JUNCTION_CLIENT_SKIP_POSTINSTALL) {
+  process.exit(0);
+}
+
+const { platform, arch } = process;
+
+const PLATFORMS = {
+  darwin: {
+    arm64: "darwin-arm64",
+    x64: "darwin-x64",
+  },
+  linux: {
+    arm64: "linux-arm64-gnu",
+    x64: "linux-x64-gnu",
+  },
+  win32: {
+    x64: "win32-x64-msvc",
+  },
+};
+
+const platformSuffix = PLATFORMS?.[platform]?.[arch];
+
+if (!platform) {
+  console.error(
+    `No native library is available for your platform/cpu (${platform}/${arch}). Junction will not function!`,
+  );
+  process.exit(2);
+}
+
+const libName = `@junction-labs/client-${platformSuffix}/index.node`;
+let path;
+try {
+  path = require.resolve(libName);
+} catch {
+  console.error(
+    "Failed to install native libs for @junction-labs/client. Junction will not function!",
+    "\n",
+    "",
+  );
+  process.exit(3);
+}


### PR DESCRIPTION
Adds an action to deploy to NPM. In debugging, this already successfully released 0.2.2 to npm!

### Native package setup

We're all-in on installing platform native packages as optional dependencies and checking for them in a `postinstall` hook. This is what Neon pushes us towards anyway and what `biome` and other packages in the ecosystem seem to be trending towards. Our post-install hook is heavily inspired by [biome's](https://github.com/biomejs/biome/blob/main/packages/%40biomejs/biome/scripts/postinstall.js).

To get things to compile for linux-arm64 (Neon's defaults) I ended up using `cross`. It gets installed only on that target and appears to be using a container to cross-compile correctly. This seems like it's what `maturin` is doing under the hood for us as well if you inspect the actions output from those builds.

### Secrets setup

Unlike PyPi, NPM doesn't have a trusted publishing flow set up yet. We're using an NPM granular access token stored in repo secrets, only accessible in the `release-node` env to get this done. Only @inowland and I have access to that env for now.

### Oops

In setting this up, I realized we'd been ignoring the sha input to the python release workflow. Fixed that in a commit here.

### xtask

The level of complexity in our workflow commands is getting huge. I'm tempted to sit down and move all of that into xtasks and say we should completely stay away from any toolchain-specific commands. That's a discussion/follow-up PR.