### PR TITLE
junction-python: support for Python 3.9

### DIFF
--- a/.github/workflows/junction-python-ci.yml
+++ b/.github/workflows/junction-python-ci.yml
@@ -17,42 +17,39 @@ env:
   CARGO_TERM_COLOR: always
   rust_stable: stable
   rust_min: 1.81
+  python_stable: 3.12
+  python_min: 3.9
 
 jobs:
-  # Rust CI steps
-  #
-  # These should be largely the same as the steps in junction-core-ci.yml but
-  # testing a different package.
-  msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: "Install Rust @${{ env.rust_min }}"
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.rust_min }}
-      - uses: Swatinem/rust-cache@v2
-      - name: check
-        run: cargo xtask python build
-
   # Python CI steps
   #
   # these lean on xtask tasks so they're similar to what you'd run locally
   test-python:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - python: 3.12
+            rust: stable
+          - python: 3.12
+            rust: 1.81
+          - python: 3.9
+            rust: stable
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install Rust @ ${{ env.rust_stable }}"
+      - name: "Install Rust @ ${{ matrix.version.rust }}"
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ matrix.version.rust }}
+          components: clippy, rustfmt
+
       - uses: Swatinem/rust-cache@v2
 
-      - name: Set up Python
+      - name: "Set up Python @ ${{ matrix.version.python }}"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.version.python }}
 
       - name: build python
         run: cargo xtask python build

