### PR TITLE
docs: add Node direct use, make direct use come last

### DIFF
--- a/docs/source/getting-started/node.md
+++ b/docs/source/getting-started/node.md
@@ -15,22 +15,55 @@ const nextConfig: NextConfig = {
 };
 ```
 
-## Direct use
-
-At this point in time Node.js is not supported for direct use of the client.
-
-However, Junction is generally intended to be used indirectly, though interfaces
-that that match existing HTTP clients. These are covered in the following
-sections.
 
 ## [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
 
-Junction fully replicates the `fetch()` method, with it being mapped as a 
-method on the client object:
+Junction provides a `fetch()` method, that's fully compatible with the Fetch
+standard, that uses Junction under the hood to route requests and handle
+retries.
+
 
 ```typescript
-junctionLibrary = require("@junction-labs/client");
-await junctionLibrary.fetch("http://jct-simple-app.default.svc.cluster.local:8008", { method: "GET" })
+const junction = require("@junction-labs/client");
+
+var response = await junction.fetch("http://httpbin.default.svc.cluster.local:8008/status/418");
+console.log(response.status);
+// 418
+console.log(await response.text());
+//
+//    -=[ teapot ]=-
+//
+//       _...._
+//     .'  _ _ `.
+//    | ."` ^ `". _,
+//    \_;`"---"`|//
+//      |       ;/
+//      \_     _/
+//        `"""`
 ```
+
+## Direct use
+
+To examine and debug configuration, you can instantiate a Junction client and
+use it to directly call `resolveHttp`. 
+
+```typescript
+const junction = require("@junction-labs/client");
+
+const client = await junction.Client.build({
+  adsServer: "grpc://192.168.194.201:8008",
+});
+
+console.log(await client.resolveHttp({"url": "https://httpbin.org"));
+// Endpoint {
+//   scheme: 'https',
+//   sockAddr: { address: '50.19.58.113', port: 443 },
+//   hostname: 'httpbin.org',
+//   retry: undefined,
+//   timeouts: undefined
+// }
+```
+
+APIs for dumping Route and Backend configuration are not yet available.
 
 For more, [see the full API reference](https://docs.junctionlabs.io/api/node/stable/modules/fetch.html).

--- a/docs/source/getting-started/python.md
+++ b/docs/source/getting-started/python.md
@@ -7,22 +7,6 @@ This means all you need to do is:
 pip install junction-python
 ```
 
-## Direct use
-
-To use the junction client for configuring/debugging, you can then invoke it
-via:
-
-```python
-import junction
-junction_client = junction.default_client()
-junction_client.dump_routes()
-```
-
-For more, [see the full API reference](https://docs.junctionlabs.io/api/python/stable/reference/junction.html#junction.Junction).
-
-However, Junction is generally intended to be used indirectly, though interfaces
-that that match existing HTTP clients. These are covered in the following
-sections.
 
 ## [Requests](https://pypi.org/project/requests/)
 
@@ -36,7 +20,8 @@ session = requests.Session()
 session.get("http://jct-simple-app.default.svc.cluster.local:8008")
 ```
 
-We do also monkey patch in a way to get to the client used by a session:
+The Junction client used by a session is also available on that session as a
+field, and can be used to inspect and debug configuration.
 
 ```python
 junction_client = session.junction
@@ -56,7 +41,8 @@ http = PoolManager()
 http.urlopen("GET", "http://jct-simple-app.default.svc.cluster.local:8008")
 ```
 
-We do also monkey patch in a way to get to the client used by a session:
+The Junction client used by each PoolManager is also available as a field
+and can be used to inspect and debug configuration.
 
 ```python
 junction_client = http.junction
@@ -64,3 +50,23 @@ junction_client.dump_routes()
 ```
 
 For more, [see the full API reference](https://docs.junctionlabs.io/api/python/stable/reference/urllib3.html).
+
+## Direct use
+
+Junction is generally intended to be used indirectly, though the interfaces
+that that match your HTTP client. However, using the Junction client directly
+can be useful to inspect and debug your configuration..
+
+The `junction` module makes the default Junction client available for
+introspection, and individual Sessions and PoolManagers make their
+active clients available.
+
+```python
+import junction
+
+client = junction.default_client()
+client.dump_routes()
+```
+
+For more, [see the full API reference](https://docs.junctionlabs.io/api/python/stable/reference/junction.html#junction.Junction).
+


### PR DESCRIPTION
Quick doc updates. Makes the direct use sections come last and adds a Node direct use example.