### PR TITLE
chore: run actions on dependency upgrades

### DIFF
--- a/.github/workflows/junction-ci.yml
+++ b/.github/workflows/junction-ci.yml
@@ -9,12 +9,16 @@ on:
   push:
     branches: ["main"]
     paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
       - "crates/**"
       - ".github/workflows/junction-ci.yml"
 
   pull_request:
     branches: ["main"]
     paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
       - "crates/**"
       - ".github/workflows/junction-ci.yml"
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches: ["main"]
     paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
       - "junction-python/**"
       - "crates/**"
       - ".github/workflows/smoke-test.yml"
@@ -18,6 +20,8 @@ on:
   pull_request:
     branches: ["main"]
     paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
       - "junction-python/**"
       - "crates/**"
       - ".github/workflows/smoke-test.yml"


### PR DESCRIPTION
We're not running actions on dependabot upgrades. Let's try doing that.