--- a/crates/junction-api-gen/src/python.rs
+++ b/crates/junction-api-gen/src/python.rs
@@ -112,10 +112,11 @@ struct PyTypedDict {
 #[derive(Debug, Template)]
 #[template(
     source = r#"
-{{name}} =
-{%- for type in types -%}
-    {{ type }} {% if !loop.last -%}|{%- endif %}
-{%- endfor -%}
+{{name}} = typing.Union[
+    {%- for type in types -%}
+        {{ type }} {% if !loop.last -%},{%- endif %}
+    {%- endfor -%}
+]
 {%- match doc -%}
 {%- when Some with (doc) %}
 """{{ doc|doc_pad(4) }}"""
@@ -283,7 +284,10 @@ impl std::fmt::Display for PyType {
                         .map(|t| format!("typing.Literal[\"{}\"]", t.as_literal_str().unwrap()))
                         .collect();
 
-                    write!(f, "{}", lit_types.join(" | "))
+                    match lit_types.as_slice() {
+                        [t] => write!(f, "{t}"),
+                        _ => write!(f, "typing.Union[{}]", lit_types.join(", ")),
+                    }
                 } else {
                     write!(f, "{name}")
                 }

--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -14,8 +14,8 @@ from . import config, requests, urllib3
 
 
 def _default_client(
-    static_routes: typing.List[config.Route] | None,
-    static_backends: typing.List[config.Backend] | None,
+    static_routes: typing.Optional[typing.List[config.Route]],
+    static_backends: typing.Optional[typing.List[config.Backend]],
 ) -> Junction:
     """
     Return a Junction client with default Routes and Backends.

--- a/junction-python/junction/config.py
+++ b/junction-python/junction/config.py
@@ -4,7 +4,7 @@
 import typing
 
 
-Duration = str | int | float
+Duration = typing.Union[str, int, float]
 """A duration expressed as a total number of seconds. Durations should never be negative."""
 
 
@@ -24,7 +24,7 @@ class ServiceKube(typing.TypedDict):
     specified, and won't be inferred from context."""
 
 
-Service = ServiceDns | ServiceKube
+Service = typing.Union[ServiceDns, ServiceKube]
 
 
 class Fraction(typing.TypedDict):
@@ -45,7 +45,7 @@ class BackendRef(typing.TypedDict):
     """The namespace of the Kubernetes service to target. This must be explicitly
     specified, and won't be inferred from context."""
 
-    type: typing.Literal["Dns"] | typing.Literal["Kube"]
+    type: typing.Union[typing.Literal["Dns"], typing.Literal["Kube"]]
     port: int
     """The port to route traffic to, used in combination with
     [service][Self::service] to identify the
@@ -119,7 +119,7 @@ class HeaderMatchExact(typing.TypedDict):
     value: str
 
 
-HeaderMatch = HeaderMatchRegularExpression | HeaderMatchExact
+HeaderMatch = typing.Union[HeaderMatchRegularExpression, HeaderMatchExact]
 
 
 class QueryParamMatchRegularExpression(typing.TypedDict):
@@ -134,7 +134,7 @@ class QueryParamMatchExact(typing.TypedDict):
     value: str
 
 
-QueryParamMatch = QueryParamMatchRegularExpression | QueryParamMatchExact
+QueryParamMatch = typing.Union[QueryParamMatchRegularExpression, QueryParamMatchExact]
 
 
 class PathMatchPrefix(typing.TypedDict):
@@ -152,7 +152,7 @@ class PathMatchExact(typing.TypedDict):
     value: str
 
 
-PathMatch = PathMatchPrefix | PathMatchRegularExpression | PathMatchExact
+PathMatch = typing.Union[PathMatchPrefix, PathMatchRegularExpression, PathMatchExact]
 
 
 class RouteMatch(typing.TypedDict):
@@ -283,7 +283,7 @@ class BackendId(typing.TypedDict):
     """The namespace of the Kubernetes service to target. This must be explicitly
     specified, and won't be inferred from context."""
 
-    type: typing.Literal["Dns"] | typing.Literal["Kube"]
+    type: typing.Union[typing.Literal["Dns"], typing.Literal["Kube"]]
     port: int
     """The port backend traffic is sent on."""
 
@@ -298,7 +298,7 @@ class RequestHashPolicy(typing.TypedDict):
     name: str
     """The name of the header to use as hash input."""
 
-    type: typing.Literal["Header"] | typing.Literal["QueryParam"]
+    type: typing.Union[typing.Literal["Header"], typing.Literal["QueryParam"]]
 
 
 class LbPolicyRoundRobin(typing.TypedDict):
@@ -327,7 +327,7 @@ class LbPolicyUnspecified(typing.TypedDict):
     type: typing.Literal["Unspecified"]
 
 
-LbPolicy = LbPolicyRoundRobin | LbPolicyRingHash | LbPolicyUnspecified
+LbPolicy = typing.Union[LbPolicyRoundRobin, LbPolicyRingHash, LbPolicyUnspecified]
 
 
 class Backend(typing.TypedDict):

--- a/junction-python/junction/requests.py
+++ b/junction-python/junction/requests.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Mapping
+from typing import List, Mapping, Union, Optional
 
 import requests
 
@@ -58,10 +58,10 @@ class HTTPAdapter(requests.adapters.HTTPAdapter):
         self,
         request: requests.PreparedRequest,
         stream: bool = False,
-        timeout: None | float | tuple[float, float] | tuple[float, None] = None,
-        verify: bool | str = True,
-        cert: None | bytes | str | tuple[bytes | str, bytes | str] = None,
-        proxies: Mapping[str, str] | None = None,
+        timeout: Union[None, float, tuple[float, float], tuple[float, None]] = None,
+        verify: Union[bool, str] = True,
+        cert: Union[None, bytes, str, tuple[bytes, str, Union[bytes, str]]] = None,
+        proxies: Optional[Mapping[str, str]] = None,
     ) -> requests.Response:
         """Sends PreparedRequest object. Returns Response object.
 
@@ -205,9 +205,9 @@ class Session(requests.Session):
 
     def __init__(
         self,
-        static_routes: List[junction.config.Route] | None = None,
-        static_backends: List[junction.config.Backend] | None = None,
-        junction_client: junction.Junction | None = None,
+        static_routes: Optional[List["junction.config.Route"]] = None,
+        static_backends: Optional[List["junction.config.Backend"]] = None,
+        junction_client: Optional[junction.Junction] = None,
     ) -> None:
         super().__init__()
 

--- a/junction-python/junction/urllib3.py
+++ b/junction-python/junction/urllib3.py
@@ -43,8 +43,8 @@ def _is_redirect_err(e: MaxRetryError) -> bool:
 
 
 def _configure_retries(
-    retries: urllib3.Retry | None, policy: RetryPolicy
-) -> typing.Tuple[urllib3.Retry, int | bool]:
+    retries: typing.Optional[urllib3.Retry], policy: RetryPolicy
+) -> typing.Tuple[urllib3.Retry, typing.Union[int, bool]]:
     """
     Merge Junction retries with callsite specific urilib3.Retry objects.
 
