### PR TITLE
junction-core: don't immediately time out with no deadline

### DIFF
--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -642,8 +642,9 @@ async fn select_endpoint(
 }
 
 async fn sleep_until(deadline: Option<Instant>) {
-    if let Some(d) = deadline {
-        tokio::time::sleep_until(d.into()).await;
+    match deadline {
+        Some(d) => tokio::time::sleep_until(d.into()).await,
+        None => std::future::pending().await,
     }
 }
 


### PR DESCRIPTION
For some reason, I wrote `sleep_until` so that it immediately returns with no deadline. It should wait forever instead. Oops!