### PR TITLE
Tidy up the doc release workflow

### DIFF
--- a/.github/actions/node-reference-docs/action.yaml
+++ b/.github/actions/node-reference-docs/action.yaml
@@ -1,0 +1,62 @@
+name: "Publish Node Reference Docs"
+description: |
+  Publish Node stable and dev reference docs for Node.
+inputs:
+  node-version:
+    description: "The version of node used to build the docs. Passed to actions/setup-node."
+    required: true
+  doc-version:
+    description: |
+      The Junction version that docs are being built at. This may
+      be a a string like dev or a semver version.
+    required: true
+  build-dev:
+    description: "Build dev docs"
+    required: false
+    default: ""
+  build-stable:
+    description: "Build stable docs"
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Build node
+      shell: bash
+      run: cargo xtask node build
+
+    - name: Build node documentation
+      shell: bash
+      run: cargo xtask node docs
+
+    - name: Deploy Node dev docs
+      uses: JamesIves/github-pages-deploy-action@v4
+      if: ${{ inputs.build-dev == 'true' }}
+      with:
+        folder: junction-node/docs
+        target-folder: api/node/dev
+        single-commit: true
+
+    # NOTE: we're deploying a per-version copy of the docs here, but we're not
+    # DOING anything with it. there's no way to switch to them, but they're
+    # there.
+    - name: Deploy versioned docs
+      uses: JamesIves/github-pages-deploy-action@v4
+      if: ${{ inputs.doc-version && inputs.build-stable == 'true' }}
+      with:
+        folder: junction-node/docs
+        target-folder: api/node/${{ inputs.doc-version }}
+        single-commit: true
+
+    - name: Deploy Node stable docs
+      uses: JamesIves/github-pages-deploy-action@v4
+      if: ${{ inputs.build-stable == 'true' }}
+      with:
+        folder: junction-node/docs
+        target-folder: api/node/stable
+        single-commit: true

--- a/.github/actions/python-reference-docs/action.yaml
+++ b/.github/actions/python-reference-docs/action.yaml
@@ -1,0 +1,64 @@
+name: "Publish Python Reference Docs"
+description: |
+  Publish versioned and dev reference docs for Python.
+inputs:
+  doc-version:
+    description: |
+      The Junction version that docs are being built at. This may
+      be a a string like dev or a semver version.
+    required: true
+  python-version:
+    description: "The version of Python to build docs with."
+    required: true
+    default: "3.13"
+  build-dev:
+    description: "Build dev docs"
+    required: false
+    default: ""
+  build-stable:
+    description: "Build stable docs"
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Build python
+      shell: bash
+      run: cargo xtask python build
+
+    - name: Build python documentation
+      shell: bash
+      run: cargo xtask python docs
+      env:
+        JUNCTION_VERSION: ${{ inputs.doc-version }}
+
+    - name: Deploy Python dev docs
+      if: ${{ inputs.build-dev == 'true' }}
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: junction-python/docs/build/html
+        target-folder: api/python/dev
+        single-commit: true
+
+    # NOTE: we're deploying a per-version copy of the docs here, but we're not
+    # DOING anything with it. the sphinx version switcher is still broken.
+    - name: Deploy versioned docs
+      uses: JamesIves/github-pages-deploy-action@v4
+      if: ${{ inputs.doc-version && inputs.build-stable == 'true' }}
+      with:
+        folder: junction-python/docs/build/html
+        target-folder: api/python/${{ inputs.doc-version }}
+        single-commit: true
+
+    - name: Deploy Python stable docs
+      uses: JamesIves/github-pages-deploy-action@v4
+      if: ${{ inputs.build-stable == 'true' }}
+      with:
+        folder: junction-python/docs/build/html
+        target-folder: api/python/stable
+        single-commit: true

--- a/.github/workflows/docs-reference.yml
+++ b/.github/workflows/docs-reference.yml
@@ -26,8 +26,27 @@ permissions:
   contents: write
 
 jobs:
+  what:
+    name: doc vars
+    runs-on: ubuntu-latest
+    outputs:
+      dev: ${{ steps.vars.outputs.dev }}
+      version: ${{ steps.vars.outputs.version }}
+      node: ${{ steps.vars.outputs.node}}
+      python: ${{ steps.vars.outputs.python }}
+    steps:
+      - name: handle inputs
+        id: vars
+        shell: bash
+        run: |
+          echo "dev=${{ github.event_name == 'push' && github.ref_name == 'main' }}" >> $GITHUB_OUTPUT
+          echo "version=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
+          echo "node=${{ github.event_name == 'repository_dispatch' && github.event.action == 'node-release' }}" >> $GITHUB_OUTPUT
+          echo "python=${{ github.event_name == 'repository_dispatch' && github.event.action == 'python-release' }}" >> $GITHUB_OUTPUT
+
   build-docs:
     runs-on: ubuntu-latest
