### PR TITLE
junction-core: Fix an add-remove-add caching bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "tokio",
+ "tracing-subscriber",
  "xds-api",
 ]
 

--- a/junction-python/Cargo.toml
+++ b/junction-python/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing-subscriber = { workspace = true }
 xds-api = { workspace = true, features = ["pbjson"] }
 pyo3 = { version = "0.21", features = [
     "extension-module",

--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -10,6 +10,7 @@ from junction.junction import (
     check_route,
     dump_kube_backend,
     dump_kube_route,
+    enable_tracing,
 )
 
 from . import config, requests, urllib3
@@ -55,4 +56,5 @@ __all__ = (
     default_client,
     dump_kube_backend,
     dump_kube_route,
+    enable_tracing,
 )

--- a/junction-python/samples/smoke-test/client.py
+++ b/junction-python/samples/smoke-test/client.py
@@ -148,7 +148,7 @@ def retry_test(args):
     }
     routes: List[junction.config.Route] = [
         {
-            "id": "retry-sample",
+            "id": "smoke-test-retry-test",
             "hostnames": ["jct-simple-app.default.svc.cluster.local"],
             "rules": [
                 {
@@ -207,7 +207,7 @@ def path_match_test(args):
     }
     routes: List[junction.config.Route] = [
         {
-            "id": "retry-sample",
+            "id": "smoke-test-path-match",
             "hostnames": ["jct-simple-app.default.svc.cluster.local"],
             "rules": [
                 {
@@ -317,7 +317,7 @@ def timeouts_test(args):
         }
         routes: List[junction.config.Route] = [
             {
-                "id": "timeouts-sample",
+                "id": "smoke-test-timeouts-test",
                 "hostnames": ["jct-simple-app.default.svc.cluster.local"],
                 "rules": [
                     {
@@ -362,7 +362,7 @@ def urllib3_test(args):
     }
     default_routes: List[junction.config.Route] = [
         {
-            "id": "urllib3-sample",
+            "id": "smoke-test-urllib3",
             "hostnames": ["jct-simple-app.default.svc.cluster.local"],
             "rules": [
                 {


### PR DESCRIPTION
We managed to turn up an add-remove-add bug where the client cache was marking an xDS Cluster as not-found when removing it instead of just removing it from the cache. This was, unfortunately, fairly easy to turn up - speeding up ingest and changing route names in the smoke test (a6cb862) were enough to trigger it reliably.

The fix is trivial - on removing a resource from the cache, don't create a subscription node if one doesn't already exist. 

```diff
     fn remove(&mut self, rtype: ResourceType, name: &str) {
-        if let Some(sub) = self.find_subcribed(rtype, name) {
+        if let Some(sub) = self.find(rtype, name) {
            self.reset_refs(sub);
          }
     }
```

For resources that are not wildcards, this was a noop, but for Clusters this would both tombstone resource data and create a wildcard subscription, which marks the resource as not-found.

Most of the fix is a connection level test I wrote trying to reproduce, and a cache-level test that scopes this more tightly. To repro, it was necessary to interleave a call to `cache.collect` between removing a reference to the cluster from the RouteConfig and removing the cluster itself from the cache.

#### More Debugging Tools

While reproducing, it was useful to have tracing enabled in Rust. Enabling tracing doesn't happen automatically, but there is now a hook that Python clients can call to enable the standard tracing subscriber. This isn't the best interface but is an improvement.