### PR TITLE
Fix node deps, bump junction-node to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "junction-node"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http 1.2.0",
  "junction-api",

--- a/junction-node/Cargo.toml
+++ b/junction-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junction-node"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = """
 Dynamically configurable HTTP service discovery bindings for NodeJS

--- a/junction-node/package-lock.json
+++ b/junction-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@junction-labs/client",
-  "version": "0.2.6",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@junction-labs/client",
-      "version": "0.2.6",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -22,11 +22,11 @@
         "typescript": "^5.3.3"
       },
       "optionalDependencies": {
-        "@junction-labs/client-darwin-arm64": "0.2.6",
-        "@junction-labs/client-darwin-x64": "0.2.6",
-        "@junction-labs/client-linux-arm64-gnu": "0.2.6",
-        "@junction-labs/client-linux-x64-gnu": "0.2.6",
-        "@junction-labs/client-win32-x64-msvc": "0.2.6"
+        "@junction-labs/client-darwin-arm64": "0.3.1",
+        "@junction-labs/client-darwin-x64": "0.3.1",
+        "@junction-labs/client-linux-arm64-gnu": "0.3.1",
+        "@junction-labs/client-linux-x64-gnu": "0.3.1",
+        "@junction-labs/client-win32-x64-msvc": "0.3.1"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -344,71 +344,6 @@
         "@shikijs/types": "^1.26.1",
         "@shikijs/vscode-textmate": "^10.0.1"
       }
-    },
-    "node_modules/@junction-labs/client-darwin-arm64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-arm64/-/client-darwin-arm64-0.2.6.tgz",
-      "integrity": "sha512-5NbLl2tgQG4WpcBLZ0dxDTnxNlr5drS4sbVOc5yU4f6z0kknVY5ezYk8h9XUTwvTDw2GZI3ZjoPQByfVuJSCIg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@junction-labs/client-darwin-x64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-x64/-/client-darwin-x64-0.2.6.tgz",
-      "integrity": "sha512-5Pl8Rf6diKAsIFZeWiH3ylXYOmBIhzhdc/sNEzPjtwYhjwfskwuEJrCDo36AsPxFNmF0iE+cP2OfalLYrQwQ/A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@junction-labs/client-linux-arm64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-arm64-gnu/-/client-linux-arm64-gnu-0.2.6.tgz",
-      "integrity": "sha512-rY02U0ZMOSOZ0tGeq9V1RiXOco2Mse5sgOHcx8xq5iVAqA77JeLpUa1Z2UtBJe0g55iiqJktiRwUmfUNqP1E9Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@junction-labs/client-linux-x64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-x64-gnu/-/client-linux-x64-gnu-0.2.6.tgz",
-      "integrity": "sha512-uYxn6S49WVwzoynmxkJqrJ9pqDdUG8OyEtYRFEkcgwtZqL3FcgBZDuBx+gk7+/rRhlepnYf9ToHvB1zmwXkppg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@junction-labs/client-win32-x64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-win32-x64-msvc/-/client-win32-x64-msvc-0.2.6.tgz",
-      "integrity": "sha512-GQK/lCSHDSHb2XSze7SUR3jkGO+XKv2W4bq1cmdG0o+6dBTFOfT13EAlCjkAS/HySOtYkuDS/aIjEQ7ZNrVq+g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@neon-rs/cli": {
       "version": "0.1.82",

--- a/junction-node/package.json
+++ b/junction-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junction-labs/client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {
@@ -56,10 +56,10 @@
     "url": "https://github.com/junction-labs/junction-client"
   },
   "optionalDependencies": {
-    "@junction-labs/client-darwin-arm64": "0.2.6",
-    "@junction-labs/client-darwin-x64": "0.2.6",
-    "@junction-labs/client-linux-arm64-gnu": "0.2.6",
-    "@junction-labs/client-linux-x64-gnu": "0.2.6",
-    "@junction-labs/client-win32-x64-msvc": "0.2.6"
+    "@junction-labs/client-darwin-arm64": "0.3.1",
+    "@junction-labs/client-darwin-x64": "0.3.1",
+    "@junction-labs/client-linux-arm64-gnu": "0.3.1",
+    "@junction-labs/client-linux-x64-gnu": "0.3.1",
+    "@junction-labs/client-win32-x64-msvc": "0.3.1"
   }
 }

--- a/junction-node/platforms/darwin-arm64/package.json
+++ b/junction-node/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-darwin-arm64",
   "description": "Prebuilt binary package for `@junction-labs/client` on `darwin-arm64`.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "index.node",

--- a/junction-node/platforms/darwin-x64/package.json
+++ b/junction-node/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-darwin-x64",
   "description": "Prebuilt binary package for `@junction-labs/client` on `darwin-x64`.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "os": ["darwin"],
   "cpu": ["x64"],
   "main": "index.node",

--- a/junction-node/platforms/linux-arm64-gnu/package.json
+++ b/junction-node/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@junction-labs/client` on `linux-arm64-gnu`.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "index.node",

--- a/junction-node/platforms/linux-x64-gnu/package.json
+++ b/junction-node/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-linux-x64-gnu",
   "description": "Prebuilt binary package for `@junction-labs/client` on `linux-x64-gnu`.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "index.node",

--- a/junction-node/platforms/win32-x64-msvc/package.json
+++ b/junction-node/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@junction-labs/client-win32-x64-msvc",
   "description": "Prebuilt binary package for `@junction-labs/client` on `win32-x64-msvc`.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "index.node",


### PR DESCRIPTION
I forgot to bump optional dependencies when releasing `junction-node` 0.3.1. Bumps them, and modifies the `cargo xtask node version` task so we can't forget again.