### PR TITLE
clippy: add rust-version to all crates

### DIFF
--- a/crates/junction-api-gen/Cargo.toml
+++ b/crates/junction-api-gen/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
+rust-version.workspace = true
 description = """
 cross-language API generation for Junction
 """

--- a/crates/junction-api/Cargo.toml
+++ b/crates/junction-api/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 categories = ["api-bindings", "network-programming"]
+rust-version.workspace = true
 
 [dependencies]
 http = { workspace = true }

--- a/crates/junction-core/Cargo.toml
+++ b/crates/junction-core/Cargo.toml
@@ -14,6 +14,8 @@ categories = [
     "web-programming::http-client",
 ]
 
+rust-version.workspace = true
+
 [dependencies]
 arc-swap = { workspace = true }
 bytes = { workspace = true }

--- a/crates/junction-typeinfo-derive/Cargo.toml
+++ b/crates/junction-typeinfo-derive/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
+rust-version.workspace = true
 description = """
 TypeInfo derive macro
 """

--- a/crates/junction-typeinfo/Cargo.toml
+++ b/crates/junction-typeinfo/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
+rust-version.workspace = true
 description = """
 reflection for junction API generation
 """

--- a/junction-node/Cargo.toml
+++ b/junction-node/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 categories = ["api-bindings", "network-programming"]
+rust-version.workspace = true
 
 exclude = ["index.node"]
 

--- a/junction-python/Cargo.toml
+++ b/junction-python/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 categories = ["api-bindings", "network-programming"]
+rust-version.workspace = true
 
 [lib]
 name = "junction"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 edition = "2021"
 version = "0.1.0"
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
I didn't realize that Cargo `workspace.package` metadata isn't auto-inherited so all of our sub-crates aren't picking up the workspace `rust-version`.

Updates every crate to use the workspace's `rust-version` so we stop getting clippy lints that conflict with our MSRV.