### PR TITLE
Expose build versions at runtime in Python and Node

### DIFF
--- a/junction-node/build.rs
+++ b/junction-node/build.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+fn main() {
+    // set BUILD_SHA as an env var
+    let short_sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .expect("failed to get build version");
+    let short_sha = std::str::from_utf8(short_sha.stdout.trim_ascii()).unwrap();
+
+    let status = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .expect("failed to get git status");
+    let dirty = if status.stdout.trim_ascii().is_empty() {
+        ""
+    } else {
+        "-dirty"
+    };
+    println!("cargo::rustc-env=BUILD_SHA={short_sha}{dirty}")
+}

--- a/junction-node/src/lib.rs
+++ b/junction-node/src/lib.rs
@@ -19,8 +19,17 @@ use neon::{
 // neon-serde is effectively abandoned or that would be an easy start. it
 // depends on neon 0.4.0 https://github.com/GabrielCastro/neon-serde
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const BUILD: &str = env!("BUILD_SHA");
+
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
+    let version = cx.string(VERSION);
+    cx.export_value("version", version)?;
+
+    let build_version = cx.string(BUILD);
+    cx.export_value("build", build_version)?;
+
     cx.export_function("newRuntime", new_runtime)?;
     cx.export_function("newClient", new_client)?;
     cx.export_function("resolveHttp", resolve_http)?;

--- a/junction-node/ts/core.cts
+++ b/junction-node/ts/core.cts
@@ -16,6 +16,9 @@ declare module "./load.cjs" {
 
   type Headers = Array<[string, string]>;
 
+  const version: string;
+  const build: string;
+
   function newRuntime(): Runtime;
 
   function newClient(
@@ -43,6 +46,9 @@ declare module "./load.cjs" {
 }
 
 const defaultRuntime: ffi.Runtime = ffi.newRuntime();
+
+export const _VERSION = ffi.version;
+export const _BUILD = ffi.build;
 
 /**
  * An error in the Junction client.

--- a/junction-node/ts/index.cts
+++ b/junction-node/ts/index.cts
@@ -1,2 +1,2 @@
-export { Client, type ClientOpts } from "./core.cjs";
+export { _BUILD, _VERSION, Client, type ClientOpts } from "./core.cjs";
 export { fetch, setDefaultClient as setGlobalClient } from "./fetch.cjs";

--- a/junction-python/build.rs
+++ b/junction-python/build.rs
@@ -1,7 +1,27 @@
+use std::process::Command;
+
 fn main() {
     // pyo3 requires special linker args on macos. instead of setting .cargo/config.toml
     // we can do that here instead:
     //
     // https://pyo3.rs/v0.22.2/building-and-distribution#macos
     pyo3_build_config::add_extension_module_link_args();
+
+    // set BUILD_SHA as an env var
+    let short_sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .expect("failed to get build version");
+    let short_sha = std::str::from_utf8(short_sha.stdout.trim_ascii()).unwrap();
+
+    let status = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .expect("failed to get git status");
+    let dirty = if status.stdout.trim_ascii().is_empty() {
+        ""
+    } else {
+        "-dirty"
+    };
+    println!("cargo::rustc-env=BUILD_SHA={short_sha}{dirty}")
 }

--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -1,6 +1,8 @@
 import typing
 
 from junction.junction import (
+    _version,
+    _build,
     Junction,
     Endpoint,
     RetryPolicy,
@@ -11,6 +13,9 @@ from junction.junction import (
 )
 
 from . import config, requests, urllib3
+
+__version__ = _version
+__build__ = _build
 
 
 def _default_client(

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -22,8 +22,13 @@ use xds_api::pb::google::protobuf;
 
 mod runtime;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const BUILD: &str = env!("BUILD_SHA");
+
 #[pymodule]
 fn junction(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("_version", VERSION)?;
+    m.add("_build", BUILD)?;
     m.add_class::<Junction>()?;
     m.add_class::<Endpoint>()?;
     m.add_class::<RetryPolicy>()?;


### PR DESCRIPTION
While debugging #164 we had a hard time figuring out what version of `junction` we were actually importing. It would have been really useful to have a runtime build version to look at, so we exposed one.

Like with the rest of the versioning here, we're using the version in `Cargo.toml` as the canonical library version. In both Python and Node we're just exposing [CARGO_PKG_VERSION](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates) at runtime.