### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "junction-api-gen"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "junction-node"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "http 1.2.0",
  "junction-api",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "junction-python"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "http 1.2.0",
  "junction-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 homepage = "https://junctionlabs.io"
 repository = "https://github.com/junction-labs/junction-client"

--- a/junction-node/Cargo.toml
+++ b/junction-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junction-node"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 description = """
 Dynamically configurable HTTP service discovery bindings for NodeJS

--- a/junction-python/Cargo.toml
+++ b/junction-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junction-python"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = """
 Dynamically configurable HTTP service discovery bindings for Python


### PR DESCRIPTION
Bumping a 0.3.0 release 0.3.0 for junction-core, Python, and Node to pick up incremental xDS support and API changes in Python.