### PR TITLE
junction-python: omit xds tombstones in dump_xds

### DIFF
--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -510,9 +510,15 @@ impl Client {
     ///
     /// This is a programmatic view of the same data that you can fetch over
     /// gRPC by starting a [Client::csds_server].
-    pub fn dump_xds(&self) -> Vec<crate::XdsConfig> {
+    pub fn dump_xds(&self, not_found: bool) -> Vec<crate::XdsConfig> {
         match self.config.ads() {
-            Some(ads) => ads.iter_xds().collect(),
+            Some(ads) => {
+                if not_found {
+                    ads.iter_xds().collect()
+                } else {
+                    ads.iter_xds().filter(|c| c.xds.is_some()).collect()
+                }
+            }
             None => Vec::new(),
         }
     }

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -517,10 +517,11 @@ impl Junction {
     ///
     /// The xDS config will contain the latest values for all resources and any
     /// errors encountered while trying to fetch updated versions.
-    fn dump_xds(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+    #[pyo3(signature = (not_found=false))]
+    fn dump_xds(&self, py: Python<'_>, not_found: bool) -> PyResult<Vec<Py<PyAny>>> {
         let mut values = vec![];
 
-        for config in self.core.dump_xds() {
+        for config in self.core.dump_xds(not_found) {
             let config: XdsConfig = config.into();
             let as_py = pythonize::pythonize(py, &config)?;
             values.push(as_py);
@@ -550,6 +551,8 @@ impl Junction {
 struct XdsConfig {
     name: String,
 
+    type_url: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<ResourceVersion>,
 
@@ -575,6 +578,7 @@ impl From<junction_core::XdsConfig> for XdsConfig {
 
         Self {
             name: value.name,
+            type_url: value.type_url,
             version: value.version,
             xds: value.xds,
             error_info,


### PR DESCRIPTION
With ndots, xDS dumps were getting quite noisy - tombstones are clogging up our results. Since we're not expiring them or putting TTLs or timestamps on client-side caches yet, there's only value here if you want to see not-found resources. Hide them behind a boolean flag.

```
>>> pprint([{k: x.get(k) for k in ['name', 'version']} for x in j.dump_xds(not_found=True) if 'Listener' in x['type_url']])
[
│   {'name': 'nginx-staging.default.svc.cluster.local.lb.jct:80', 'version': '2s576DjfTR7sSEDEpPEaALZYuGn'},
│   {'name': 'nginx.bopp-vector.ts.net:80', 'version': None},
│   {'name': 'nginx.default.svc.cluster.local.lb.jct:80', 'version': '2s576DjfTR7sSEDEpPEaALZYuGn'},
│   {'name': 'nginx.default.svc.cluster.local:80', 'version': '2s58H93ELhaUQbN01cS3tUQztVj'},
│   {'name': 'nginx:80', 'version': None}
]
>>> pprint([{k: x.get(k) for k in ['name', 'version']} for x in j.dump_xds() if 'Listener' in x['type_url']])
[
│   {'name': 'nginx-staging.default.svc.cluster.local.lb.jct:80', 'version': '2s576DjfTR7sSEDEpPEaALZYuGn'},
│   {'name': 'nginx.default.svc.cluster.local.lb.jct:80', 'version': '2s576DjfTR7sSEDEpPEaALZYuGn'},
│   {'name': 'nginx.default.svc.cluster.local:80', 'version': '2s58H93ELhaUQbN01cS3tUQztVj'}
]
```