@@ -89,11 +89,11 @@ class PoolManager(urllib3.PoolManager):
         # urrlib3
         self,
         num_pools: int = 10,
-        headers: typing.Mapping[str, str] | None = None,
+        headers: typing.Optional[typing.Mapping[str, str]] = None,
         # junction
-        static_routes: typing.List[junction.config.Route] | None = None,
-        static_backends: typing.List[junction.config.Backend] | None = None,
-        junction_client: junction.Junction | None = None,
+        static_routes: typing.Optional[typing.List["junction.config.Route"]] = None,
+        static_backends: typing.Optional[typing.List["junction.config.Backend"]] = None,
+        junction_client: typing.Optional[junction.Junction] = None,
         # kwargs
         **kwargs: typing.Any,
     ) -> None:

--- a/junction-python/samples/smoke-test/Dockerfile
+++ b/junction-python/samples/smoke-test/Dockerfile
@@ -17,7 +17,7 @@ RUN uv pip install --system -r requirements-dev.txt
 ADD junction-python/samples/smoke-test/server.py .
 
 # extra stuff just for the client as having it in the same docker image is convenient
-RUN if [[ "$junction_wheel" = "default[x]" ]] ; then uv pip install --system junction-python ; else uv pip install --system *.whl ; fi
+RUN if [ "$junction_wheel" = "default[x]" ] ; then uv pip install --system junction-python ; else uv pip install --system *.whl ; fi
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl

--- a/junction-python/samples/smoke-test/client.py
+++ b/junction-python/samples/smoke-test/client.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from time import sleep
-from typing import List
+from typing import List, Optional
 import subprocess
 import tempfile
 import argparse
@@ -34,8 +34,8 @@ class SessionFactory:
     def __init__(
         self,
         args,
-        routes: List[junction.config.Route] | None = None,
-        backends: List[junction.config.Backend] | None = None,
+        routes: Optional[List[junction.config.Route]] = None,
+        backends: Optional[List[junction.config.Backend]] = None,
     ):
         self.args = args
         self.delete_resources = []

--- a/junction-python/tests/test_routes.py
+++ b/junction-python/tests/test_routes.py
@@ -18,7 +18,7 @@ def test_check_basic_route_url_port(nginx):
     route: config.Route = {
         "id": "test-route",
         "hostnames": [
-            f"{nginx["name"]}.{nginx["namespace"]}.svc.cluster.local",
+            f"{nginx['name']}.{nginx['namespace']}.svc.cluster.local",
         ],
         "rules": [{"backends": [nginx]}],
     }
@@ -35,7 +35,7 @@ def test_check_basic_route_backend_port(nginx):
     route: config.Route = {
         "id": "test-route",
         "hostnames": [
-            f"{nginx["name"]}.{nginx["namespace"]}.svc.cluster.local",
+            f"{nginx['name']}.{nginx['namespace']}.svc.cluster.local",
         ],
         "rules": [{"backends": [{**nginx, "port": 8888}]}],
     }
@@ -70,7 +70,7 @@ def test_check_basic_route_ports_match(nginx):
     route: config.Route = {
         "id": "test-route",
         "hostnames": [
-            f"{nginx["name"]}.{nginx["namespace"]}.svc.cluster.local",
+            f"{nginx['name']}.{nginx['namespace']}.svc.cluster.local",
         ],
         "ports": [1234],
         "rules": [{"backends": [{**nginx, "port": 1234}]}],
@@ -112,7 +112,7 @@ def test_check_empty_rules(nginx, nginx_staging):
     route: config.Route = {
         "id": "test-route",
         "hostnames": [
-            f"{nginx["name"]}.{nginx["namespace"]}.svc.cluster.local",
+            f"{nginx['name']}.{nginx['namespace']}.svc.cluster.local",
         ],
         "rules": [
             # /users hits staging


### PR DESCRIPTION
Adjusts our type-hints to be compatible with Python 3.9. This mostly means switching to `typing.Union` everywhere we can instead of `|`, with some extra `typing.Optional` thrown in, but we had to drop some double-quotes from f-strings in tests.

Also updates CI so that we run Python CI on our minimum supported version of Python as well as our minimum supported Rust.