+    needs: [what]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,32 +58,28 @@ jobs:
           toolchain: ${{ env.rust_stable }}
       - uses: Swatinem/rust-cache@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
+      - name: node reference docs
+        uses: ./.github/actions/node-reference-docs
         with:
           node-version: 22
+          doc-version: ${{ needs.what.outputs.version }}
+          build-dev: ${{ needs.what.outputs.dev }}
+          build-stable: ${{ needs.what.outputs.node }}
 
+      - name: Python reference docs
+        uses: ./.github/actions/python-reference-docs
+        with:
+          python-version: 3.12
+          doc-version: ${{ needs.what.outputs.version }}
+          build-dev: ${{ needs.what.outputs.dev }}
+          build-stable: ${{ needs.what.outputs.python }}
+
+      # Rustdoc only deploys to dev, since the stable versions are all hosted on
+      # docs.rs when we release.
+      #
+      # TODO: move this into a composite action?
       - name: Build Rust documentation
         run: cargo xtask core doc
-
-      - name: Build python
-        run: cargo xtask python build
-
-      - name: Build python documentation
-        env:
-          JUNCTION_VERSION: ${{ github.event.client_payload.version || 'main' }}
-        run: cargo xtask python docs
-
-      - name: Build node
-        run: cargo xtask node build
-
-      - name: Build node documentation
-        run: cargo xtask node docs
 
       - name: Deploy Rust dev docs
         if: github.event_name == 'push' && github.ref_name == 'main'
@@ -76,43 +91,3 @@ jobs:
 
       - name: Clean up rust dev docs artifacts
         run: rm -rf target/doc
-
-      - name: Deploy Python dev docs
-        if: github.event_name == 'push' && github.ref_name == 'main'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: junction-python/docs/build/html
-          target-folder: api/python/dev
-          single-commit: true
-
-      - name: Deploy Node dev docs
-        if: github.event_name == 'push' && github.ref_name == 'main'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: junction-node/docs
-          target-folder: api/node/dev
-          single-commit: true
-
-      - name: Deploy Python versioned docs
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'python-release'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: junction-python/docs/build/html
-          target-folder: api/python/version/${{ github.event.client_payload.maj_min_version }}
-          single-commit: true
-
-      - name: Deploy Python stable docs
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'python-release'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: junction-python/docs/build/html
-          target-folder: api/python/stable
-          single-commit: true
-
-      - name: Deploy Node stable docs
-        if: github.event_name == 'repository_dispatch' && github.event.action == 'node-release'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: junction-node/docs
-          target-folder: api/node/stable
-          single-commit: true

--- a/junction-node/package-lock.json
+++ b/junction-node/package-lock.json
@@ -345,6 +345,71 @@
         "@shikijs/vscode-textmate": "^10.0.1"
       }
     },
+    "node_modules/@junction-labs/client-darwin-arm64": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-arm64/-/client-darwin-arm64-0.3.1.tgz",
+      "integrity": "sha512-2Ae2cuomWdMSm/Sw6lKbp3EFqGrsg6wS4KEVJKWk5QcfF336lUM2onOAnX1z8WndXMUZYcMiZmYIeHQ2UlS8Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@junction-labs/client-darwin-x64": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-x64/-/client-darwin-x64-0.3.1.tgz",
+      "integrity": "sha512-0iF8Qw6wdEQR7Z9+eJ+gvKTDdzLLomQZsuLe/trqfCNju47P1NrLZ0lP3xMqCRI7cp3sqkSRZV/cWpC0ieyuKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@junction-labs/client-linux-arm64-gnu": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-arm64-gnu/-/client-linux-arm64-gnu-0.3.1.tgz",
+      "integrity": "sha512-yxaCMPPUIJYLtJYqerm/wrHUE6P0hVJkRWsZXeWKRUT4HiDuvvv7468h8+7+w7QwkD9CRfBWKn8S4KAr0U8hJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@junction-labs/client-linux-x64-gnu": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-x64-gnu/-/client-linux-x64-gnu-0.3.1.tgz",
+      "integrity": "sha512-pTVrIhUh0Aa9ZeuPN4dJ6h/ZEK+oShoCuvr/eRUMLxgtRMicqyTY2YZfeUbuVGsSY/5bI8hRwoNJ+CYDqmB3kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@junction-labs/client-win32-x64-msvc": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-win32-x64-msvc/-/client-win32-x64-msvc-0.3.1.tgz",
+      "integrity": "sha512-KHi6S7BPncAnAeuAMbA/u6rgy+hqn0cXpqVxMdsInrAy3WpMPi1gGkywiJgISiLKdJ5KDNcB8pVWZsZUBrY2dQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@neon-rs/cli": {
       "version": "0.1.82",
       "resolved": "https://registry.npmjs.org/@neon-rs/cli/-/cli-0.1.82.tgz",

--- a/junction-python/docs/source/_static/version_switcher.json
+++ b/junction-python/docs/source/_static/version_switcher.json
@@ -2,6 +2,6 @@
     {
         "name": "dev",
         "version": "dev",
-        "url": "https://docs.junction-labs.io/api/python/dev/"
+        "url": "https://docs.junctionlabs.io/api/python/dev/"
     }
 ]

