### PR TITLE
junction-core: Stop using &mut receivers in junction-client

### DIFF
--- a/crates/junction-core/examples/dns-backend.rs
+++ b/crates/junction-core/examples/dns-backend.rs
@@ -38,7 +38,7 @@ async fn main() {
         },
     ];
 
-    let mut client = client.with_static_config(vec![], backends);
+    let client = client.with_static_config(vec![], backends);
 
     eprintln!("{:?}", client.dump_routes());
 

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -73,7 +73,7 @@ async fn main() {
             lb: LbPolicy::Unspecified,
         },
     ];
-    let mut client = client.with_static_config(routes, backends);
+    let client = client.with_static_config(routes, backends);
 
     let url: junction_core::Url = "https://nginx.default.svc.cluster.local".parse().unwrap();
     let prod_headers = http::HeaderMap::new();

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -346,7 +346,7 @@ impl Client {
     /// full URL and hostname, the complete set of headers, and retry and timeout
     /// policy the client should use to make a request.
     pub async fn resolve_http(
-        &mut self,
+        &self,
         method: &http::Method,
         url: &crate::Url,
         headers: &http::HeaderMap,
@@ -424,7 +424,7 @@ impl Client {
     /// history information, but request details will remain the same. Clients
     /// may use that value for status or error reporting.
     pub async fn report_status(
-        &mut self,
+        &self,
         endpoint: Endpoint,
         response: HttpResult,
     ) -> crate::Result<Endpoint> {

--- a/junction-node/src/lib.rs
+++ b/junction-node/src/lib.rs
@@ -110,7 +110,7 @@ fn resolve_http(mut cx: FunctionContext) -> JsResult<JsPromise> {
     // have to wrap the client.resolve_http call in an async move block so it
     // takes ownership of the client. otherwise it would be nice to make the
     // whole thing just a call to client.resolve_http
-    let mut client = client.cloned();
+    let client = client.cloned();
     let resolve_http = async move { client.resolve_http(&method, &url, &headers).await };
 
     Ok(
@@ -146,7 +146,7 @@ fn report_status(mut cx: FunctionContext) -> JsResult<JsPromise> {
     // make an async block here so that it captures client, endpoint, and
     // http_result. it'd be nice to just pass `client.report_status(e, r)` but
     // that doesn't move anything into the capture, it just takes references.
-    let mut client = client.cloned();
+    let client = client.cloned();
     let endpoint = endpoint.cloned();
     let report_status = async move { client.report_status(endpoint, http_result).await };
 

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -385,7 +385,7 @@ impl Junction {
     /// fetching any new routing data over the network.
     #[pyo3(signature = (url, *, method=None, headers=None, timeout=None))]
     fn resolve_route(
-        &mut self,
+        &self,
         py: Python<'_>,
         url: &str,
         method: Option<&str>,
@@ -430,7 +430,7 @@ impl Junction {
     /// combine multiple responses.
     #[pyo3(signature = (url, *, method=None, headers=None))]
     fn resolve_http(
-        &mut self,
+        &self,
         url: &str,
         method: Option<&str>,
         headers: Option<&Bound<PyMapping>>,
@@ -448,7 +448,7 @@ impl Junction {
 
     #[pyo3(signature = (*, endpoint, status_code=None, error=None))]
     fn report_status(
-        &mut self,
+        &self,
         endpoint: Endpoint,
         status_code: Option<u16>,
         error: Option<Bound<PyAny>>,


### PR DESCRIPTION
We've started seeing Already Borrowed exceptions from Pyo3 when using the client with an ASGI web server in the demo. @ptravers pointed out that `junction-core` doesn't actually require mutable access to the client, so there's no cost to removing the &mut access here.