### PR TITLE
[docs]: fix up broken link to the "getting started" page in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ the xds configuration to drive the Junction Client.
 
 ## Getting started
 
-[See here](https://docs.junctionlabs.io/getting-started/index.md)
+[See here](https://docs.junctionlabs.io/getting-started/)
 
 ## Project status
 


### PR DESCRIPTION
Hi all,

Just a trivial change here: the README has a slightly broken link:

```
$ curl -so /dev/null -w "%{http_code}\n" https://docs.junctionlabs.io/getting-started/index.md
404
$ curl -so /dev/null -w "%{http_code}\n" https://docs.junctionlabs.io/getting-started/
200
$
```

Cheers!
Nathan