--- a/junction-python/docs/source/conf.py
+++ b/junction-python/docs/source/conf.py
@@ -106,14 +106,14 @@ github_root = "https://github.com/junction-labs/junction-client"
 web_root = "https://docs.junctionlabs.io"
 
 # Specify version for version switcher dropdown menu
-git_ref = os.environ.get("JUNCTION_VERSION", "main")
-version_match = re.fullmatch(r"py-(\d+)\.\d+\.\d+.*", git_ref)
-switcher_version = version_match.group(1) if version_match is not None else "dev"
+junction_version = os.environ.get("JUNCTION_VERSION", "main")
+version_match = re.fullmatch(r"\d+\.\d+\.\d+.*", junction_version)
+switcher_version = junction_version if version_match is not None else "dev"
 
 html_js_files = [
     (
         "https://plausible.io/js/script.js",
-        {"data-domain": "docs.junction-labs,combined.junction-labs", "defer": "defer"},
+        {"data-domain": "docs.junctionlabs", "defer": "defer"},
     ),
 ]
 
@@ -135,11 +135,6 @@ html_theme_options = {
             "url": "https://discord.gg/9Uq9FwnW3y",
             "icon": "fa-brands fa-discord",
         },
-        # {
-        #     "name": "Twitter",
-        #     "url": "https://twitter.com/DataPolars",
-        #     "icon": "fa-brands fa-twitter",
-        # },
     ],
     "logo": {
         "image_light": f"{static_assets_root}/67099720085278dbb34eccb2_logo-closed-orange-grey.svg",
@@ -225,7 +220,9 @@ def linkcode_resolve(domain: str, info: dict[str, Any]) -> str | None:
     junction_client_root = (conf_dir_path.parent.parent / "junction").absolute()
 
     fn = os.path.relpath(fn, start=junction_client_root)
-    return f"{github_root}/blob/{git_ref}/junction-python/junction/{fn}{linespec}"
+    return (
+        f"{github_root}/blob/{junction_version}/junction-python/junction/{fn}{linespec}"
+    )
 
 
 def process_signature(  # noqa: D103

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,7 +41,6 @@ struct CrateInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     version: semver::Version,
-    maj_min_version: String,
     sha: String,
 }
 
@@ -99,19 +98,13 @@ fn crate_info<P: AsRef<Path>>(sh: &Shell, path: P) -> anyhow::Result<CrateInfo> 
 
     let name = crate_name(&manifest)?;
     let version = package_version(&manifest).or_else(|_| workspace_version(&manifest))?;
-    let maj_min_version = format!("{}.{}", version.major, version.minor);
 
     let mut sha = cmd!(sh, "git rev-parse HEAD").read()?.trim().to_string();
     if check_diffs(sh).is_err() {
         sha.push_str(" (dirty)");
     }
 
-    Ok(CrateInfo {
-        name,
-        version,
-        maj_min_version,
-        sha,
-    })
+    Ok(CrateInfo { name, version, sha })
 }
 
 /// Cargo xtasks for development.


### PR DESCRIPTION
Makes the doc release workflow a little easier to reason about by putting Node and Python docs in their own composite actions. This means we can do all the actions if/else in YAML once and then let those actions be much simpler.

Changes the Python doc release action to save docs for every patch version, instead of overwriting on X.Y releases. We realized that the Sphinx version switcher is manually populated, and are just going to save docs for every release until we have a reason not to.

Similarly, we're now versioning our Node typedoc output.