### PR TITLE
The start of an xDS forward client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "delegate"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +769,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1074,6 +1094,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "crossbeam-skiplist",
+ "dashmap",
  "enum-map",
  "form_urlencoded",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.81"
 arc-swap = "1.7"
 bytes = "1.7"
 crossbeam-skiplist = "0.1"
+dashmap = "6.1"
 enum-map = "2.7"
 form_urlencoded = "1.1.1"
 futures = "0.3"
@@ -39,7 +40,7 @@ smol_str = "0.3"
 thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-xds-api = { version = "0.2", default-features = false}
+xds-api = { version = "0.2", default-features = false }
 
 xxhash-rust = { version = "0.8.15", features = ["xxh64"] }
 

--- a/crates/junction-api/src/error.rs
+++ b/crates/junction-api/src/error.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, fmt::Write as _, str::FromStr};
 ///
 /// Errors should be treated as opaque, and contain a message about what went
 /// wrong and a jsonpath style path to the field that caused problems.
-#[derive(Clone, thiserror::Error)]
+#[derive(Clone, PartialEq, thiserror::Error)]
 pub struct Error {
     // an error message
     message: String,

--- a/crates/junction-core/Cargo.toml
+++ b/crates/junction-core/Cargo.toml
@@ -20,6 +20,7 @@ rust-version.workspace = true
 arc-swap = { workspace = true }
 bytes = { workspace = true }
 crossbeam-skiplist = { workspace = true }
+dashmap = { workspace = true }
 enum-map = { workspace = true }
 form_urlencoded = { workspace = true }
 futures = { workspace = true }

--- a/crates/junction-core/examples/dns-backend.rs
+++ b/crates/junction-core/examples/dns-backend.rs
@@ -10,59 +10,59 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    // tracing_subscriber::fmt()
+    //     .with_env_filter(EnvFilter::from_default_env())
+    //     .init();
 
-    let server_addr =
-        env::var("JUNCTION_ADS_SERVER").unwrap_or("http://127.0.0.1:8008".to_string());
+    // let server_addr =
+    //     env::var("JUNCTION_ADS_SERVER").unwrap_or("http://127.0.0.1:8008".to_string());
 
-    let client = Client::build(
-        server_addr,
-        "example-client".to_string(),
-        "example-cluster".to_string(),
-    )
-    .await
-    .unwrap();
+    // let client = Client::build(
+    //     server_addr,
+    //     "example-client".to_string(),
+    //     "example-cluster".to_string(),
+    // )
+    // .await
+    // .unwrap();
 
-    let httpbin = Service::dns("httpbin.org").unwrap();
+    // let httpbin = Service::dns("httpbin.org").unwrap();
 
-    let backends = vec![
-        Backend {
-            id: httpbin.as_backend_id(80),
-            lb: LbPolicy::RoundRobin,
-        },
-        Backend {
-            id: httpbin.as_backend_id(443),
-            lb: LbPolicy::RoundRobin,
-        },
-    ];
+    // let backends = vec![
+    //     Backend {
+    //         id: httpbin.as_backend_id(80),
+    //         lb: LbPolicy::RoundRobin,
+    //     },
+    //     Backend {
+    //         id: httpbin.as_backend_id(443),
+    //         lb: LbPolicy::RoundRobin,
+    //     },
+    // ];
 
-    let client = client.with_static_config(vec![], backends);
+    // let client = client.with_static_config(vec![], backends);
 
-    eprintln!("{:?}", client.dump_routes());
+    // eprintln!("{:?}", client.dump_routes());
 
-    let http_url: junction_core::Url = "http://httpbin.org".parse().unwrap();
-    let https_url: junction_core::Url = "https://httpbin.org".parse().unwrap();
-    let headers = http::HeaderMap::new();
+    // let http_url: junction_core::Url = "http://httpbin.org".parse().unwrap();
+    // let https_url: junction_core::Url = "https://httpbin.org".parse().unwrap();
+    // let headers = http::HeaderMap::new();
 
-    loop {
-        match client.resolve_http(&Method::GET, &http_url, &headers).await {
-            Ok(endpoint) => {
-                eprintln!(" http: {:>15}", &endpoint.addr());
-            }
-            Err(e) => eprintln!("http: something went wrong: {e}"),
-        }
-        match client
-            .resolve_http(&Method::GET, &https_url, &headers)
-            .await
-        {
-            Ok(endpoint) => {
-                eprintln!("https: {:>15}", &endpoint.addr());
-            }
-            Err(e) => eprintln!("https: something went wrong: {e}"),
-        }
+    // loop {
+    //     match client.resolve_http(&Method::GET, &http_url, &headers).await {
+    //         Ok(endpoint) => {
+    //             eprintln!(" http: {:>15}", &endpoint.addr());
+    //         }
+    //         Err(e) => eprintln!("http: something went wrong: {e}"),
+    //     }
+    //     match client
+    //         .resolve_http(&Method::GET, &https_url, &headers)
+    //         .await
+    //     {
+    //         Ok(endpoint) => {
+    //             eprintln!("https: {:>15}", &endpoint.addr());
+    //         }
+    //         Err(e) => eprintln!("https: something went wrong: {e}"),
+    //     }
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
-    }
+    //     tokio::time::sleep(Duration::from_secs(2)).await;
+    // }
 }

--- a/crates/junction-core/examples/get-endpoints.rs
+++ b/crates/junction-core/examples/get-endpoints.rs
@@ -10,106 +10,106 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    // tracing_subscriber::fmt()
+    //     .with_env_filter(EnvFilter::from_default_env())
+    //     .init();
 
-    let server_addr =
-        env::var("JUNCTION_ADS_SERVER").unwrap_or("http://127.0.0.1:8008".to_string());
+    // let server_addr =
+    //     env::var("JUNCTION_ADS_SERVER").unwrap_or("http://127.0.0.1:8008".to_string());
 
-    let client = Client::build(
-        server_addr,
-        "example-client".to_string(),
-        "example-cluster".to_string(),
-    )
-    .await
-    .unwrap();
+    // let client = Client::build(
+    //     server_addr,
+    //     "example-client".to_string(),
+    //     "example-cluster".to_string(),
+    // )
+    // .await
+    // .unwrap();
 
-    // spawn a CSDS server that allows inspecting xDS over gRPC while the client
-    // is running
-    tokio::spawn(client.clone().csds_server(8009));
+    // // spawn a CSDS server that allows inspecting xDS over gRPC while the client
+    // // is running
+    // tokio::spawn(client.clone().csds_server(8009));
 
-    let nginx = Service::kube("default", "nginx").unwrap();
-    let nginx_staging = Service::kube("default", "nginx-staging").unwrap();
+    // let nginx = Service::kube("default", "nginx").unwrap();
+    // let nginx_staging = Service::kube("default", "nginx-staging").unwrap();
 
-    let routes = vec![Route {
-        id: Name::from_static("nginx"),
-        hostnames: vec![nginx.hostname().into()],
-        ports: vec![],
-        tags: Default::default(),
-        rules: vec![
-            RouteRule {
-                matches: vec![RouteMatch {
-                    headers: vec![HeaderMatch::RegularExpression {
-                        name: "x-demo-staging".to_string(),
-                        value: Regex::from_str(".*").unwrap(),
-                    }],
-                    ..Default::default()
-                }],
-                backends: vec![BackendRef {
-                    service: nginx_staging.clone(),
-                    port: Some(80),
-                    weight: 1,
-                }],
-                ..Default::default()
-            },
-            RouteRule {
-                backends: vec![BackendRef {
-                    service: nginx.clone(),
-                    port: Some(80),
-                    weight: 1,
-                }],
-                ..Default::default()
-            },
-        ],
-    }];
-    let backends = vec![
-        Backend {
-            id: nginx.as_backend_id(80),
-            lb: LbPolicy::Unspecified,
-        },
-        Backend {
-            id: nginx_staging.as_backend_id(80),
-            lb: LbPolicy::Unspecified,
-        },
-    ];
-    let client = client.with_static_config(routes, backends);
+    // let routes = vec![Route {
+    //     id: Name::from_static("nginx"),
+    //     hostnames: vec![nginx.hostname().into()],
+    //     ports: vec![],
+    //     tags: Default::default(),
+    //     rules: vec![
+    //         RouteRule {
+    //             matches: vec![RouteMatch {
+    //                 headers: vec![HeaderMatch::RegularExpression {
+    //                     name: "x-demo-staging".to_string(),
+    //                     value: Regex::from_str(".*").unwrap(),
+    //                 }],
+    //                 ..Default::default()
+    //             }],
+    //             backends: vec![BackendRef {
+    //                 service: nginx_staging.clone(),
+    //                 port: Some(80),
+    //                 weight: 1,
+    //             }],
+    //             ..Default::default()
+    //         },
+    //         RouteRule {
+    //             backends: vec![BackendRef {
+    //                 service: nginx.clone(),
+    //                 port: Some(80),
+    //                 weight: 1,
+    //             }],
+    //             ..Default::default()
+    //         },
+    //     ],
+    // }];
+    // let backends = vec![
+    //     Backend {
+    //         id: nginx.as_backend_id(80),
+    //         lb: LbPolicy::Unspecified,
+    //     },
+    //     Backend {
+    //         id: nginx_staging.as_backend_id(80),
+    //         lb: LbPolicy::Unspecified,
+    //     },
+    // ];
+    // let client = client.with_static_config(routes, backends);
 
-    let url: junction_core::Url = "https://nginx.default.svc.cluster.local".parse().unwrap();
-    let prod_headers = http::HeaderMap::new();
-    let staging_headers = {
-        let mut headers = http::HeaderMap::new();
-        headers.insert("x-demo-staging", HeaderValue::from_static("true"));
-        headers
-    };
+    // let url: junction_core::Url = "https://nginx.default.svc.cluster.local".parse().unwrap();
+    // let prod_headers = http::HeaderMap::new();
+    // let staging_headers = {
+    //     let mut headers = http::HeaderMap::new();
+    //     headers.insert("x-demo-staging", HeaderValue::from_static("true"));
+    //     headers
+    // };
 
-    loop {
-        let prod_endpoints = client
-            .resolve_http(&http::Method::GET, &url, &prod_headers)
-            .await;
-        let staging_endpoints = client
-            .resolve_http(&http::Method::GET, &url, &staging_headers)
-            .await;
+    // loop {
+    //     let prod_endpoints = client
+    //         .resolve_http(&http::Method::GET, &url, &prod_headers)
+    //         .await;
+    //     let staging_endpoints = client
+    //         .resolve_http(&http::Method::GET, &url, &staging_headers)
+    //         .await;
 
-        let mut error = false;
-        if let Err(e) = &prod_endpoints {
-            eprintln!("error: prod: {e:?}");
-            error = true;
-        }
-        if let Err(e) = &staging_endpoints {
-            eprintln!("error: staging: {e:?}");
-            error = true;
-        }
+    //     let mut error = false;
+    //     if let Err(e) = &prod_endpoints {
+    //         eprintln!("error: prod: {e:?}");
+    //         error = true;
+    //     }
+    //     if let Err(e) = &staging_endpoints {
+    //         eprintln!("error: staging: {e:?}");
+    //         error = true;
+    //     }
 
-        if error {
-            tokio::time::sleep(Duration::from_secs(3)).await;
-            continue;
-        }
+    //     if error {
+    //         tokio::time::sleep(Duration::from_secs(3)).await;
+    //         continue;
+    //     }
 
-        let prod = prod_endpoints.unwrap();
-        let staging = staging_endpoints.unwrap();
-        println!("prod={:<20} staging={:<20}", prod.addr(), staging.addr());
+    //     let prod = prod_endpoints.unwrap();
+    //     let staging = staging_endpoints.unwrap();
+    //     println!("prod={:<20} staging={:<20}", prod.addr(), staging.addr());
 
-        tokio::time::sleep(Duration::from_millis(1500)).await;
-    }
+    //     tokio::time::sleep(Duration::from_millis(1500)).await;
+    // }
 }

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -1,24 +1,32 @@
 use crate::{
     dns,
-    endpoints::{EndpointGroup, EndpointIter},
     error::Trace,
-    load_balancer::BackendLb,
-    xds::AdsClient,
-    ConfigCache, Endpoint, Error, StaticConfig,
+    xds::{self, AdsClient},
+    Endpoint, Error,
 };
-use futures::{stream::FuturesOrdered, FutureExt, StreamExt};
-use junction_api::{
-    backend::{Backend, BackendId},
-    http::{HeaderMatch, PathMatch, QueryParamMatch, Route, RouteMatch, RouteRule},
-    Hostname,
-};
-use rand::distributions::WeightedError;
+use futures::{stream::FuturesOrdered, StreamExt};
+use junction_api::Hostname;
+use rand::{distributions::WeightedError, rngs::StdRng, seq::SliceRandom};
 use serde::Deserialize;
 use std::{
     borrow::Cow,
+    collections::HashMap,
     time::{Duration, Instant},
 };
 use std::{net::SocketAddr, sync::Arc};
+
+macro_rules! with_deadline {
+    ($fut:expr, $deadline:expr, $msg:expr, $trace:expr $(,)*) => {
+        tokio::select! {
+            biased;
+
+            res = $fut => res,
+            _ = sleep_until($deadline) => {
+                return Err(Error::timed_out($msg, $trace));
+            }
+        }
+    };
+}
 
 /// An outgoing HTTP Request, before any rewrites or modifications have been
 /// made.
@@ -42,65 +50,11 @@ impl<'a> HttpRequest<'a> {
         method: &'a http::Method,
         url: &'a crate::Url,
         headers: &'a http::HeaderMap,
-    ) -> crate::Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             method,
             url,
             headers,
-        })
-    }
-}
-
-/// The result of resolving a route (see [Client::resolve_route]).
-#[derive(Debug, Clone)]
-pub struct ResolvedRoute {
-    /// The resolved route.
-    pub route: Arc<Route>,
-
-    /// The index of the rule that matched the request.
-    //TODO: doesn't need to be optional? remove it for the request trace anyway
-    pub rule: usize,
-
-    /// The backend selected as part of route resolution.
-    pub backend: BackendId,
-
-    /// smuggle the request trace through here
-    trace: Trace,
-}
-
-/// The context required to select an address from a backend. Includes the URL
-/// and headers from an outgoing request.
-#[derive(Debug, Clone)]
-pub struct LbContext<'a> {
-    url: &'a crate::Url,
-
-    headers: &'a http::HeaderMap,
-
-    previous_addrs: &'a [SocketAddr],
-
-    /// smuggle the request trace through here
-    trace: Trace,
-}
-
-impl<'a> LbContext<'a> {
-    // unused, allowed so that we can make select_endpoint public without exposing Trace
-    #[allow(unused)]
-    pub fn from_parts(url: &'a crate::Url, headers: &'a http::HeaderMap) -> Self {
-        let trace = Trace::new();
-        Self {
-            url,
-            headers,
-            previous_addrs: &[],
-            trace,
-        }
-    }
-
-    fn new(trace: Trace, url: &'a crate::Url, headers: &'a http::HeaderMap) -> Self {
-        Self {
-            url,
-            headers,
-            previous_addrs: &[],
-            trace,
         }
     }
 }
@@ -110,7 +64,6 @@ pub struct SelectedEndpoint {
     /// The selected endpoint address
     pub addr: SocketAddr,
 
-    // smuggle trace data back out
     trace: Trace,
 }
 
@@ -170,8 +123,7 @@ pub struct Client {
     // expanding the search over the set of possible authority matches.
     search_config: SearchConfig,
 
-    // junction data
-    config: Config,
+    config: Arc<DynamicConfig>,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -192,64 +144,16 @@ impl SearchConfig {
         Self { ndots, search }
     }
 }
-// the entire static config thing might be a mistake and worth revisting - we
-// could insert resources into cache and let multiple clients in the same process
-// all see static resources. is that good? idk. we already have to_xds() on every
-// resource type, and it would remove a lot of code.
-//
-// revisit this when we hit the problem of static bootstrapping/fallback for
-// clients .
-#[derive(Clone)]
-enum Config {
-    Static(Arc<StaticConfig>),
-    DynamicEndpoints(Arc<StaticConfig>, Arc<DynamicConfig>),
-    Dynamic(Arc<DynamicConfig>),
-}
 
 struct DynamicConfig {
-    ads_client: AdsClient,
+    ads: AdsClient,
 
     /// a the shared handle to the task that's actually running the client in
     /// the background. should not drop until every active client drops.
     ///
     /// TODO: should this get bundled into AdsClient? shrug emoji?
     #[allow(unused)]
-    ads_task: tokio::task::JoinHandle<()>,
-}
-
-impl Config {
-    fn ads(&self) -> Option<&AdsClient> {
-        match self {
-            Config::Static(_) => None,
-            Config::DynamicEndpoints(_, d) | Config::Dynamic(d) => Some(&d.ads_client),
-        }
-    }
-}
-
-impl ConfigCache for Config {
-    async fn get_route<S: AsRef<str>>(&self, host: S) -> Option<Arc<Route>> {
-        match &self {
-            Config::Static(s) => s.get_route(host).await,
-            Config::DynamicEndpoints(s, _) => s.get_route(host).await,
-            Config::Dynamic(d) => d.ads_client.get_route(host).await,
-        }
-    }
-
-    async fn get_backend(&self, target: &BackendId) -> Option<Arc<BackendLb>> {
-        match &self {
-            Config::Static(s) => s.get_backend(target).await,
-            Config::DynamicEndpoints(s, _) => s.get_backend(target).await,
-            Config::Dynamic(d) => d.ads_client.get_backend(target).await,
-        }
-    }
-
-    async fn get_endpoints(&self, backend: &BackendId) -> Option<Arc<EndpointGroup>> {
-        match &self {
-            Config::Static(s) => s.get_endpoints(backend).await,
-            Config::DynamicEndpoints(_, d) => d.ads_client.get_endpoints(backend).await,
-            Config::Dynamic(d) => d.ads_client.get_endpoints(backend).await,
-        }
-    }
+    task_handle: tokio::task::JoinHandle<()>,
 }
 
 // FIXME: Vec<Endpoints> is probably the wrong thing to return from all our
@@ -271,7 +175,7 @@ impl Client {
         node_id: String,
         cluster: String,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let (ads_client, mut ads_task) = AdsClient::build(address, node_id, cluster).unwrap();
+        let (ads, mut ads_task) = AdsClient::build(address, node_id, cluster).unwrap();
 
         // try to start the ADS connection while blocking. if it fails, fail
         // fast here instead of letting the client start.
@@ -300,14 +204,14 @@ impl Client {
         };
 
         // wrap it all up in a dynamic config and return
-        let config = Config::Dynamic(Arc::new(DynamicConfig {
-            ads_client,
-            ads_task: handle,
-        }));
+        let config = Arc::new(DynamicConfig {
+            ads,
+            task_handle: handle,
+        });
         let client = Self {
             resolve_timeout: Duration::from_secs(5),
-            config,
             search_config,
+            config,
         };
 
         Ok(client)
@@ -320,18 +224,18 @@ impl Client {
     /// This method will panic if the client being cloned is fully static. To
     /// convert a static client to a client that uses dynamic config, create a
     /// new client.
-    pub fn with_static_config(self, routes: Vec<Route>, backends: Vec<Backend>) -> Client {
-        let static_config = Arc::new(StaticConfig::with_inferred(routes, backends));
+    // pub fn with_static_config(self, routes: Vec<Route>, backends: Vec<Backend>) -> Client {
+    //     let static_config = Arc::new(StaticConfig::with_inferred(routes, backends));
 
-        let dyn_config = match &self.config {
-            Config::Static(_) => panic!("can't use dynamic endpoints with a fully static client"),
-            Config::DynamicEndpoints(_, d) => Arc::clone(d),
-            Config::Dynamic(d) => Arc::clone(d),
-        };
+    //     let dyn_config = match &self.config {
+    //         Config::Static(_) => panic!("can't use dynamic endpoints with a fully static client"),
+    //         Config::DynamicEndpoints(_, d) => Arc::clone(d),
+    //         Config::Dynamic(d) => Arc::clone(d),
+    //     };
 
-        let config = Config::DynamicEndpoints(static_config, dyn_config);
-        Client { config, ..self }
-    }
+    //     let config = Config::DynamicEndpoints(static_config, dyn_config);
+    //     Client { config, ..self }
+    // }
 
     /// Construct a client that uses fully static configuration and does not
     /// connect to a control plane at all.
@@ -340,11 +244,11 @@ impl Client {
     /// or to use Junction an offline mode. Once a client has been converted to
     /// fully static, it's not possible to convert it back to using dynamic
     /// discovery data.
-    pub fn with_static_endpoints(self, routes: Vec<Route>, backends: Vec<Backend>) -> Client {
-        let static_config = Arc::new(StaticConfig::with_inferred(routes, backends));
-        let config = Config::Static(static_config);
-        Client { config, ..self }
-    }
+    // pub fn with_static_endpoints(self, routes: Vec<Route>, backends: Vec<Backend>) -> Client {
+    //     let static_config = Arc::new(StaticConfig::with_inferred(routes, backends));
+    //     let config = Config::Static(static_config);
+    //     Client { config, ..self }
+    // }
 
     /// Resolve an HTTP method, URL, and headers into an [Endpoint].
     ///
@@ -365,30 +269,68 @@ impl Client {
     ) -> crate::Result<Endpoint> {
         let deadline = Instant::now() + self.resolve_timeout;
 
-        let request = HttpRequest::from_parts(method, url, headers)?;
+        let request = HttpRequest::from_parts(method, url, headers);
 
-        let resolved = self.resolve_route(request, Some(deadline)).await?;
+        let trace = Trace::new();
+        let resolved = resolve_route(
+            &self.config.ads,
+            &self.search_config,
+            trace,
+            request.clone(),
+            Some(deadline),
+        )
+        .await?;
 
-        let lb_context = LbContext::new(resolved.trace, url, headers);
-        let selected = self
-            .select_endpoint(&resolved.backend, lb_context, Some(deadline))
-            .await?;
+        // fetch the cluster for this request and compute the request hash. both
+        // cluster selection and endpoint hashing should be done at this point,
+        // even if the request gets retried.
+        //
+        // this happens here so that in THEORY we can switch out the hash
+        // function. in practice, there's no reason to do it here since there
+        // is exactly one hash function we support at the moment.
+        let cluster = with_deadline!(
+            self.config.ads.get_cluster(&resolved.cluster),
+            Some(deadline),
+            "timed out fetching backend",
+            resolved.trace,
+        );
+        let Some(cluster) = cluster else {
+            return Err(Error::no_backend(todo!(), resolved.trace));
+        };
+
+        // if there's nothign in the request that matches this hash policy, fall
+        // back to essentially random with sticky sessions. this is what envoy
+        // does with the rationale that this is better than failing the request
+        // if the config is bad.
+        //
+        // https://github.com/envoyproxy/envoy/blob/73fe00fc139fd5053f4c4a5d66569cc254449896/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc#L157-L164
+        let request_hash = hash_request(request.clone(), &resolved.hash_policy)
+            .unwrap_or_else(crate::rand::random);
+
+        // select endpoints using the result of route resolution
+        let selected = select_endpoint(
+            &self.config.ads,
+            resolved.trace,
+            RequestContext {
+                request,
+                request_hash,
+                previous_addrs: &[],
+            },
+            cluster,
+            Some(deadline),
+        )
+        .await?;
 
         let address = selected.addr;
         let trace = selected.trace;
-        let (timeouts, retry) = {
-            let rule = &resolved.route.rules[resolved.rule];
-            (rule.timeouts.clone(), rule.retry.clone())
-        };
 
         Ok(Endpoint {
             method: method.clone(),
             url: url.clone(),
             headers: headers.clone(),
+            request_hash,
             address,
-            timeouts,
-            retry,
-            backend: resolved.backend,
+            cluster_name: resolved.cluster,
             trace,
             previous_addrs: vec![],
         })
@@ -410,25 +352,40 @@ impl Client {
         endpoint: Endpoint,
         response: HttpResult,
     ) -> crate::Result<Endpoint> {
-        // TODO: track response stats
+        // TODO: track response stats per address
 
         // if there's no reason to pick a new endpoint, just return the existing one as-is
         if response.is_ok() || !endpoint.should_retry(response) {
             return Ok(endpoint);
         }
 
-        // redo endpoint selection
-        // FIXME: real deadline here
+        // redo endpoint selection. this should use the same cluster that was
+        // used in the initial request, and the same request hash, but should
+        // not necessarily pick the same endpoint.
         let deadline = Instant::now() + self.resolve_timeout;
-        let lb_context = LbContext {
-            url: &endpoint.url,
-            headers: &endpoint.headers,
+        let context = RequestContext {
+            request: HttpRequest::from_parts(&endpoint.method, &endpoint.url, &endpoint.headers),
+            request_hash: endpoint.request_hash,
             previous_addrs: &endpoint.previous_addrs,
-            trace: endpoint.trace,
         };
-        let next = self
-            .select_endpoint(&endpoint.backend, lb_context, Some(deadline))
-            .await?;
+        let cluster = with_deadline!(
+            self.config.ads.get_cluster(&endpoint.cluster_name),
+            Some(deadline),
+            "timed out fetching backend",
+            endpoint.trace,
+        );
+        let Some(cluster) = cluster else {
+            return Err(Error::no_backend(todo!(), endpoint.trace));
+        };
+
+        let next = select_endpoint(
+            &self.config.ads,
+            endpoint.trace,
+            context,
+            cluster,
+            Some(deadline),
+        )
+        .await?;
         let address = next.addr;
         let trace = next.trace;
 
@@ -452,14 +409,14 @@ impl Client {
     /// This is a lower-level method that only performs the Route matching part
     /// of resolution. It's intended for debugging or querying a client for
     /// specific information. For everyday use, prefer [Client::resolve_http].
-    pub async fn resolve_route(
-        &self,
-        request: HttpRequest<'_>,
-        deadline: Option<Instant>,
-    ) -> crate::Result<ResolvedRoute> {
-        let trace = Trace::new();
-        resolve_routes(&self.config, trace, request, deadline, &self.search_config).await
-    }
+    // pub async fn resolve_route(
+    //     &self,
+    //     request: HttpRequest<'_>,
+    //     deadline: Option<Instant>,
+    // ) -> crate::Result<xds::ResourceName> {
+    //     let trace = Trace::new();
+    //     resolve_route(&self.config, trace, request, deadline, &self.search_config).await
+    // }
 
     /// Select an endpoint address for this backend from the set of currently
     /// available endpoints.
@@ -467,24 +424,21 @@ impl Client {
     /// This is a lower level method that only performs part of route
     /// resolution, and is intended for debugging and testing. For everyday use,
     /// prefer [Client::resolve_http].
-    pub async fn select_endpoint(
-        &self,
-        backend: &BackendId,
-        ctx: LbContext<'_>,
-        deadline: Option<Instant>,
-    ) -> crate::Result<SelectedEndpoint> {
-        select_endpoint(&self.config, backend, ctx, deadline).await
-    }
+    // pub async fn select_endpoint(
+    //     &self,
+    //     backend: &BackendId,
+    //     ctx: LbContext<'_>,
+    //     deadline: Option<Instant>,
+    // ) -> crate::Result<SelectedEndpoint> {
+    //     select_endpoint(&self.config, backend, ctx, deadline).await
+    // }
 
     /// Start a gRPC CSDS server on the given port. To run the server, you must
     /// `await` this future.
     ///
     /// For static clients, this does nothing.
     pub async fn csds_server(self, port: u16) -> Result<(), tonic::transport::Error> {
-        match self.config.ads() {
-            Some(ads) => ads.csds_server(port).await,
-            None => std::future::pending().await,
-        }
+        self.config.ads.csds_server(port).await
     }
 
     /// Dump the client's current cache of xDS resources, as fetched from the
@@ -492,110 +446,97 @@ impl Client {
     ///
     /// This is a programmatic view of the same data that you can fetch over
     /// gRPC by starting a [Client::csds_server].
-    pub fn dump_xds(&self, not_found: bool) -> Vec<crate::XdsConfig> {
-        match self.config.ads() {
-            Some(ads) => {
-                if not_found {
-                    ads.iter_xds().collect()
-                } else {
-                    ads.iter_xds().filter(|c| c.xds.is_some()).collect()
-                }
-            }
-            None => Vec::new(),
-        }
+    pub fn dump_xds(&self) -> impl Iterator<Item = crate::XdsConfig> + '_ {
+        self.config.ads.iter_xds()
     }
 
     /// Dump xDS resources that failed to update. This is a view of the data
     /// returned by [Client::dump_xds] that only contains resources with
     /// errors.
-    pub fn dump_xds_errors(&self) -> Vec<crate::XdsConfig> {
-        match self.config.ads() {
-            Some(ads) => ads
-                .iter_xds()
-                .filter(|xds| xds.last_error.is_some())
-                .collect(),
-            None => Vec::new(),
-        }
-    }
-
-    /// Dump the Client's current table of [Route]s, merging together any
-    /// default routes and remotely fetched routes the same way the client would
-    /// when resolving endpoints.
-    pub fn dump_routes(&self) -> Vec<Arc<Route>> {
-        match &self.config {
-            Config::Static(c) | Config::DynamicEndpoints(c, _) => c.routes.clone(),
-            Config::Dynamic(d) => d.ads_client.iter_routes().collect(),
-        }
-    }
-
-    /// Dump the Client's current table of [BackendLb]s, merging together any
-    /// default configuration and remotely fetched config the same way the
-    /// client would when resolving endpoints.
-    pub fn dump_backends(&self) -> Vec<Arc<BackendLb>> {
-        match &self.config {
-            Config::Static(c) | Config::DynamicEndpoints(c, _) => {
-                c.backends.values().cloned().collect()
-            }
-            Config::Dynamic(d) => d.ads_client.iter_backends().collect(),
-        }
-    }
-
-    /// Return the endpoints currently in cache for this backend.
-    ///
-    /// The returned endpoints are a snapshot of what is currently in cache and
-    /// will not update as new discovery information is pushed.
-    pub fn dump_endpoints(&self, backend: &BackendId) -> Option<EndpointIter> {
+    pub fn dump_xds_errors(&self) -> impl Iterator<Item = crate::XdsConfig> + '_ {
         self.config
-            .get_endpoints(backend)
-            .now_or_never()
-            .flatten()
-            .map(EndpointIter::from)
+            .ads
+            .iter_xds()
+            .filter(|x| x.last_error.is_some())
     }
 }
 
-macro_rules! with_deadline {
-    ($fut:expr, $deadline:expr, $msg:expr, $trace:expr $(,)*) => {
-        tokio::select! {
-            biased;
-
-            res = $fut => res,
-            _ = sleep_until($deadline) => {
-                return Err(Error::timed_out($msg, $trace));
-            }
-        }
-    };
+pub(crate) trait XdsCache {
+    async fn subscribe(&self, rtype: xds::ResourceType, name: xds::ResourceName);
+    async fn get_listener(&self, name: &xds::ResourceName) -> Option<Arc<xds::ApiListener>>;
+    async fn get_route_config(
+        &self,
+        name: &xds::ResourceName,
+    ) -> Option<Arc<xds::RouteConfiguration>>;
+    async fn get_cluster(&self, target: &xds::ResourceName) -> Option<Arc<xds::Cluster>>;
+    async fn get_load_assignment(
+        &self,
+        backend: &xds::ResourceName,
+    ) -> Option<Arc<xds::LoadAssignment>>;
 }
 
-pub(crate) async fn resolve_routes(
-    cache: &impl ConfigCache,
-    mut trace: Trace,
+// this is basically Either<_, > so that we don't have to deal with borrowck
+// while resolving_routes
+enum RouteConfigRef {
+    Route(Arc<xds::RouteConfiguration>),
+    Inlined(Arc<xds::ApiListener>),
+}
+
+impl AsRef<xds::RouteConfiguration> for RouteConfigRef {
+    fn as_ref(&self) -> &xds::RouteConfiguration {
+        match self {
+            RouteConfigRef::Route(route) => &route,
+            RouteConfigRef::Inlined(listener) => match &listener.route_config {
+                xds::listeners::RouteConfig::Inline(route) => &route,
+                _ => panic!("expected an inline RouteConfiguration"),
+            },
+        }
+    }
+}
+
+pub(crate) struct ResolvedRoute {
+    cluster: xds::ResourceName,
+    hash_policy: Vec<xds::route_configs::HashPolicy>,
+    retries: xds::route_configs::Retries,
+    timeouts: xds::route_configs::Timeouts,
+    trace: Trace,
+}
+
+pub(crate) async fn resolve_route(
+    cache: &impl XdsCache,
+    search_config: &SearchConfig,
+    trace: Trace,
     request: HttpRequest<'_>,
     deadline: Option<Instant>,
-    search_config: &SearchConfig,
 ) -> crate::Result<ResolvedRoute> {
-    use rand::seq::SliceRandom;
-
     let uris_to_search = search(search_config, request.url);
     assert!(
         !uris_to_search.is_empty(),
         "URI search is empty, this is a bug in Junction."
     );
 
+    // fetch the first listener that resolves, returning the first error we see.
+    //
+    // using FuturesOrdered means that the responses will come back in
+    // search_path order - a valid not-found response is not necessarily a
+    // signal and we should fall back to the next response in the path, but a
+    // timeout or error means we should stop processing immediately and return
+    // the error.
     let mut futures_ordered = FuturesOrdered::new();
     for url in uris_to_search {
-        futures_ordered.push_back(cache.get_route(url.authority().to_string()));
+        let name = xds::ResourceName::from(url.authority().to_string());
+        futures_ordered.push_back(async move {
+            cache
+                .subscribe(xds::ResourceType::Listener, name.clone())
+                .await;
+            cache.get_listener(&name).await
+        });
     }
 
-    // NB[pt): two potential surprises below:
-    //  1. we do not surface any errors that occur subsequent to the first success in the list of
-    //     routes.
-    //  2. we rely on .next() called on FuturesOrdered to start all the futures contained in
-    //     futures_ordered. We expect all routes to be checked in parallel depending on load in
-    //     tokio.
     let msg = "timed out fetching route";
-    let route = loop {
+    let listener = loop {
         match with_deadline!(futures_ordered.next(), deadline, msg, trace) {
-            Some(Some(route)) => break route,
+            Some(Some(found)) => break found,
             Some(None) => {
                 continue;
             }
@@ -608,112 +549,91 @@ pub(crate) async fn resolve_routes(
         }
     };
 
-    trace.lookup_route(&route);
+    // immdediately try to fetch the route
+    let route_config = match &listener.route_config {
+        xds::listeners::RouteConfig::Rds(name) => {
+            let msg = "timed out fetching route";
+            match with_deadline!(cache.get_route_config(&name), deadline, msg, trace) {
+                Some(route) => RouteConfigRef::Route(route),
+                None => {
+                    return Err(Error::no_route_matched(
+                        request.url.authority().to_string(),
+                        trace,
+                    ))
+                }
+            }
+        }
+        xds::listeners::RouteConfig::Inline(_) => RouteConfigRef::Inlined(listener),
+    };
 
     // match the request against the list of RouteRules that are part of this
     // request. the hostname and port of the request have already matched but we
     // need to match headers/url params/method and so on.
-    let (rule, matching_rule) = match find_matching_rule(&route, request.clone()) {
-        Some((idx, r)) => (idx, r),
-        None => return Err(Error::no_rule_matched(route.id.clone(), trace)),
+    let action = match find_match(route_config.as_ref(), request.clone()) {
+        Some(route) => route,
+        None => return Err(Error::no_rule_matched(todo!(), trace)),
     };
-    trace.matched_rule(
-        rule,
-        route.rules.get(rule).and_then(|rule| rule.name.as_ref()),
-    );
 
     // pick a target at random from the list, respecting weights. if there are
     // no backends listed we should blackhole here.
-    let weighted_backend = &crate::rand::with_thread_rng(|rng| {
-        matching_rule.backends.choose_weighted(rng, |wc| wc.weight)
-    });
-    let backend_ref = match weighted_backend {
-        Ok(backend_ref) => backend_ref,
-        Err(WeightedError::NoItem) => {
-            // TODO: should this just return a special endpoint that 500s?
-            return Err(Error::invalid_route(
-                "route has no backends",
-                route.id.clone(),
-                rule,
-                trace,
-            ));
-        }
-        Err(_) => {
-            return Err(Error::invalid_route(
-                "backends weights are invalid: total weights must be greater than zero",
-                route.id.clone(),
-                rule,
-                trace,
-            ))
-        }
-    };
-    let backend = backend_ref.into_backend_id(request.url.default_port());
-    trace.select_backend(&backend);
-
+    let cluster = crate::rand::with_thread_rng(|rng| pick_cluster(rng, &action.cluster))?;
     Ok(ResolvedRoute {
-        route,
-        rule,
-        backend,
         trace,
+        cluster: cluster.clone(),
+        hash_policy: action.hash_policies.clone(),
+        retries: action.retries.clone(),
+        timeouts: action.timeouts.clone(),
     })
 }
 
+#[derive(Debug, Clone)]
+struct RequestContext<'a> {
+    request: HttpRequest<'a>,
+    request_hash: u64,
+    previous_addrs: &'a [SocketAddr],
+}
+
 async fn select_endpoint(
-    cache: &impl ConfigCache,
-    backend: &BackendId,
-    mut ctx: LbContext<'_>,
+    cache: &impl XdsCache,
+    mut trace: Trace,
+    request: RequestContext<'_>,
+    cluster: Arc<xds::Cluster>,
     deadline: Option<Instant>,
 ) -> crate::Result<SelectedEndpoint> {
-    // start the next trace phase
-    ctx.trace.start_endpoint_selection();
-
-    // lookup backend and endpoints
-    //
-    // these lookups are done sequentially, even though they could be raced, so
-    // that we can tell what step a lookup timed out on. we're assuming that
-    // this is okay because in the background fetching a backend for a cache
-    // will also trigger fetching its endpoints and parallelism here won't do
-    // much for us.
-    let blb = with_deadline!(
-        cache.get_backend(backend),
-        deadline,
-        "timed out fetching backend",
-        ctx.trace,
-    );
-    let Some(blb) = blb else {
-        return Err(Error::no_backend(backend.clone(), ctx.trace));
+    // lookup endpoints for a cluster
+    let load_assignment = match &cluster.endpoints {
+        xds::clusters::Endpoints::Eds(name) => with_deadline!(
+            cache.get_load_assignment(&name),
+            deadline,
+            "timed out fetching endpoints",
+            trace
+        ),
+        xds::clusters::Endpoints::LogicalDns { hostname, port } => {
+            // get a handle to the DNS resolver here and call into it
+            todo!("support LOGICAL_DNS clusters")
+        }
     };
-    ctx.trace.lookup_backend(backend);
-
-    let endpoints = with_deadline!(
-        cache.get_endpoints(backend),
-        deadline,
-        "timed out fetching endpoints",
-        ctx.trace,
-    );
-    let Some(endpoints) = endpoints else {
-        return Err(Error::no_reachable_endpoints(backend.clone(), ctx.trace));
+    let Some(load_assignment) = load_assignment else {
+        return Err(Error::no_reachable_endpoints(todo!(), trace));
     };
-    ctx.trace.lookup_endpoints(backend);
+    let Some(endpoints) = load_assignment.endpoints.first() else {
+        return Err(Error::no_reachable_endpoints(todo!(), trace));
+    };
 
     // load balance.
     //
     // no trace is done here, the load balancer impls stamp the traces themselves
-    let addr = blb.load_balancer.load_balance(
-        &mut ctx.trace,
+    let addr = cluster.load_balancer.load_balance(
+        &mut trace,
+        request.request_hash,
         &endpoints,
-        ctx.url,
-        ctx.headers,
-        ctx.previous_addrs,
+        request.previous_addrs,
     );
     let Some(addr) = addr else {
-        return Err(Error::no_reachable_endpoints(backend.clone(), ctx.trace));
+        return Err(Error::no_reachable_endpoints(todo!(), trace));
     };
 
-    Ok(SelectedEndpoint {
-        addr: *addr,
-        trace: ctx.trace,
-    })
+    Ok(SelectedEndpoint { addr: *addr, trace })
 }
 
 async fn sleep_until(deadline: Option<Instant>) {
@@ -723,84 +643,160 @@ async fn sleep_until(deadline: Option<Instant>) {
     }
 }
 
-//FIXME(routing): picking between these is way more complicated than finding the
-//first match
-fn find_matching_rule<'a>(
-    route: &'a Route,
+fn find_match<'a>(
+    route: &'a xds::RouteConfiguration,
     request: HttpRequest<'_>,
-) -> Option<(usize, &'a RouteRule)> {
-    let rule_idx = route
-        .rules
-        .iter()
-        .position(|rule| is_route_rule_match(rule, request.method, request.url, request.headers))?;
-
-    let rule = &route.rules[rule_idx];
-    Some((rule_idx, rule))
-}
-
-pub fn is_route_rule_match(
-    rule: &RouteRule,
-    method: &http::Method,
-    url: &crate::Url,
-    headers: &http::HeaderMap,
-) -> bool {
-    if rule.matches.is_empty() {
-        return true;
-    }
-    rule.matches
-        .iter()
-        .any(|m| is_route_match_match(m, method, url, headers))
-}
-
-pub fn is_route_match_match(
-    rule: &RouteMatch,
-    method: &http::Method,
-    url: &crate::Url,
-    headers: &http::HeaderMap,
-) -> bool {
-    let mut method_matches = true;
-    if let Some(rule_method) = &rule.method {
-        method_matches = rule_method.eq(&method.to_string());
-    }
-
-    let mut path_matches = true;
-    if let Some(rule_path) = &rule.path {
-        path_matches = match &rule_path {
-            PathMatch::Exact { value } => value == url.path(),
-            PathMatch::Prefix { value } => url.path().starts_with(value),
-            PathMatch::RegularExpression { value } => value.is_match(url.path()),
+) -> Option<&'a xds::route_configs::Action> {
+    // FIXME: support match order. we have to follow xDS search order for
+    // domains instead of just picking the first match. we don't want to support
+    // just the wildcard but the others need to be handled appropriately.
+    //
+    // - Exact domain names: www.foo.com.
+    // - Suffix domain wildcards: *.foo.com or *-bar.foo.com.
+    // - Prefix domain wildcards: foo.* or foo-*.
+    // - Special wildcard * matching any domain.
+    //
+    // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-routematch
+    let mut matching_vhost = None;
+    let authority = request.url.authority();
+    for vhost in &route.vhosts {
+        if vhost.domains.iter().any(|d| d.matches_hostname(&authority)) {
+            matching_vhost = Some(vhost);
         }
     }
 
-    let headers_matches = rule.headers.iter().all(|m| is_header_match(m, headers));
-    let qp_matches = rule
-        .query_params
+    let route = matching_vhost?
+        .routes
         .iter()
-        .all(|m| is_query_params_match(m, url.query()));
+        .find(|route| matches_request(&route.matcher, &request))?;
 
-    method_matches && path_matches && headers_matches && qp_matches
+    Some(&route.action)
 }
 
-pub fn is_header_match(rule: &HeaderMatch, headers: &http::HeaderMap) -> bool {
-    let Some(header_val) = headers.get(rule.name()) else {
-        return false;
-    };
-    let Ok(header_val) = header_val.to_str() else {
-        return false;
-    };
-    rule.is_match(header_val)
+fn matches_request(matcher: &xds::route_configs::Matcher, request: &HttpRequest<'_>) -> bool {
+    is_method_match(&matcher.method, request.method)
+        && is_path_match(&matcher.path, request.url)
+        && is_header_match(&matcher.headers, request.headers)
+        && is_query_match(&matcher.query, request.url)
 }
 
-pub fn is_query_params_match(rule: &QueryParamMatch, query: Option<&str>) -> bool {
-    let Some(query) = query else {
-        return false;
+#[inline]
+fn is_method_match(
+    method_match: &Option<xds::route_configs::MethodMatcher>,
+    method: &http::Method,
+) -> bool {
+    method_match.as_ref().is_some_and(|m| m.is_match(method))
+}
+
+#[inline]
+fn is_path_match(path_match: &xds::route_configs::PathMatcher, url: &crate::Url) -> bool {
+    path_match.matches_path(url.path())
+}
+
+#[inline]
+fn is_header_match(
+    header_matches: &[xds::route_configs::HeaderMatcher],
+    headers: &http::HeaderMap,
+) -> bool {
+    header_matches.iter().all(|h| {
+        let header_val = headers.get(&h.name).map(|val| val.as_bytes());
+        h.matches_value(header_val)
+    })
+}
+
+fn is_query_match(query_matches: &[xds::route_configs::QueryMatcher], url: &crate::Url) -> bool {
+    let Some(query) = url.query() else {
+        return query_matches.is_empty();
     };
-    for (param, value) in form_urlencoded::parse(query.as_bytes()) {
-        if param == rule.name() {
-            return rule.is_match(&value);
+
+    let query: HashMap<_, _> = form_urlencoded::parse(query.as_bytes()).collect();
+
+    query_matches.iter().all(|q| {
+        let query_val = query.get(&Cow::Borrowed(q.name.as_str()));
+        q.matches(query_val.as_ref().map(|cow| cow.as_ref()))
+    })
+}
+
+fn pick_cluster<'a>(
+    rng: &mut StdRng,
+    action: &'a xds::route_configs::ClusterSpecifier,
+) -> Result<&'a xds::ResourceName, Error> {
+    match action {
+        xds::route_configs::ClusterSpecifier::Cluster(name) => Ok(name),
+        xds::route_configs::ClusterSpecifier::Weighted(clusters) => {
+            match clusters.choose_weighted(rng, |c| c.weight) {
+                Ok(cluster) => Ok(&cluster.name),
+                Err(WeightedError::NoItem) => {
+                    // TODO: should this just return a special endpoint that 500s?
+                    return Err(todo!());
+                }
+                Err(_) => return Err(todo!()),
+            }
         }
     }
-    false
+}
+
+/// Hash an outgoing request based on a set of hash policies.
+///
+/// Like Envoy and gRPC, multiple hash policies are combined by applying a
+/// bitwise left-rotate to the previous value and xor-ing the new value into
+/// the previous value.
+///
+/// See:
+/// - https://github.com/grpc/proposal/blob/master/A42-xds-ring-hash-lb-policy.md#xds-api-fields
+/// - https://github.com/envoyproxy/envoy/blob/73fe00fc139fd5053f4c4a5d66569cc254449896/source/common/http/hash_policy.cc#L251-L272
+fn hash_request(
+    request: HttpRequest<'_>,
+    hash_policies: &[xds::route_configs::HashPolicy],
+) -> Option<u64> {
+    let mut hash: Option<u64> = None;
+
+    for hash_policy in hash_policies {
+        if let Some(new_hash) = hash_component(hash_policy, request.url, request.headers) {
+            hash = Some(match hash {
+                Some(hash) => hash.rotate_left(1) ^ new_hash,
+                None => new_hash,
+            });
+
+            if hash_policy.terminal {
+                break;
+            }
+        }
+    }
+
+    hash
+}
+
+fn hash_component(
+    policy: &xds::route_configs::HashPolicy,
+    url: &crate::Url,
+    headers: &http::HeaderMap,
+) -> Option<u64> {
+    use crate::hash::thread_local_xxhash;
+    use xds::route_configs::RequestHasher;
+
+    match &policy.hasher {
+        RequestHasher::Header { name } => {
+            let mut header_values: Vec<_> = headers
+                .get_all(name)
+                .iter()
+                .map(http::HeaderValue::as_bytes)
+                .collect();
+
+            if header_values.is_empty() {
+                None
+            } else {
+                // sort values so that "foo,bar" and "bar,foo" hash to the same value
+                header_values.sort();
+                Some(thread_local_xxhash::hash_iter(header_values))
+            }
+        }
+        RequestHasher::QueryParameter { ref name } => url.query().map(|query| {
+            let matching_vals = form_urlencoded::parse(query.as_bytes())
+                .filter_map(|(param, value)| (&param == name).then_some(value));
+            thread_local_xxhash::hash_iter(matching_vals)
+        }),
+    }
 }
 
 /// generate a URL search path for this url.
@@ -900,402 +896,402 @@ mod test {
         );
     }
 
-    #[track_caller]
-    fn assert_resolve_routes(cache: &impl ConfigCache, request: HttpRequest<'_>) -> ResolvedRoute {
-        resolve_routes(cache, Trace::new(), request, None, &SearchConfig::default())
-            .now_or_never()
-            .unwrap()
-            .unwrap()
-    }
+    // #[track_caller]
+    // fn assert_resolve_routes(cache: &impl ConfigCache, request: HttpRequest<'_>) -> ResolvedRoute {
+    //     resolve_routes(cache, Trace::new(), request, None, &SearchConfig::default())
+    //         .now_or_never()
+    //         .unwrap()
+    //         .unwrap()
+    // }
 
-    #[track_caller]
-    fn assert_resolve_err(cache: &impl ConfigCache, request: HttpRequest<'_>) -> crate::Error {
-        resolve_routes(cache, Trace::new(), request, None, &SearchConfig::default())
-            .now_or_never()
-            .unwrap()
-            .unwrap_err()
-    }
+    // #[track_caller]
+    // fn assert_resolve_err(cache: &impl ConfigCache, request: HttpRequest<'_>) -> crate::Error {
+    //     resolve_routes(cache, Trace::new(), request, None, &SearchConfig::default())
+    //         .now_or_never()
+    //         .unwrap()
+    //         .unwrap_err()
+    // }
 
-    #[test]
-    fn test_resolve_passthrough_route() {
-        let svc = Service::dns("example.com").unwrap();
+    // #[test]
+    // fn test_resolve_passthrough_route() {
+    //     let svc = Service::dns("example.com").unwrap();
 
-        let routes = StaticConfig::new(
-            vec![Route::passthrough_route(
-                Name::from_static("example"),
-                svc.clone(),
-            )],
-            vec![],
-        );
+    //     let routes = StaticConfig::new(
+    //         vec![Route::passthrough_route(
+    //             Name::from_static("example"),
+    //             svc.clone(),
+    //         )],
+    //         vec![],
+    //     );
 
-        // check with no port
-        let url = Url::from_str("http://example.com/test-path").unwrap();
-        let headers = http::HeaderMap::default();
-        let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
+    //     // check with no port
+    //     let url = Url::from_str("http://example.com/test-path").unwrap();
+    //     let headers = http::HeaderMap::default();
+    //     let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
 
-        let resolved = assert_resolve_routes(&routes, request);
-        assert_eq!(resolved.backend, svc.as_backend_id(80));
+    //     let resolved = assert_resolve_routes(&routes, request);
+    //     assert_eq!(resolved.backend, svc.as_backend_id(80));
 
-        // check with explicit ports
-        for port in [443, 8008] {
-            let url = Url::from_str(&format!("http://example.com:{port}/test-path")).unwrap();
-            let headers = http::HeaderMap::default();
-            let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
+    //     // check with explicit ports
+    //     for port in [443, 8008] {
+    //         let url = Url::from_str(&format!("http://example.com:{port}/test-path")).unwrap();
+    //         let headers = http::HeaderMap::default();
+    //         let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
 
-            let resolved = assert_resolve_routes(&routes, request);
-            assert_eq!(resolved.backend, svc.as_backend_id(port));
-        }
-    }
+    //         let resolved = assert_resolve_routes(&routes, request);
+    //         assert_eq!(resolved.backend, svc.as_backend_id(port));
+    //     }
+    // }
 
-    #[test]
-    fn test_resolve_route_no_rules() {
-        let route = Route {
-            id: Name::from_static("no-rules"),
-            hostnames: vec![Hostname::from_static("example.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![],
-        };
+    // #[test]
+    // fn test_resolve_route_no_rules() {
+    //     let route = Route {
+    //         id: Name::from_static("no-rules"),
+    //         hostnames: vec![Hostname::from_static("example.com").into()],
+    //         ports: vec![],
+    //         tags: Default::default(),
+    //         rules: vec![],
+    //     };
 
-        let routes = StaticConfig::new(vec![route], vec![]);
+    //     let routes = StaticConfig::new(vec![route], vec![]);
 
-        let url = Url::from_str("http://example.com:3214/users/123").unwrap();
-        let headers = http::HeaderMap::default();
-        let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
+    //     let url = Url::from_str("http://example.com:3214/users/123").unwrap();
+    //     let headers = http::HeaderMap::default();
+    //     let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
 
-        let err = assert_resolve_err(&routes, request);
-        assert!(err.to_string().contains("no rules matched the request"));
-        assert!(!err.is_temporary());
-    }
+    //     let err = assert_resolve_err(&routes, request);
+    //     assert!(err.to_string().contains("no rules matched the request"));
+    //     assert!(!err.is_temporary());
+    // }
 
-    #[test]
-    fn test_resolve_route_no_rules_with_search_config() {
-        let route = Route {
-            id: Name::from_static("no-rules"),
-            hostnames: vec![Hostname::from_static("example.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![],
-        };
+    // #[test]
+    // fn test_resolve_route_no_rules_with_search_config() {
+    //     let route = Route {
+    //         id: Name::from_static("no-rules"),
+    //         hostnames: vec![Hostname::from_static("example.com").into()],
+    //         ports: vec![],
+    //         tags: Default::default(),
+    //         rules: vec![],
+    //     };
 
-        let routes = StaticConfig::new(vec![route], vec![]);
+    //     let routes = StaticConfig::new(vec![route], vec![]);
 
-        let url = Url::from_str("http://example.com:3214/users/123").unwrap();
-        let headers = http::HeaderMap::default();
-        let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
+    //     let url = Url::from_str("http://example.com:3214/users/123").unwrap();
+    //     let headers = http::HeaderMap::default();
+    //     let request = HttpRequest::from_parts(&http::Method::GET, &url, &headers).unwrap();
 
-        let err = resolve_routes(
-            &routes,
-            Trace::new(),
-            request,
-            None,
-            &SearchConfig::new(2, vec![Hostname::from_static("example.com")]),
-        )
-        .now_or_never()
-        .unwrap()
-        .unwrap_err();
+    //     let err = resolve_routes(
+    //         &routes,
+    //         Trace::new(),
+    //         request,
+    //         None,
+    //         &SearchConfig::new(2, vec![Hostname::from_static("example.com")]),
+    //     )
+    //     .now_or_never()
+    //     .unwrap()
+    //     .unwrap_err();
 
-        assert!(err.to_string().contains("no rules matched the request"));
-        assert!(!err.is_temporary());
-    }
+    //     assert!(err.to_string().contains("no rules matched the request"));
+    //     assert!(!err.is_temporary());
+    // }
 
-    #[test]
-    fn test_resolve_route_no_backends() {
-        let route = Route {
-            id: Name::from_static("no-backends"),
-            hostnames: vec![Hostname::from_static("example.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![RouteRule {
-                matches: vec![RouteMatch {
-                    path: Some(PathMatch::Prefix {
-                        value: "".to_string(),
-                    }),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }],
-        };
+    // #[test]
+    // fn test_resolve_route_no_backends() {
+    //     let route = Route {
+    //         id: Name::from_static("no-backends"),
+    //         hostnames: vec![Hostname::from_static("example.com").into()],
+    //         ports: vec![],
+    //         tags: Default::default(),
+    //         rules: vec![RouteRule {
+    //             matches: vec![RouteMatch {
+    //                 path: Some(PathMatch::Prefix {
+    //                     value: "".to_string(),
+    //                 }),
+    //                 ..Default::default()
+    //             }],
+    //             ..Default::default()
+    //         }],
+    //     };
 
-        let routes = StaticConfig::new(vec![route], vec![]);
+    //     let routes = StaticConfig::new(vec![route], vec![]);
 
-        for port in [80, 7887] {
-            let method = &http::Method::GET;
-            let url = &Url::from_str(&format!("http://example.com:{port}/users/123")).unwrap();
-            let headers = &http::HeaderMap::default();
-            let request = HttpRequest::from_parts(method, url, headers).unwrap();
+    //     for port in [80, 7887] {
+    //         let method = &http::Method::GET;
+    //         let url = &Url::from_str(&format!("http://example.com:{port}/users/123")).unwrap();
+    //         let headers = &http::HeaderMap::default();
+    //         let request = HttpRequest::from_parts(method, url, headers).unwrap();
 
-            let err = assert_resolve_err(&routes, request);
-            assert_eq!(err.to_string(), "invalid route configuration");
-            assert!(!err.is_temporary());
-        }
-    }
+    //         let err = assert_resolve_err(&routes, request);
+    //         assert_eq!(err.to_string(), "invalid route configuration");
+    //         assert!(!err.is_temporary());
+    //     }
+    // }
 
-    #[test]
-    fn test_resolve_path_match() {
-        let backend_one = Service::kube("web", "svc1").unwrap();
-        let backend_two = Service::kube("web", "svc2").unwrap();
+    // #[test]
+    // fn test_resolve_path_match() {
+    //     let backend_one = Service::kube("web", "svc1").unwrap();
+    //     let backend_two = Service::kube("web", "svc2").unwrap();
 
-        let route = Route {
-            id: Name::from_static("path-match"),
-            hostnames: vec![Hostname::from_static("example.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![
-                RouteRule {
-                    matches: vec![RouteMatch {
-                        path: Some(PathMatch::Prefix {
-                            value: "/users".to_string(),
-                        }),
-                        ..Default::default()
-                    }],
-                    backends: vec![BackendRef {
-                        weight: 1,
-                        service: backend_one.clone(),
-                        port: Some(8910),
-                    }],
-                    ..Default::default()
-                },
-                RouteRule {
-                    backends: vec![BackendRef {
-                        weight: 1,
-                        service: backend_two.clone(),
-                        port: Some(8919),
-                    }],
-                    ..Default::default()
-                },
-            ],
-        };
+    //     let route = Route {
+    //         id: Name::from_static("path-match"),
+    //         hostnames: vec![Hostname::from_static("example.com").into()],
+    //         ports: vec![],
+    //         tags: Default::default(),
+    //         rules: vec![
+    //             RouteRule {
+    //                 matches: vec![RouteMatch {
+    //                     path: Some(PathMatch::Prefix {
+    //                         value: "/users".to_string(),
+    //                     }),
+    //                     ..Default::default()
+    //                 }],
+    //                 backends: vec![BackendRef {
+    //                     weight: 1,
+    //                     service: backend_one.clone(),
+    //                     port: Some(8910),
+    //                 }],
+    //                 ..Default::default()
+    //             },
+    //             RouteRule {
+    //                 backends: vec![BackendRef {
+    //                     weight: 1,
+    //                     service: backend_two.clone(),
+    //                     port: Some(8919),
+    //                 }],
+    //                 ..Default::default()
+    //             },
+    //         ],
+    //     };
 
-        let routes = StaticConfig::new(vec![route], vec![]);
+    //     let routes = StaticConfig::new(vec![route], vec![]);
 
-        let url = &Url::from_str("http://example.com/test-path").unwrap();
-        let headers = &http::HeaderMap::default();
-        let request = HttpRequest::from_parts(&http::Method::GET, url, headers).unwrap();
-        let resolved = assert_resolve_routes(&routes, request);
+    //     let url = &Url::from_str("http://example.com/test-path").unwrap();
+    //     let headers = &http::HeaderMap::default();
+    //     let request = HttpRequest::from_parts(&http::Method::GET, url, headers).unwrap();
+    //     let resolved = assert_resolve_routes(&routes, request);
 
-        // should match the fallthrough rule
-        assert_eq!(resolved.rule, 1);
-        assert_eq!(resolved.backend, backend_two.as_backend_id(8919));
+    //     // should match the fallthrough rule
+    //     assert_eq!(resolved.rule, 1);
+    //     assert_eq!(resolved.backend, backend_two.as_backend_id(8919));
 
-        let url = Url::from_str("http://example.com/users/123").unwrap();
-        let headers = &http::HeaderMap::default();
-        let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
-        let resolved = assert_resolve_routes(&routes, request);
+    //     let url = Url::from_str("http://example.com/users/123").unwrap();
+    //     let headers = &http::HeaderMap::default();
+    //     let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
+    //     let resolved = assert_resolve_routes(&routes, request);
 
-        // should match the first rule, with the path match
-        assert_eq!(resolved.backend, backend_one.as_backend_id(8910));
-        assert!(!resolved.route.rules[resolved.rule].matches.is_empty());
+    //     // should match the first rule, with the path match
+    //     assert_eq!(resolved.backend, backend_one.as_backend_id(8910));
+    //     assert!(!resolved.route.rules[resolved.rule].matches.is_empty());
 
-        let url = Url::from_str("http://example.com/users/123").unwrap();
-        let headers = &http::HeaderMap::default();
-        let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
+    //     let url = Url::from_str("http://example.com/users/123").unwrap();
+    //     let headers = &http::HeaderMap::default();
+    //     let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-        let resolved = assert_resolve_routes(&routes, request);
-        // should match the first rule, with the path match
-        assert_eq!(resolved.rule, 0);
-        assert_eq!(resolved.backend, backend_one.as_backend_id(8910));
-    }
+    //     let resolved = assert_resolve_routes(&routes, request);
+    //     // should match the first rule, with the path match
+    //     assert_eq!(resolved.rule, 0);
+    //     assert_eq!(resolved.backend, backend_one.as_backend_id(8910));
+    // }
 
-    #[test]
-    fn test_resolve_query_match() {
-        let backend_one = Service::kube("web", "svc1").unwrap();
-        let backend_two = Service::kube("web", "svc2").unwrap();
+    // #[test]
+    // fn test_resolve_query_match() {
+    //     let backend_one = Service::kube("web", "svc1").unwrap();
+    //     let backend_two = Service::kube("web", "svc2").unwrap();
 
-        let route = Route {
-            id: Name::from_static("query-match"),
-            hostnames: vec![Hostname::from_static("example.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![
-                RouteRule {
-                    matches: vec![RouteMatch {
-                        query_params: vec![
-                            QueryParamMatch::Exact {
-                                name: "qp1".to_string(),
-                                value: "potato".to_string(),
-                            },
-                            QueryParamMatch::RegularExpression {
-                                name: "qp2".to_string(),
-                                value: Regex::from_str("foo.*bar").unwrap(),
-                            },
-                        ],
-                        ..Default::default()
-                    }],
-                    backends: vec![BackendRef {
-                        weight: 1,
-                        service: backend_one.clone(),
-                        port: Some(8910),
-                    }],
-                    ..Default::default()
-                },
-                RouteRule {
-                    backends: vec![BackendRef {
-                        weight: 1,
-                        service: backend_two.clone(),
-                        port: Some(8919),
-                    }],
-                    ..Default::default()
-                },
-            ],
-        };
+    //     let route = Route {
+    //         id: Name::from_static("query-match"),
+    //         hostnames: vec![Hostname::from_static("example.com").into()],
+    //         ports: vec![],
+    //         tags: Default::default(),
+    //         rules: vec![
+    //             RouteRule {
+    //                 matches: vec![RouteMatch {
+    //                     query_params: vec![
+    //                         QueryParamMatch::Exact {
+    //                             name: "qp1".to_string(),
+    //                             value: "potato".to_string(),
+    //                         },
+    //                         QueryParamMatch::RegularExpression {
+    //                             name: "qp2".to_string(),
+    //                             value: Regex::from_str("foo.*bar").unwrap(),
+    //                         },
+    //                     ],
+    //                     ..Default::default()
+    //                 }],
+    //                 backends: vec![BackendRef {
+    //                     weight: 1,
+    //                     service: backend_one.clone(),
+    //                     port: Some(8910),
+    //                 }],
+    //                 ..Default::default()
+    //             },
+    //             RouteRule {
+    //                 backends: vec![BackendRef {
+    //                     weight: 1,
+    //                     service: backend_two.clone(),
+    //                     port: Some(8919),
+    //                 }],
+    //                 ..Default::default()
+    //             },
+    //         ],
+    //     };
 
-        let routes = StaticConfig::new(vec![route], vec![]);
+    //     let routes = StaticConfig::new(vec![route], vec![]);
 
-        let wont_match = [
-            "http://example.com?qp1=tomato",
-            "http://example.com?qp1=potatooo",
-            "http://example.com?qp2=barfoo",
-            "http://example.com?qp2=fobar",
-            "http://example.com?qp1=potat&qp2=foobar",
-            "http://example.com?qp1=potato&qp2=fbar",
-        ];
+    //     let wont_match = [
+    //         "http://example.com?qp1=tomato",
+    //         "http://example.com?qp1=potatooo",
+    //         "http://example.com?qp2=barfoo",
+    //         "http://example.com?qp2=fobar",
+    //         "http://example.com?qp1=potat&qp2=foobar",
+    //         "http://example.com?qp1=potato&qp2=fbar",
+    //     ];
 
-        for url in wont_match {
-            let url = Url::from_str(url).unwrap();
-            let headers = &http::HeaderMap::default();
-            let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
+    //     for url in wont_match {
+    //         let url = Url::from_str(url).unwrap();
+    //         let headers = &http::HeaderMap::default();
+    //         let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-            let resolved = assert_resolve_routes(&routes, request);
-            // should match the fallthrough rule
-            assert_eq!(resolved.rule, 1);
-            assert_eq!(resolved.backend, backend_two.as_backend_id(8919));
-        }
+    //         let resolved = assert_resolve_routes(&routes, request);
+    //         // should match the fallthrough rule
+    //         assert_eq!(resolved.rule, 1);
+    //         assert_eq!(resolved.backend, backend_two.as_backend_id(8919));
+    //     }
 
-        let will_match = [
-            "http://example.com?qp1=potato&qp2=foobar",
-            "http://example.com?qp1=potato&qp2=foobazbar",
-            "http://example.com?qp1=potato&qp2=fooooooooooooooobar",
-        ];
+    //     let will_match = [
+    //         "http://example.com?qp1=potato&qp2=foobar",
+    //         "http://example.com?qp1=potato&qp2=foobazbar",
+    //         "http://example.com?qp1=potato&qp2=fooooooooooooooobar",
+    //     ];
 
-        for url in will_match {
-            let url = Url::from_str(url).unwrap();
-            let headers = &http::HeaderMap::default();
-            let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
+    //     for url in will_match {
+    //         let url = Url::from_str(url).unwrap();
+    //         let headers = &http::HeaderMap::default();
+    //         let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-            let resolved = assert_resolve_routes(&routes, request);
-            // should match one of the query matches
-            assert_eq!(
-                (resolved.rule, &resolved.backend),
-                (0, &backend_one.as_backend_id(8910)),
-                "should match the first rule: {url}"
-            );
-        }
-    }
+    //         let resolved = assert_resolve_routes(&routes, request);
+    //         // should match one of the query matches
+    //         assert_eq!(
+    //             (resolved.rule, &resolved.backend),
+    //             (0, &backend_one.as_backend_id(8910)),
+    //             "should match the first rule: {url}"
+    //         );
+    //     }
+    // }
 
-    #[test]
-    fn test_resolve_routes_resolves_ndots() {
-        let backend = Service::kube("web", "svc1").unwrap();
+    // #[test]
+    // fn test_resolve_routes_resolves_ndots() {
+    //     let backend = Service::kube("web", "svc1").unwrap();
 
-        let route = Route {
-            id: Name::from_static("ndots-match"),
-            hostnames: vec![Hostname::from_static("example.foo.bar.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![RouteRule {
-                matches: vec![],
-                backends: vec![BackendRef {
-                    weight: 1,
-                    service: backend.clone(),
-                    port: Some(8910),
-                }],
-                ..Default::default()
-            }],
-        };
+    //     let route = Route {
+    //         id: Name::from_static("ndots-match"),
+    //         hostnames: vec![Hostname::from_static("example.foo.bar.com").into()],
+    //         ports: vec![],
+    //         tags: Default::default(),
+    //         rules: vec![RouteRule {
+    //             matches: vec![],
+    //             backends: vec![BackendRef {
+    //                 weight: 1,
+    //                 service: backend.clone(),
+    //                 port: Some(8910),
+    //             }],
+    //             ..Default::default()
+    //         }],
+    //     };
 
-        let routes = StaticConfig::new(vec![route], vec![]);
+    //     let routes = StaticConfig::new(vec![route], vec![]);
 
-        let will_match = [
-            "http://example",
-            "http://example.foo",
-            "http://example.foo.bar",
-            "http://example.foo.bar.com",
-        ];
-        let will_match_hostnames = vec![
-            Hostname::from_static("foo.bar.com"),
-            Hostname::from_static("bar.com"),
-            Hostname::from_static("com"),
-        ];
+    //     let will_match = [
+    //         "http://example",
+    //         "http://example.foo",
+    //         "http://example.foo.bar",
+    //         "http://example.foo.bar.com",
+    //     ];
+    //     let will_match_hostnames = vec![
+    //         Hostname::from_static("foo.bar.com"),
+    //         Hostname::from_static("bar.com"),
+    //         Hostname::from_static("com"),
+    //     ];
 
-        for url in will_match {
-            let url = crate::Url::from_str(url).unwrap();
-            let headers = &http::HeaderMap::default();
-            let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
+    //     for url in will_match {
+    //         let url = crate::Url::from_str(url).unwrap();
+    //         let headers = &http::HeaderMap::default();
+    //         let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-            let resolved = resolve_routes(
-                &routes,
-                Trace::new(),
-                request,
-                None,
-                &SearchConfig::new(3, will_match_hostnames.clone()),
-            )
-            .now_or_never()
-            .unwrap()
-            .unwrap();
+    //         let resolved = resolve_routes(
+    //             &routes,
+    //             Trace::new(),
+    //             request,
+    //             None,
+    //             &SearchConfig::new(3, will_match_hostnames.clone()),
+    //         )
+    //         .now_or_never()
+    //         .unwrap()
+    //         .unwrap();
 
-            // should match one of the query matches
-            assert_eq!(
-                (resolved.rule, &resolved.backend),
-                (0, &backend.as_backend_id(8910)),
-                "should match the first rule: {url}"
-            );
-        }
-    }
+    //         // should match one of the query matches
+    //         assert_eq!(
+    //             (resolved.rule, &resolved.backend),
+    //             (0, &backend.as_backend_id(8910)),
+    //             "should match the first rule: {url}"
+    //         );
+    //     }
+    // }
 
-    #[test]
-    fn test_resolve_routes_resolves_ndots_no_search() {
-        let backend = Service::kube("web", "svc1").unwrap();
+    // #[test]
+    // fn test_resolve_routes_resolves_ndots_no_search() {
+    //     let backend = Service::kube("web", "svc1").unwrap();
 
-        let will_match = [
-            "http://example.com",
-            "http://example.foo.com",
-            "http://example.foo.bar.com",
-        ];
+    //     let will_match = [
+    //         "http://example.com",
+    //         "http://example.foo.com",
+    //         "http://example.foo.bar.com",
+    //     ];
 
-        let route = Route {
-            id: Name::from_static("ndots-match"),
-            hostnames: vec![
-                Hostname::from_static("example.com").into(),
-                Hostname::from_static("example.foo.com").into(),
-                Hostname::from_static("example.foo.bar.com").into(),
-            ],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![RouteRule {
-                matches: vec![],
-                backends: vec![BackendRef {
-                    weight: 1,
-                    service: backend.clone(),
-                    port: Some(8910),
-                }],
-                ..Default::default()
-            }],
-        };
+    //     let route = Route {
+    //         id: Name::from_static("ndots-match"),
+    //         hostnames: vec![
+    //             Hostname::from_static("example.com").into(),
+    //             Hostname::from_static("example.foo.com").into(),
+    //             Hostname::from_static("example.foo.bar.com").into(),
+    //         ],
+    //         ports: vec![],
+    //         tags: Default::default(),
+    //         rules: vec![RouteRule {
+    //             matches: vec![],
+    //             backends: vec![BackendRef {
+    //                 weight: 1,
+    //                 service: backend.clone(),
+    //                 port: Some(8910),
+    //             }],
+    //             ..Default::default()
+    //         }],
+    //     };
 
-        let routes = StaticConfig::new(vec![route], vec![]);
+    //     let routes = StaticConfig::new(vec![route], vec![]);
 
-        for url in will_match {
-            let url = crate::Url::from_str(url).unwrap();
-            let headers = &http::HeaderMap::default();
-            let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
+    //     for url in will_match {
+    //         let url = crate::Url::from_str(url).unwrap();
+    //         let headers = &http::HeaderMap::default();
+    //         let request = HttpRequest::from_parts(&http::Method::GET, &url, headers).unwrap();
 
-            let resolved = resolve_routes(
-                &routes,
-                Trace::new(),
-                request,
-                None,
-                &SearchConfig::new(3, vec![]),
-            )
-            .now_or_never()
-            .unwrap()
-            .unwrap();
+    //         let resolved = resolve_routes(
+    //             &routes,
+    //             Trace::new(),
+    //             request,
+    //             None,
+    //             &SearchConfig::new(3, vec![]),
+    //         )
+    //         .now_or_never()
+    //         .unwrap()
+    //         .unwrap();
 
-            // should match one of the query matches
-            assert_eq!(
-                (resolved.rule, &resolved.backend),
-                (0, &backend.as_backend_id(8910)),
-                "should match the first rule: {url}"
-            );
-        }
-    }
+    //         // should match one of the query matches
+    //         assert_eq!(
+    //             (resolved.rule, &resolved.backend),
+    //             (0, &backend.as_backend_id(8910)),
+    //             "should match the first rule: {url}"
+    //         );
+    //     }
+    // }
 }

--- a/crates/junction-core/src/dns.rs
+++ b/crates/junction-core/src/dns.rs
@@ -27,7 +27,7 @@ use junction_api::Hostname;
 use rand::Rng;
 use tokio::sync::Notify;
 
-use crate::endpoints::EndpointGroup;
+use crate::xds::endpoints::EndpointGroup;
 
 /// An error that occurred while parsing a system DNS configuration.
 #[derive(Debug, thiserror::Error)]

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -1,10 +1,6 @@
-use junction_api::{
-    backend::BackendId,
-    http::{RouteRetry, RouteTimeouts},
-};
-use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
 
-use crate::{error::Trace, hash::thread_local_xxhash, HttpResult};
+use crate::{error::Trace, xds, HttpRequest, HttpResult};
 
 // TODO: move to Client? all these fields can be private then.
 // TODO: this is way more than just a resolved endpoint, it's the whole request
@@ -16,14 +12,17 @@ pub struct Endpoint {
     pub(crate) method: http::Method,
     pub(crate) url: crate::Url,
     pub(crate) headers: http::HeaderMap,
+    pub(crate) request_hash: u64,
 
     // matched route info
     // TODO: do we need the matched route here???? is it enough to have the name and
     // version? is it enough to have it in the trace?
-    pub(crate) backend: BackendId,
     pub(crate) address: SocketAddr,
-    pub(crate) timeouts: Option<RouteTimeouts>,
-    pub(crate) retry: Option<RouteRetry>,
+    pub(crate) cluster_name: xds::ResourceName,
+
+    // FIXME: figure out what the type is here and expose it
+    // pub(crate) timeouts: Option<RouteTimeouts>,
+    // pub(crate) retry: Option<RouteRetry>,
 
     // debugging data
     pub(crate) trace: Trace,
@@ -47,33 +46,34 @@ impl Endpoint {
         self.address
     }
 
-    pub fn timeouts(&self) -> &Option<RouteTimeouts> {
-        &self.timeouts
-    }
+    // pub fn timeouts(&self) -> &Option<RouteTimeouts> {
+    //     &self.timeouts
+    // }
 
-    pub fn retry(&self) -> &Option<RouteRetry> {
-        &self.retry
-    }
+    // pub fn retry(&self) -> &Option<RouteRetry> {
+    //     &self.retry
+    // }
 
     pub(crate) fn should_retry(&self, result: HttpResult) -> bool {
-        let Some(retry) = &self.retry else {
-            return false;
-        };
-        let Some(allowed) = &retry.attempts else {
-            return false;
-        };
-        let allowed = *allowed as usize;
+        todo!()
+        // let Some(retry) = &self.retry else {
+        //     return false;
+        // };
+        // let Some(allowed) = &retry.attempts else {
+        //     return false;
+        // };
+        // let allowed = *allowed as usize;
 
-        match result {
-            HttpResult::StatusError(code) if !retry.codes.contains(&code.as_u16()) => return false,
-            _ => (),
-        }
+        // match result {
+        //     HttpResult::StatusError(code) if !retry.codes.contains(&code.as_u16()) => return false,
+        //     _ => (),
+        // }
 
-        // total number of attempts taken is history + 1 because we include the
-        // the current addr as an attempt.
-        let attempts = self.previous_addrs.len() + 1;
+        // // total number of attempts taken is history + 1 because we include the
+        // // the current addr as an attempt.
+        // let attempts = self.previous_addrs.len() + 1;
 
-        attempts < allowed
+        // attempts < allowed
     }
 
     // FIXME: lol
@@ -101,167 +101,86 @@ impl Endpoint {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum Locality {
-    Unknown,
-    #[allow(unused)]
-    Known(LocalityInfo),
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct LocalityInfo {
-    pub(crate) region: String,
-    pub(crate) zone: String,
-}
-
-/// A snapshot of endpoint data.
-pub struct EndpointIter {
-    endpoint_group: Arc<EndpointGroup>,
-}
-
-impl From<Arc<EndpointGroup>> for EndpointIter {
-    fn from(endpoint_group: Arc<EndpointGroup>) -> Self {
-        Self { endpoint_group }
-    }
-}
-
-// TODO: add a way to see endpoints grouped by locality. have to decide how
-// to publicly expose Locality.
-impl EndpointIter {
-    /// Iterate over all of the addresses in this group, without any locality
-    /// information.
-    pub fn addrs(&self) -> impl Iterator<Item = &SocketAddr> {
-        self.endpoint_group.iter()
-    }
-}
-
-#[derive(Debug, Default, Hash, PartialEq, Eq)]
-pub(crate) struct EndpointGroup {
-    pub(crate) hash: u64,
-    endpoints: BTreeMap<Locality, Vec<SocketAddr>>,
-}
-
-impl EndpointGroup {
-    pub(crate) fn new(endpoints: BTreeMap<Locality, Vec<SocketAddr>>) -> Self {
-        let hash = thread_local_xxhash::hash(&endpoints);
-        Self { hash, endpoints }
-    }
-
-    pub(crate) fn from_dns_addrs(addrs: impl IntoIterator<Item = SocketAddr>) -> Self {
-        let mut endpoints = BTreeMap::new();
-        let endpoint_addrs = addrs.into_iter().collect();
-        endpoints.insert(Locality::Unknown, endpoint_addrs);
-
-        Self::new(endpoints)
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.endpoints.values().map(|v| v.len()).sum()
-    }
-
-    /// Returns an iterator over all endpoints in the group.
-    ///
-    /// Iteration order is guaranteed to be stable as long as the EndpointGroup is
-    /// not modified, and guaranteed to consecutively produce all addresses in a single
-    /// locality.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &SocketAddr> {
-        self.endpoints.values().flatten()
-    }
-
-    /// Return the nth address in this group. The order
-    pub(crate) fn nth(&self, n: usize) -> Option<&SocketAddr> {
-        let mut n = n;
-        for endpoints in self.endpoints.values() {
-            if n < endpoints.len() {
-                return Some(&endpoints[n]);
-            }
-            n -= endpoints.len();
-        }
-
-        None
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use std::net::Ipv4Addr;
+    // use std::net::Ipv4Addr;
 
-    use http::StatusCode;
-    use junction_api::{Duration, Service};
+    // use http::StatusCode;
+    // use junction_api::{Duration, Service};
 
-    use crate::Url;
+    // use crate::Url;
 
-    use super::*;
+    // use super::*;
 
-    #[test]
-    fn test_endpoint_should_retry_no_policy() {
-        let mut endpoint = new_endpoint();
-        endpoint.retry = None;
+    // #[test]
+    // fn test_endpoint_should_retry_no_policy() {
+    //     let mut endpoint = new_endpoint();
+    //     endpoint.retry = None;
 
-        assert!(!endpoint.should_retry(HttpResult::StatusFailed));
-        assert!(!endpoint.should_retry(HttpResult::StatusError(
-            http::StatusCode::SERVICE_UNAVAILABLE
-        )));
-    }
+    //     assert!(!endpoint.should_retry(HttpResult::StatusFailed));
+    //     assert!(!endpoint.should_retry(HttpResult::StatusError(
+    //         http::StatusCode::SERVICE_UNAVAILABLE
+    //     )));
+    // }
 
-    #[test]
-    fn test_endpoint_should_retry_with_policy() {
-        let mut endpoint = new_endpoint();
-        endpoint.retry = Some(RouteRetry {
-            codes: vec![StatusCode::BAD_REQUEST.as_u16()],
-            attempts: Some(3),
-            backoff: Some(Duration::from_secs(2)),
-        });
+    // #[test]
+    // fn test_endpoint_should_retry_with_policy() {
+    //     let mut endpoint = new_endpoint();
+    //     endpoint.retry = Some(RouteRetry {
+    //         codes: vec![StatusCode::BAD_REQUEST.as_u16()],
+    //         attempts: Some(3),
+    //         backoff: Some(Duration::from_secs(2)),
+    //     });
 
-        assert!(endpoint.should_retry(HttpResult::StatusFailed));
-        assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
-        assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
-    }
+    //     assert!(endpoint.should_retry(HttpResult::StatusFailed));
+    //     assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
+    //     assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
+    // }
 
-    #[test]
-    fn test_endpoint_should_retry_with_history() {
-        let mut endpoint = new_endpoint();
-        endpoint.retry = Some(RouteRetry {
-            codes: vec![StatusCode::BAD_REQUEST.as_u16()],
-            attempts: Some(3),
-            backoff: Some(Duration::from_secs(2)),
-        });
+    // #[test]
+    // fn test_endpoint_should_retry_with_history() {
+    //     let mut endpoint = new_endpoint();
+    //     endpoint.retry = Some(RouteRetry {
+    //         codes: vec![StatusCode::BAD_REQUEST.as_u16()],
+    //         attempts: Some(3),
+    //         backoff: Some(Duration::from_secs(2)),
+    //     });
 
-        // first endpoint was the first attempt
-        assert!(endpoint.should_retry(HttpResult::StatusFailed));
-        assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
-        assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
+    //     // first endpoint was the first attempt
+    //     assert!(endpoint.should_retry(HttpResult::StatusFailed));
+    //     assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
+    //     assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
 
-        // add on ip to history - this is the second attempt
-        endpoint
-            .previous_addrs
-            .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
-        assert!(endpoint.should_retry(HttpResult::StatusFailed),);
-        assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)),);
+    //     // add on ip to history - this is the second attempt
+    //     endpoint
+    //         .previous_addrs
+    //         .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
+    //     assert!(endpoint.should_retry(HttpResult::StatusFailed),);
+    //     assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)),);
 
-        // two ips in history and one current ip, three attempts have been made, shouldn't retry again
-        endpoint
-            .previous_addrs
-            .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
-        assert!(!endpoint.should_retry(HttpResult::StatusFailed));
-        assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
-    }
+    //     // two ips in history and one current ip, three attempts have been made, shouldn't retry again
+    //     endpoint
+    //         .previous_addrs
+    //         .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
+    //     assert!(!endpoint.should_retry(HttpResult::StatusFailed));
+    //     assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
+    // }
 
-    fn new_endpoint() -> Endpoint {
-        let url: Url = "http://example.com".parse().unwrap();
-        let backend = Service::dns(url.hostname()).unwrap().as_backend_id(443);
-        let address = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443);
+    // fn new_endpoint() -> Endpoint {
+    //     let url: Url = "http://example.com".parse().unwrap();
+    //     let backend = Service::dns(url.hostname()).unwrap().as_backend_id(443);
+    //     let address = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443);
 
-        Endpoint {
-            method: http::Method::GET,
-            url,
-            headers: Default::default(),
-            backend,
-            address,
-            timeouts: None,
-            retry: None,
-            trace: Trace::new(),
-            previous_addrs: vec![],
-        }
-    }
+    //     Endpoint {
+    //         method: http::Method::GET,
+    //         url,
+    //         headers: Default::default(),
+    //         backend,
+    //         address,
+    //         timeouts: None,
+    //         retry: None,
+    //         trace: Trace::new(),
+    //         previous_addrs: vec![],
+    //     }
+    // }
 }

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -12,16 +12,12 @@ pub(crate) mod rand;
 
 mod endpoints;
 pub use endpoints::Endpoint;
-use endpoints::EndpointGroup;
 
 mod client;
 mod dns;
-mod load_balancer;
 mod xds;
 
-pub use client::{
-    Client, HttpRequest, HttpResult, LbContext, ResolvedRoute, SearchConfig, SelectedEndpoint,
-};
+pub use client::{Client, HttpRequest, HttpResult, SearchConfig, SelectedEndpoint};
 use error::Trace;
 use futures::FutureExt;
 use junction_api::Name;
@@ -33,342 +29,341 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
 
-pub use crate::load_balancer::{BackendLb, LoadBalancer};
 use junction_api::backend::{Backend, LbPolicy};
 
-/// Check route resolution.
-///
-/// Resolves a route against a table of routes, returning the chosen [Route],
-/// the index of the rule that matched, and the [BackendId] selected based on
-/// the route.
-///
-/// Use this function to test routing configuration without requiring a full
-/// client or a live connection to a control plane. For actual route resolution,
-/// see [Client::resolve_http].
-pub fn check_route(
-    routes: Vec<Route>,
-    method: &http::Method,
-    url: &crate::Url,
-    headers: &http::HeaderMap,
-    search_config: Option<&SearchConfig>,
-) -> Result<ResolvedRoute> {
-    let request = client::HttpRequest::from_parts(method, url, headers)?;
-    // resolve with an empty cache and the passed config used as defaults and a
-    // no-op subscribe fn.
-    //
-    // TODO: do we actually want that or do we want to treat the passed routes
-    // as the primary config?
-    let config = StaticConfig::new(routes, Vec::new());
-    let search_config = search_config.cloned().unwrap_or_default();
+// /// Check route resolution.
+// ///
+// /// Resolves a route against a table of routes, returning the chosen [Route],
+// /// the index of the rule that matched, and the [BackendId] selected based on
+// /// the route.
+// ///
+// /// Use this function to test routing configuration without requiring a full
+// /// client or a live connection to a control plane. For actual route resolution,
+// /// see [Client::resolve_http].
+// pub fn check_route(
+//     routes: Vec<Route>,
+//     method: &http::Method,
+//     url: &crate::Url,
+//     headers: &http::HeaderMap,
+//     search_config: Option<&SearchConfig>,
+// ) -> Result<ResolvedRoute> {
+//     let request = client::HttpRequest::from_parts(method, url, headers)?;
+//     // resolve with an empty cache and the passed config used as defaults and a
+//     // no-op subscribe fn.
+//     //
+//     // TODO: do we actually want that or do we want to treat the passed routes
+//     // as the primary config?
+//     let config = StaticConfig::new(routes, Vec::new());
+//     let search_config = search_config.cloned().unwrap_or_default();
 
-    // resolve_routes is async but we know that with StaticConfig, fetching
-    // config should NEVER block. now-or-never just calls Poll with a noop
-    // waker and unwraps the result ASAP.
-    client::resolve_routes(&config, Trace::new(), request, None, &search_config)
-        .now_or_never()
-        .expect("check_route yielded unexpectedly. this is a bug in Junction, please file an issue")
-}
+//     // resolve_routes is async but we know that with StaticConfig, fetching
+//     // config should NEVER block. now-or-never just calls Poll with a noop
+//     // waker and unwraps the result ASAP.
+//     client::resolve_route(&config, Trace::new(), request, None, &search_config)
+//         .now_or_never()
+//         .expect("check_route yielded unexpectedly. this is a bug in Junction, please file an issue")
+// }
 
-pub(crate) trait ConfigCache {
-    async fn get_route<S: AsRef<str>>(&self, authority: S) -> Option<Arc<Route>>;
-    async fn get_backend(&self, target: &BackendId) -> Option<Arc<BackendLb>>;
-    async fn get_endpoints(&self, backend: &BackendId) -> Option<Arc<EndpointGroup>>;
-}
+// pub(crate) trait ConfigCache {
+//     async fn get_route<S: AsRef<str>>(&self, authority: S) -> Option<Arc<Route>>;
+//     async fn get_backend(&self, target: &BackendId) -> Option<Arc<BackendLb>>;
+//     async fn get_endpoints(&self, backend: &BackendId) -> Option<Arc<EndpointGroup>>;
+// }
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct StaticConfig {
-    pub routes: Vec<Arc<Route>>,
-    pub backends: HashMap<BackendId, Arc<BackendLb>>,
-}
+// #[derive(Clone, Debug, Default)]
+// pub(crate) struct StaticConfig {
+//     pub routes: Vec<Arc<Route>>,
+//     pub backends: HashMap<BackendId, Arc<BackendLb>>,
+// }
 
-impl StaticConfig {
-    pub(crate) fn new(routes: Vec<Route>, backends: Vec<Backend>) -> Self {
-        let routes = routes.into_iter().map(Arc::new).collect();
+// impl StaticConfig {
+//     pub(crate) fn new(routes: Vec<Route>, backends: Vec<Backend>) -> Self {
+//         let routes = routes.into_iter().map(Arc::new).collect();
 
-        let backends: HashMap<_, _> = backends
-            .into_iter()
-            .map(|config| {
-                let load_balancer = LoadBalancer::from_config(&config.lb);
-                let backend_id = config.id.clone();
-                let backend_lb = Arc::new(BackendLb {
-                    config,
-                    load_balancer,
-                });
-                (backend_id, backend_lb)
-            })
-            .collect();
+//         let backends: HashMap<_, _> = backends
+//             .into_iter()
+//             .map(|config| {
+//                 let load_balancer = LoadBalancer::from_config(&config.lb);
+//                 let backend_id = config.id.clone();
+//                 let backend_lb = Arc::new(BackendLb {
+//                     config,
+//                     load_balancer,
+//                 });
+//                 (backend_id, backend_lb)
+//             })
+//             .collect();
 
-        Self { routes, backends }
-    }
+//         Self { routes, backends }
+//     }
 
-    pub(crate) fn with_inferred(routes: Vec<Route>, backends: Vec<Backend>) -> Self {
-        let mut routes: Vec<_> = routes.into_iter().map(Arc::new).collect();
-        let mut backends: HashMap<_, _> = backends
-            .into_iter()
-            .map(|config| {
-                let load_balancer = LoadBalancer::from_config(&config.lb);
-                let backend_id = config.id.clone();
-                let backend_lb = Arc::new(BackendLb {
-                    config,
-                    load_balancer,
-                });
-                (backend_id, backend_lb)
-            })
-            .collect();
+//     pub(crate) fn with_inferred(routes: Vec<Route>, backends: Vec<Backend>) -> Self {
+//         let mut routes: Vec<_> = routes.into_iter().map(Arc::new).collect();
+//         let mut backends: HashMap<_, _> = backends
+//             .into_iter()
+//             .map(|config| {
+//                 let load_balancer = LoadBalancer::from_config(&config.lb);
+//                 let backend_id = config.id.clone();
+//                 let backend_lb = Arc::new(BackendLb {
+//                     config,
+//                     load_balancer,
+//                 });
+//                 (backend_id, backend_lb)
+//             })
+//             .collect();
 
-        // infer default backends for Routes with no specified backends.  we can
-        // only infer a backend for a backendref with a port
-        let mut inferred_backends = vec![];
-        for route in &routes {
-            for rule in &route.rules {
-                for backend_ref in &rule.backends {
-                    let Some(backend_id) = backend_ref.as_backend_id() else {
-                        continue;
-                    };
+//         // infer default backends for Routes with no specified backends.  we can
+//         // only infer a backend for a backendref with a port
+//         let mut inferred_backends = vec![];
+//         for route in &routes {
+//             for rule in &route.rules {
+//                 for backend_ref in &rule.backends {
+//                     let Some(backend_id) = backend_ref.as_backend_id() else {
+//                         continue;
+//                     };
 
-                    if backends.contains_key(&backend_id) {
-                        continue;
-                    }
+//                     if backends.contains_key(&backend_id) {
+//                         continue;
+//                     }
 
-                    let config = Backend {
-                        id: backend_id.clone(),
-                        lb: LbPolicy::default(),
-                    };
-                    let load_balancer = LoadBalancer::from_config(&config.lb);
+//                     let config = Backend {
+//                         id: backend_id.clone(),
+//                         lb: LbPolicy::default(),
+//                     };
+//                     let load_balancer = LoadBalancer::from_config(&config.lb);
 
-                    inferred_backends.push((
-                        backend_id,
-                        Arc::new(BackendLb {
-                            config,
-                            load_balancer,
-                        }),
-                    ))
-                }
-            }
-        }
+//                     inferred_backends.push((
+//                         backend_id,
+//                         Arc::new(BackendLb {
+//                             config,
+//                             load_balancer,
+//                         }),
+//                     ))
+//                 }
+//             }
+//         }
 
-        // infer default Routes for Backends. Track the set of Services
-        // referenced all Routes, and create a new passthrough for every
-        // Service that doesn't have one.
-        let mut inferred_routes = vec![];
-        let mut route_refs = HashSet::new();
-        for route in &routes {
-            for rule in &route.rules {
-                for backend_ref in &rule.backends {
-                    route_refs.insert(backend_ref.service.clone());
-                }
-            }
-        }
-        for backend in backends.values() {
-            if !route_refs.contains(&backend.config.id.service) {
-                let route = Route::passthrough_route(
-                    Name::from_static("inferred"),
-                    backend.config.id.service.clone(),
-                );
-                inferred_routes.push(Arc::new(route));
-                route_refs.insert(backend.config.id.service.clone());
-            }
-        }
+//         // infer default Routes for Backends. Track the set of Services
+//         // referenced all Routes, and create a new passthrough for every
+//         // Service that doesn't have one.
+//         let mut inferred_routes = vec![];
+//         let mut route_refs = HashSet::new();
+//         for route in &routes {
+//             for rule in &route.rules {
+//                 for backend_ref in &rule.backends {
+//                     route_refs.insert(backend_ref.service.clone());
+//                 }
+//             }
+//         }
+//         for backend in backends.values() {
+//             if !route_refs.contains(&backend.config.id.service) {
+//                 let route = Route::passthrough_route(
+//                     Name::from_static("inferred"),
+//                     backend.config.id.service.clone(),
+//                 );
+//                 inferred_routes.push(Arc::new(route));
+//                 route_refs.insert(backend.config.id.service.clone());
+//             }
+//         }
 
-        routes.extend(inferred_routes);
-        backends.extend(inferred_backends);
+//         routes.extend(inferred_routes);
+//         backends.extend(inferred_backends);
 
-        Self { routes, backends }
-    }
-}
+//         Self { routes, backends }
+//     }
+// }
 
-impl ConfigCache for StaticConfig {
-    async fn get_route<S: AsRef<str>>(&self, authority: S) -> Option<Arc<Route>> {
-        let (host, port) = authority.as_ref().split_once(":")?;
-        let port = port.parse().ok()?;
+// impl ConfigCache for StaticConfig {
+//     async fn get_route<S: AsRef<str>>(&self, authority: S) -> Option<Arc<Route>> {
+//         let (host, port) = authority.as_ref().split_once(":")?;
+//         let port = port.parse().ok()?;
 
-        self.routes
-            .iter()
-            .find(|r| route_matches(r, host, port))
-            .map(Arc::clone)
-    }
+//         self.routes
+//             .iter()
+//             .find(|r| route_matches(r, host, port))
+//             .map(Arc::clone)
+//     }
 
-    fn get_backend(&self, target: &BackendId) -> impl Future<Output = Option<Arc<BackendLb>>> {
-        std::future::ready(self.backends.get(target).cloned())
-    }
+//     fn get_backend(&self, target: &BackendId) -> impl Future<Output = Option<Arc<BackendLb>>> {
+//         std::future::ready(self.backends.get(target).cloned())
+//     }
 
-    fn get_endpoints(&self, _: &BackendId) -> impl Future<Output = Option<Arc<EndpointGroup>>> {
-        std::future::ready(None)
-    }
-}
+//     fn get_endpoints(&self, _: &BackendId) -> impl Future<Output = Option<Arc<EndpointGroup>>> {
+//         std::future::ready(None)
+//     }
+// }
 
-fn route_matches(route: &Route, host: &str, port: u16) -> bool {
-    if !route.hostnames.iter().any(|h| h.matches_str(host)) {
-        return false;
-    }
+// fn route_matches(route: &Route, host: &str, port: u16) -> bool {
+//     if !route.hostnames.iter().any(|h| h.matches_str(host)) {
+//         return false;
+//     }
 
-    if !(route.ports.is_empty() || route.ports.contains(&port)) {
-        return false;
-    }
+//     if !(route.ports.is_empty() || route.ports.contains(&port)) {
+//         return false;
+//     }
 
-    true
-}
+//     true
+// }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use junction_api::{
-        http::{BackendRef, RouteRule},
-        Hostname, Service,
-    };
-    use std::str::FromStr;
+// #[cfg(test)]
+// mod test {
+//     use super::*;
+//     use junction_api::{
+//         http::{BackendRef, RouteRule},
+//         Hostname, Service,
+//     };
+//     use std::str::FromStr;
 
-    #[test]
-    fn test_check_routes_resolves_ndots_no_match() {
-        let backend = Service::kube("web", "svc1").unwrap();
+//     #[test]
+//     fn test_check_routes_resolves_ndots_no_match() {
+//         let backend = Service::kube("web", "svc1").unwrap();
 
-        let wont_match = ["http://not.example.com", "http://notexample.com"];
+//         let wont_match = ["http://not.example.com", "http://notexample.com"];
 
-        let route = Route {
-            id: Name::from_static("ndots-match"),
-            hostnames: vec![Hostname::from_static("example.foo.bar.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![RouteRule {
-                matches: vec![],
-                backends: vec![BackendRef {
-                    weight: 1,
-                    service: backend.clone(),
-                    port: Some(8910),
-                }],
-                ..Default::default()
-            }],
-        };
+//         let route = Route {
+//             id: Name::from_static("ndots-match"),
+//             hostnames: vec![Hostname::from_static("example.foo.bar.com").into()],
+//             ports: vec![],
+//             tags: Default::default(),
+//             rules: vec![RouteRule {
+//                 matches: vec![],
+//                 backends: vec![BackendRef {
+//                     weight: 1,
+//                     service: backend.clone(),
+//                     port: Some(8910),
+//                 }],
+//                 ..Default::default()
+//             }],
+//         };
 
-        let routes = vec![route];
+//         let routes = vec![route];
 
-        for url in wont_match {
-            let url = crate::Url::from_str(url).unwrap();
-            let headers = &http::HeaderMap::default();
+//         for url in wont_match {
+//             let url = crate::Url::from_str(url).unwrap();
+//             let headers = &http::HeaderMap::default();
 
-            let resolved_route = check_route(
-                routes.clone(),
-                &http::Method::GET,
-                &url,
-                headers,
-                Some(&SearchConfig::new(3, vec![])),
-            );
+//             let resolved_route = check_route(
+//                 routes.clone(),
+//                 &http::Method::GET,
+//                 &url,
+//                 headers,
+//                 Some(&SearchConfig::new(3, vec![])),
+//             );
 
-            match resolved_route {
-                Ok(_) => panic!("succeeded for {} should have failed.", url.authority()),
-                Err(e) => assert_eq!(
-                    format!("{}", e),
-                    format!("no route matched: '{}'", url.authority())
-                ),
-            }
-        }
-    }
+//             match resolved_route {
+//                 Ok(_) => panic!("succeeded for {} should have failed.", url.authority()),
+//                 Err(e) => assert_eq!(
+//                     format!("{}", e),
+//                     format!("no route matched: '{}'", url.authority())
+//                 ),
+//             }
+//         }
+//     }
 
-    #[test]
-    fn test_check_routes_resolves_ndots_match_without_search() {
-        let backend = Service::kube("web", "svc1").unwrap();
+//     #[test]
+//     fn test_check_routes_resolves_ndots_match_without_search() {
+//         let backend = Service::kube("web", "svc1").unwrap();
 
-        let route = Route {
-            id: Name::from_static("ndots-match"),
-            hostnames: vec![
-                Hostname::from_static("example.com").into(),
-                Hostname::from_static("example.foo.com").into(),
-                Hostname::from_static("example.foo.bar.com").into(),
-            ],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![RouteRule {
-                matches: vec![],
-                backends: vec![BackendRef {
-                    weight: 1,
-                    service: backend.clone(),
-                    port: Some(8910),
-                }],
-                ..Default::default()
-            }],
-        };
+//         let route = Route {
+//             id: Name::from_static("ndots-match"),
+//             hostnames: vec![
+//                 Hostname::from_static("example.com").into(),
+//                 Hostname::from_static("example.foo.com").into(),
+//                 Hostname::from_static("example.foo.bar.com").into(),
+//             ],
+//             ports: vec![],
+//             tags: Default::default(),
+//             rules: vec![RouteRule {
+//                 matches: vec![],
+//                 backends: vec![BackendRef {
+//                     weight: 1,
+//                     service: backend.clone(),
+//                     port: Some(8910),
+//                 }],
+//                 ..Default::default()
+//             }],
+//         };
 
-        let routes = vec![route];
+//         let routes = vec![route];
 
-        let will_match = [
-            "http://example.com",
-            "http://example.foo.com",
-            "http://example.foo.bar.com",
-        ];
+//         let will_match = [
+//             "http://example.com",
+//             "http://example.foo.com",
+//             "http://example.foo.bar.com",
+//         ];
 
-        for url in will_match {
-            let url = crate::Url::from_str(url).unwrap();
-            let headers = &http::HeaderMap::default();
+//         for url in will_match {
+//             let url = crate::Url::from_str(url).unwrap();
+//             let headers = &http::HeaderMap::default();
 
-            let resolved = check_route(
-                routes.clone(),
-                &http::Method::GET,
-                &url,
-                headers,
-                Some(&SearchConfig::new(3, vec![])),
-            )
-            .unwrap();
-            // should match one of the query matches
-            assert_eq!(
-                (resolved.rule, &resolved.backend),
-                (0, &backend.as_backend_id(8910)),
-                "should match the first rule: {url}"
-            );
-        }
-    }
+//             let resolved = check_route(
+//                 routes.clone(),
+//                 &http::Method::GET,
+//                 &url,
+//                 headers,
+//                 Some(&SearchConfig::new(3, vec![])),
+//             )
+//             .unwrap();
+//             // should match one of the query matches
+//             assert_eq!(
+//                 (resolved.rule, &resolved.backend),
+//                 (0, &backend.as_backend_id(8910)),
+//                 "should match the first rule: {url}"
+//             );
+//         }
+//     }
 
-    #[test]
-    fn test_check_routes_resolves_ndots() {
-        let backend = Service::kube("web", "svc1").unwrap();
+//     #[test]
+//     fn test_check_routes_resolves_ndots() {
+//         let backend = Service::kube("web", "svc1").unwrap();
 
-        let route = Route {
-            id: Name::from_static("ndots-match"),
-            hostnames: vec![Hostname::from_static("example.foo.bar.com").into()],
-            ports: vec![],
-            tags: Default::default(),
-            rules: vec![RouteRule {
-                matches: vec![],
-                backends: vec![BackendRef {
-                    weight: 1,
-                    service: backend.clone(),
-                    port: Some(8910),
-                }],
-                ..Default::default()
-            }],
-        };
+//         let route = Route {
+//             id: Name::from_static("ndots-match"),
+//             hostnames: vec![Hostname::from_static("example.foo.bar.com").into()],
+//             ports: vec![],
+//             tags: Default::default(),
+//             rules: vec![RouteRule {
+//                 matches: vec![],
+//                 backends: vec![BackendRef {
+//                     weight: 1,
+//                     service: backend.clone(),
+//                     port: Some(8910),
+//                 }],
+//                 ..Default::default()
+//             }],
+//         };
 
-        let routes = vec![route];
+//         let routes = vec![route];
 
-        let will_match = [
-            "http://example",
-            "http://example.foo",
-            "http://example.foo.bar",
-            "http://example.foo.bar.com",
-        ];
-        let will_match_hostnames = vec![
-            Hostname::from_static("foo.bar.com"),
-            Hostname::from_static("bar.com"),
-            Hostname::from_static("com"),
-        ];
+//         let will_match = [
+//             "http://example",
+//             "http://example.foo",
+//             "http://example.foo.bar",
+//             "http://example.foo.bar.com",
+//         ];
+//         let will_match_hostnames = vec![
+//             Hostname::from_static("foo.bar.com"),
+//             Hostname::from_static("bar.com"),
+//             Hostname::from_static("com"),
+//         ];
 
-        for url in will_match {
-            let url = crate::Url::from_str(url).unwrap();
-            let headers = &http::HeaderMap::default();
+//         for url in will_match {
+//             let url = crate::Url::from_str(url).unwrap();
+//             let headers = &http::HeaderMap::default();
 
-            let resolved = check_route(
-                routes.clone(),
-                &http::Method::GET,
-                &url,
-                headers,
-                Some(&SearchConfig::new(3, will_match_hostnames.clone())),
-            )
-            .unwrap();
-            // should match one of the query matches
-            assert_eq!(
-                (resolved.rule, &resolved.backend),
-                (0, &backend.as_backend_id(8910)),
-                "should match the first rule: {url}"
-            );
-        }
-    }
-}
+//             let resolved = check_route(
+//                 routes.clone(),
+//                 &http::Method::GET,
+//                 &url,
+//                 headers,
+//                 Some(&SearchConfig::new(3, will_match_hostnames.clone())),
+//             )
+//             .unwrap();
+//             // should match one of the query matches
+//             assert_eq!(
+//                 (resolved.rule, &resolved.backend),
+//                 (0, &backend.as_backend_id(8910)),
+//                 "should match the first rule: {url}"
+//             );
+//         }
+//     }
+// }

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -33,7 +33,8 @@ use bytes::Bytes;
 use cache::{Cache, CacheReader};
 use enum_map::EnumMap;
 use futures::{FutureExt, TryStreamExt};
-use junction_api::{backend::BackendId, http::Route, Hostname, Service};
+use junction_api::Hostname;
+pub(crate) use resources::ResourceName;
 use std::{
     borrow::Cow, collections::BTreeSet, future::Future, io::ErrorKind, sync::Arc, time::Duration,
 };
@@ -53,12 +54,16 @@ use xds_api::pb::{
 };
 
 mod cache;
-
+mod load_balancer;
 mod resources;
-pub use resources::ResourceVersion;
-pub(crate) use resources::{ResourceType, ResourceVec};
 
-use crate::{dns::StdlibResolver, BackendLb, ConfigCache};
+pub use resources::ResourceVersion;
+pub(crate) use resources::{
+    clusters, endpoints, listeners, route_configs, ApiListener, Cluster, LoadAssignment,
+    ResourceType, RouteConfiguration,
+};
+
+use crate::{client::XdsCache, dns::StdlibResolver};
 
 mod csds;
 
@@ -78,16 +83,8 @@ pub struct XdsConfig {
 
 #[derive(Debug)]
 enum SubscriptionUpdate {
-    AddHosts(Vec<String>),
-    AddBackends(Vec<BackendId>),
-    AddEndpoints(Vec<BackendId>),
-
-    #[allow(unused)]
-    RemoveHosts(Vec<String>),
-    #[allow(unused)]
-    RemoveBackends(Vec<BackendId>),
-    #[allow(unused)]
-    RemoveEndpoints(Vec<BackendId>),
+    Add(ResourceType, ResourceName),
+    Remove(ResourceType, ResourceName),
 }
 
 /// A Junction ADS client that manages long-lived xDS state by connecting to a
@@ -168,57 +165,29 @@ impl AdsClient {
         csds::local_server(self.cache.clone(), port)
     }
 
-    pub(super) fn iter_routes(&self) -> impl Iterator<Item = Arc<Route>> + '_ {
-        self.cache.iter_routes()
-    }
-
-    pub(super) fn iter_backends(&self) -> impl Iterator<Item = Arc<BackendLb>> + '_ {
-        self.cache.iter_backends()
-    }
-
     pub(super) fn iter_xds(&self) -> impl Iterator<Item = XdsConfig> + '_ {
         self.cache.iter_xds()
     }
 }
 
-// TODO: the whole add-a-subscription-on-get thing is a bit werid but we don't
-// have a better signal yet. there probably is one, but we need some way to
-// distinguish between "get_endpoints was called because client.resolve_http was
-// called and its downstream of a listener" and "get_endpoints was called
-// because there is a DNS cluster in a static config".
-impl ConfigCache for AdsClient {
-    async fn get_route<S: AsRef<str>>(&self, host: S) -> Option<Arc<Route>> {
-        let hosts = vec![host.as_ref().to_string()];
-        let _ = self.subs.send(SubscriptionUpdate::AddHosts(hosts)).await;
-
-        self.cache.get_route(host).await
+impl XdsCache for AdsClient {
+    async fn subscribe(&self, rtype: self::ResourceType, name: self::ResourceName) {
+        let _ = self.subs.send(SubscriptionUpdate::Add(rtype, name));
     }
 
-    async fn get_backend(
-        &self,
-        backend: &junction_api::backend::BackendId,
-    ) -> Option<std::sync::Arc<crate::BackendLb>> {
-        let bs = vec![backend.clone()];
-        let _ = self.subs.send(SubscriptionUpdate::AddBackends(bs)).await;
-
-        self.cache.get_backend(backend).await
+    async fn get_listener(&self, name: &self::ResourceName) -> Option<Arc<self::ApiListener>> {
+        self.cache.get_listener(name).await
+    }
+    async fn get_route_config(&self, name: &ResourceName) -> Option<Arc<self::RouteConfiguration>> {
+        self.cache.get_route_config(name).await
     }
 
-    async fn get_endpoints(
-        &self,
-        backend: &junction_api::backend::BackendId,
-    ) -> Option<std::sync::Arc<crate::EndpointGroup>> {
-        let bs = vec![backend.clone()];
-        let _ = self.subs.send(SubscriptionUpdate::AddEndpoints(bs)).await;
+    async fn get_cluster(&self, target: &ResourceName) -> Option<Arc<self::Cluster>> {
+        self.cache.get_cluster(target).await
+    }
 
-        match &backend.service {
-            junction_api::Service::Dns(dns) => {
-                self.dns
-                    .get_endpoints_await(&dns.hostname, backend.port)
-                    .await
-            }
-            _ => self.cache.get_endpoints(backend).await,
-        }
+    async fn get_load_assignment(&self, name: &ResourceName) -> Option<Arc<self::LoadAssignment>> {
+        self.cache.get_load_assignment(name).await
     }
 }
 
@@ -352,7 +321,10 @@ impl AdsTask {
         let mut incoming = stream_response.into_inner();
 
         // set DNS names
-        self.dns.set_names(self.cache.dns_names());
+        //
+        // FIXME: lol, lmao, etc
+        let dns_names = self.cache.dns_names().map(|h| (h, 80));
+        self.dns.set_names(dns_names);
 
         // set up the xDS connection and start sending messages
         let (mut conn, initial_requests) =
@@ -407,6 +379,9 @@ impl AdsTask {
 // awaits until an update is recvd from either subscriptions or xds, and then
 // immediately grabs any pending updates as well. returns as soon as there's
 // nothing to immediately do and handling updates would block.
+//
+// TODO: the whole should_exit thing is weird. ignore it, keep a ref to both
+// ends of the channel, and use an explicit shutodwn token maybe?
 async fn handle_update_batch(
     conn: &mut AdsConnection<'_>,
     subs: &mut Receiver<SubscriptionUpdate>,
@@ -480,16 +455,14 @@ async fn handle_update_batch(
 }
 
 #[inline]
-fn update_dns(
-    dns: &StdlibResolver,
-    add: BTreeSet<(Hostname, u16)>,
-    remove: BTreeSet<(Hostname, u16)>,
-) {
-    for (name, port) in add {
-        dns.subscribe(name, port);
+fn update_dns(dns: &StdlibResolver, add: BTreeSet<Hostname>, remove: BTreeSet<Hostname>) {
+    for name in add {
+        // FIXME: lol, lmao, etc
+        dns.subscribe(name, 80);
     }
-    for (name, port) in remove {
-        dns.unsubscribe(&name, port);
+    for name in remove {
+        // FIXME: lol, lmao, etc
+        dns.unsubscribe(&name, 80);
     }
 }
 
@@ -562,18 +535,23 @@ impl<'a> AdsConnection<'a> {
             let initial_versions = cache.versions(rtype);
             let mut subscribe = cache.initial_subscriptions(rtype);
             if cache.is_wildcard(rtype) && !subscribe.is_empty() {
-                subscribe.push("*".to_string());
+                subscribe.push(ResourceName::wildcard());
             }
 
             if !cache.is_wildcard(rtype) && subscribe.is_empty() && initial_versions.is_empty() {
                 continue;
             }
 
+            let resource_names_subscribe = subscribe.into_iter().map(|n| n.to_string()).collect();
+            let initial_resource_versions = initial_versions
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
             requests.push(DeltaDiscoveryRequest {
                 node: node.take(),
                 type_url: rtype.type_url().to_string(),
-                resource_names_subscribe: subscribe,
-                initial_resource_versions: initial_versions,
+                resource_names_subscribe,
+                initial_resource_versions,
                 ..Default::default()
             });
         }
@@ -623,9 +601,11 @@ impl<'a> AdsConnection<'a> {
 
             let node = self.node.take();
             let (response_nonce, error_detail) = ack.map(|a| a.into_ack()).unwrap_or_default();
-            let resource_names_subscribe = changes.added.into_iter().collect();
-            let resource_names_unsubscribe = changes.removed.into_iter().collect();
 
+            let resource_names_subscribe =
+                changes.added.into_iter().map(|r| r.to_string()).collect();
+            let resource_names_unsubscribe =
+                changes.removed.into_iter().map(|r| r.to_string()).collect();
             responses.push(DeltaDiscoveryRequest {
                 node,
                 type_url: rtype.type_url().to_string(),
@@ -647,21 +627,7 @@ impl<'a> AdsConnection<'a> {
             return;
         };
 
-        // add resources
-        let resources = match ResourceVec::from_resources(rtype, resp.resources) {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::trace!(err = %e, "invalid proto");
-                self.set_ack(
-                    rtype,
-                    resp.nonce,
-                    Some(format!("invalid resource: {e}").into()),
-                );
-                return;
-            }
-        };
-
-        let resource_errors = self.cache.insert(resources);
+        let resource_errors = self.cache.insert(rtype, resp.resources);
         let error = match &resource_errors[..] {
             &[] => None,
             // TOOD: actually generate a useful error message here
@@ -670,64 +636,18 @@ impl<'a> AdsConnection<'a> {
         self.set_ack(rtype, resp.nonce, error);
 
         // remove resources
-        self.cache.remove(rtype, &resp.removed_resources);
+        let removed_resources: Vec<_> = resp
+            .removed_resources
+            .into_iter()
+            .map(ResourceName::from)
+            .collect();
+        self.cache.remove(rtype, &removed_resources);
     }
 
     fn handle_subscription_update(&mut self, update: SubscriptionUpdate) {
         match update {
-            SubscriptionUpdate::AddHosts(hosts) => {
-                for host in hosts {
-                    self.cache.subscribe(ResourceType::Listener, &host);
-                }
-            }
-            SubscriptionUpdate::RemoveHosts(hosts) => {
-                for host in hosts {
-                    self.cache.unsubscribe(ResourceType::Listener, &host);
-                }
-            }
-            SubscriptionUpdate::AddBackends(backends) => {
-                for backend in backends {
-                    if let Service::Dns(dns) = &backend.service {
-                        self.cache.subscribe_dns(dns.hostname.clone(), backend.port);
-                    }
-                    self.cache.subscribe(ResourceType::Cluster, &backend.name());
-                }
-            }
-            SubscriptionUpdate::RemoveBackends(backends) => {
-                for backend in backends {
-                    if let Service::Dns(dns) = &backend.service {
-                        self.cache
-                            .unsubscribe_dns(dns.hostname.clone(), backend.port);
-                    }
-                    self.cache
-                        .unsubscribe(ResourceType::Cluster, &backend.name());
-                }
-            }
-            SubscriptionUpdate::AddEndpoints(backends) => {
-                for backend in backends {
-                    match &backend.service {
-                        Service::Dns(dns) => {
-                            self.cache.subscribe_dns(dns.hostname.clone(), backend.port);
-                        }
-                        _ => self
-                            .cache
-                            .subscribe(ResourceType::ClusterLoadAssignment, &backend.name()),
-                    }
-                }
-            }
-            SubscriptionUpdate::RemoveEndpoints(backends) => {
-                for backend in backends {
-                    match &backend.service {
-                        Service::Dns(dns) => {
-                            self.cache
-                                .unsubscribe_dns(dns.hostname.clone(), backend.port);
-                        }
-                        _ => self
-                            .cache
-                            .unsubscribe(ResourceType::ClusterLoadAssignment, &backend.name()),
-                    }
-                }
-            }
+            SubscriptionUpdate::Add(rtype, name) => self.cache.subscribe(rtype, &name),
+            SubscriptionUpdate::Remove(rtype, name) => self.cache.unsubscribe(rtype, &name),
         }
     }
 
@@ -744,10 +664,10 @@ impl<'a> AdsConnection<'a> {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct DnsUpdates {
-    add: BTreeSet<(Hostname, u16)>,
-    remove: BTreeSet<(Hostname, u16)>,
+    add: BTreeSet<Hostname>,
+    remove: BTreeSet<Hostname>,
     sync: bool,
 }
 
@@ -760,8 +680,6 @@ impl DnsUpdates {
 
 #[cfg(test)]
 mod test_ads_conn {
-    use std::collections::HashMap;
-
     use cache::Cache;
     use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
@@ -827,8 +745,14 @@ mod test_ads_conn {
         cache.set_wildcard(ResourceType::Listener, false);
         cache.set_wildcard(ResourceType::Cluster, true);
 
-        cache.subscribe(ResourceType::Cluster, "cluster.example:7891");
-        cache.subscribe(ResourceType::ClusterLoadAssignment, "cluster.example:7891");
+        cache.subscribe(
+            ResourceType::Cluster,
+            &ResourceName::from("cluster.example:7891"),
+        );
+        cache.subscribe(
+            ResourceType::ClusterLoadAssignment,
+            &ResourceName::from("cluster.example:7891"),
+        );
 
         // only the Clusters should have the wildcard sub, CLA should not, since it's
         // not a wildcard-capable resource type
@@ -856,8 +780,14 @@ mod test_ads_conn {
         cache.set_wildcard(ResourceType::Listener, false);
         cache.set_wildcard(ResourceType::Cluster, false);
 
-        cache.subscribe(ResourceType::Cluster, "cluster.example:7891");
-        cache.subscribe(ResourceType::ClusterLoadAssignment, "cluster.example:7891");
+        cache.subscribe(
+            ResourceType::Cluster,
+            &ResourceName::from("cluster.example:7891"),
+        );
+        cache.subscribe(
+            ResourceType::ClusterLoadAssignment,
+            &ResourceName::from("cluster.example:7891"),
+        );
 
         let (_, outgoing) = new_conn(&mut cache);
         assert_eq!(
@@ -883,25 +813,34 @@ mod test_ads_conn {
         assert!(cache.is_wildcard(ResourceType::Listener));
         assert!(!cache.is_wildcard(ResourceType::RouteConfiguration));
 
-        cache.insert(ResourceVec::from_listeners(
-            "123".into(),
-            vec![xds_test::listener!("cooler.example.org", "cool-route")],
-        ));
-        cache.insert(ResourceVec::from_listeners(
-            "456".into(),
-            vec![xds_test::listener!("warmer.example.org", "warm-route")],
-        ));
-        cache.insert(ResourceVec::from_route_configs(
-            "789".into(),
+        cache.insert(
+            ResourceType::Listener,
+            vec![xds_test::listener!(
+                "cooler.example.org",
+                "123",
+                "cool-route"
+            )],
+        );
+        cache.insert(
+            ResourceType::Listener,
+            vec![xds_test::listener!(
+                "warmer.example.org",
+                "456",
+                "warm-route"
+            )],
+        );
+        cache.insert(
+            ResourceType::RouteConfiguration,
             vec![xds_test::route_config!(
                 "cool-route",
+                "789",
                 vec![xds_test::vhost!(
                     "an-vhost",
                     ["cooler.example.org"],
                     [xds_test::route!(default "cooler.example.internal:8008")]
                 )]
             )],
-        ));
+        );
 
         // both wildcard and non-wildcard should start with an empty add list
         // but resources in init
@@ -929,64 +868,30 @@ mod test_ads_conn {
     }
 
     #[test]
-    fn test_handle_subscribe_hostname() {
+    fn test_handle_subscribe_listener() {
         let mut cache = Cache::default();
         let (mut conn, _) = new_conn(&mut cache);
 
-        conn.handle_subscription_update(SubscriptionUpdate::AddHosts(vec![
-            Service::dns("website.internal").unwrap().name(),
-            Service::kube("default", "nginx")
-                .unwrap()
-                .as_backend_id(4443)
-                .name(),
-        ]));
+        conn.handle_subscription_update(SubscriptionUpdate::Add(
+            ResourceType::Listener,
+            ResourceName::from("website.internal"),
+        ));
+        conn.handle_subscription_update(SubscriptionUpdate::Add(
+            ResourceType::Cluster,
+            ResourceName::from("nginx.default.svc.cluster.local:4443"),
+        ));
 
         let (outgoing, dns) = conn.outgoing();
-        // dns should not update on listeners
         assert!(dns.is_noop());
         assert_eq!(
             outgoing,
-            vec![xds_test::req!(
-                t = ResourceType::Listener,
-                add = vec!["nginx.default.svc.cluster.local:4443", "website.internal"],
-            )]
-        );
-    }
-
-    #[test]
-    fn test_handle_subscribe_backend() {
-        let mut cache = Cache::default();
-        let (mut conn, _) = new_conn(&mut cache);
-
-        conn.handle_subscription_update(SubscriptionUpdate::AddBackends(vec![
-            Service::dns("website.internal").unwrap().as_backend_id(80),
-            Service::kube("default", "nginx")
-                .unwrap()
-                .as_backend_id(4443),
-        ]));
-
-        let (outgoing, dns) = conn.outgoing();
-        // dns shouldn't preemptively update on dns backends
-        assert_eq!(
-            dns,
-            DnsUpdates {
-                add: [(Hostname::from_static("website.internal"), 80)]
-                    .into_iter()
-                    .collect(),
-                ..Default::default()
-            }
-        );
-
-        // should generate xds for clusters
-        assert_eq!(
-            outgoing,
-            vec![xds_test::req!(
-                t = ResourceType::Cluster,
-                add = vec![
-                    "nginx.default.svc.cluster.local:4443",
-                    "website.internal:80"
-                ],
-            )]
+            vec![
+                xds_test::req!(
+                    t = ResourceType::Cluster,
+                    add = vec!["nginx.default.svc.cluster.local:4443"],
+                ),
+                xds_test::req!(t = ResourceType::Listener, add = vec!["website.internal"],),
+            ]
         );
     }
 
@@ -999,33 +904,33 @@ mod test_ads_conn {
 
         conn.handle_ads_message(xds_test::resp!(
             n = "1",
-            add = ResourceVec::from_listeners(
-                "123".into(),
-                vec![xds_test::listener!("cooler.example.org", "cool-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "cooler.example.org",
+                "123",
+                "cool-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "2",
-            add = ResourceVec::from_listeners(
-                "456".into(),
-                vec![xds_test::listener!("warmer.example.org", "warm-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "warmer.example.org",
+                "456",
+                "warm-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "3",
-            add = ResourceVec::from_route_configs(
-                "789".into(),
-                vec![xds_test::route_config!(
-                    "cool-route",
-                    vec![xds_test::vhost!(
-                        "an-vhost",
-                        ["cooler.example.org"],
-                        [xds_test::route!(default "cooler.example.internal:8008")]
-                    )]
-                )],
-            ),
+            add = vec![xds_test::route_config!(
+                "cool-route",
+                "789",
+                vec![xds_test::vhost!(
+                    "an-vhost",
+                    ["cooler.example.org"],
+                    [xds_test::route!(default "cooler.example.internal:8008")]
+                )]
+            )],
             remove = vec![],
         ));
 
@@ -1053,6 +958,14 @@ mod test_ads_conn {
         );
     }
 
+    macro_rules! resource_versions {
+        ($(($k:expr, $v:expr)),* $(,)?) => {
+            [$(
+                (ResourceName::from($k.to_string()), ResourceVersion::from($v.to_string())),
+            )*].into_iter().collect()
+        }
+    }
+
     #[test]
     fn test_handle_ads_message_listener_swap_route() {
         let mut cache = Cache::default();
@@ -1063,25 +976,24 @@ mod test_ads_conn {
         // get set up with a listener pointing to a route
         conn.handle_ads_message(xds_test::resp!(
             n = "1",
-            add = ResourceVec::from_listeners(
-                "111".into(),
-                vec![xds_test::listener!("cooler.example.org", "cool-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "cooler.example.org",
+                "111",
+                "cool-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "2",
-            add = ResourceVec::from_route_configs(
-                "222".into(),
-                vec![xds_test::route_config!(
-                    "cool-route",
-                    vec![xds_test::vhost!(
-                        "an-vhost",
-                        ["cooler.example.org"],
-                        [xds_test::route!(default "cooler.example.internal:8008")]
-                    )]
-                )],
-            ),
+            add = vec![xds_test::route_config!(
+                "cool-route",
+                "222",
+                vec![xds_test::vhost!(
+                    "an-vhost",
+                    ["cooler.example.org"],
+                    [xds_test::route!(default "cooler.example.internal:8008")]
+                )]
+            )],
             remove = vec![],
         ));
 
@@ -1104,11 +1016,11 @@ mod test_ads_conn {
 
         assert_eq!(
             conn.cache.versions(ResourceType::Listener),
-            HashMap::from_iter([("cooler.example.org".to_string(), "111".to_string())])
+            resource_versions![("cooler.example.org", "111")],
         );
         assert_eq!(
             conn.cache.versions(ResourceType::RouteConfiguration),
-            HashMap::from_iter([("cool-route".to_string(), "222".to_string())])
+            resource_versions![("cool-route", "222")],
         );
 
         // swap the route and immediately swap it back
@@ -1117,18 +1029,20 @@ mod test_ads_conn {
         // update and the outgoing messages should include a Listener ACK.
         conn.handle_ads_message(xds_test::resp!(
             n = "3",
-            add = ResourceVec::from_listeners(
-                "333".into(),
-                vec![xds_test::listener!("cooler.example.org", "lame-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "cooler.example.org",
+                "333",
+                "lame-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "4",
-            add = ResourceVec::from_listeners(
-                "444".into(),
-                vec![xds_test::listener!("cooler.example.org", "cool-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "cooler.example.org",
+                "444",
+                "cool-route"
+            )],
             remove = vec![],
         ));
 
@@ -1151,19 +1065,16 @@ mod test_ads_conn {
 
         assert_eq!(
             conn.cache.versions(ResourceType::Listener),
-            HashMap::from_iter([("cooler.example.org".to_string(), "444".to_string())])
+            resource_versions![("cooler.example.org", "444")],
         );
         assert_eq!(
             conn.cache.versions(ResourceType::RouteConfiguration),
-            HashMap::from_iter([("cool-route".to_string(), "222".to_string())])
+            resource_versions![("cool-route", "222")],
         );
     }
 
     #[test]
     fn test_handle_ads_message_add_remove_add() {
-        tracing_subscriber::fmt::init();
-        tracing::trace!("HELLO?");
-
         let mut cache = Cache::default();
         assert!(cache.is_wildcard(ResourceType::Listener));
         assert!(cache.is_wildcard(ResourceType::Cluster));
@@ -1173,48 +1084,45 @@ mod test_ads_conn {
         // set up a listener -> route -> cluster resource chain
         conn.handle_ads_message(xds_test::resp!(
             n = "1",
-            add = ResourceVec::from_listeners(
-                "111".into(),
-                vec![xds_test::listener!("cooler.example.org", "cool-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "cooler.example.org",
+                "111",
+                "cool-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "2",
-            add = ResourceVec::from_route_configs(
-                "222".into(),
-                vec![xds_test::route_config!(
-                    "cool-route",
-                    vec![xds_test::vhost!(
-                        "an-vhost",
-                        ["cooler.example.org"],
-                        [xds_test::route!(default "cooler.example.internal:8008")]
-                    )]
-                )],
-            ),
+            add = vec![xds_test::route_config!(
+                "cool-route",
+                "222",
+                vec![xds_test::vhost!(
+                    "an-vhost",
+                    ["cooler.example.org"],
+                    [xds_test::route!(default "cooler.example.internal:8008")]
+                )]
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "3",
-            add = ResourceVec::from_clusters(
-                "333".into(),
-                vec![xds_test::cluster!("cooler.example.internal:8008"),],
-            ),
+            add = vec![xds_test::cluster!(eds => "cooler.example.internal:8008", "333")],
             remove = vec![],
         ));
         let (outgoing, _dns) = conn.outgoing();
         assert_eq!(
             outgoing,
             vec![
-                // cluster ack
+                // ack
                 xds_test::req!(t = ResourceType::Cluster, n = "3"),
-                // should try sub to the cluster lb route
+                // request
                 xds_test::req!(
-                    t = ResourceType::Listener,
-                    n = "1",
-                    add = vec!["cooler.example.internal.lb.jct:8008"]
+                    t = ResourceType::ClusterLoadAssignment,
+                    n = "",
+                    add = vec!["cooler.example.internal:8008"]
                 ),
-                // route config ack
+                // acks
+                xds_test::req!(t = ResourceType::Listener, n = "1"),
                 xds_test::req!(t = ResourceType::RouteConfiguration, n = "2"),
             ],
         );
@@ -1222,33 +1130,33 @@ mod test_ads_conn {
         // swap out the listener for a new route and remove the old route
         conn.handle_ads_message(xds_test::resp!(
             n = "4",
-            add = ResourceVec::from_listeners(
-                "444".into(),
-                vec![xds_test::listener!("cooler.example.org", "very-cool-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "cooler.example.org",
+                "444",
+                "very-cool-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "5",
-            add = ResourceVec::from_route_configs("444".into(), vec![]),
+            ty = ResourceType::RouteConfiguration,
             remove = vec!["very-cool-route"],
         ));
         let (outgoing, _dns) = conn.outgoing();
         assert_eq!(
             outgoing,
             vec![
-                // cluster remove
+                // cluster and CLA remove
                 xds_test::req!(
                     t = ResourceType::Cluster,
                     remove = vec!["cooler.example.internal:8008"]
                 ),
-                // listener ACK, also removes cluster lb listener
                 xds_test::req!(
-                    t = ResourceType::Listener,
-                    n = "4",
-                    add = vec![],
-                    remove = vec!["cooler.example.internal.lb.jct:8008"]
+                    t = ResourceType::ClusterLoadAssignment,
+                    remove = vec!["cooler.example.internal:8008"]
                 ),
+                // listener ack
+                xds_test::req!(t = ResourceType::Listener, n = "4"),
                 // route config add and remove
                 xds_test::req!(
                     t = ResourceType::RouteConfiguration,
@@ -1263,27 +1171,20 @@ mod test_ads_conn {
         // removes and adds the new route config.
         conn.handle_ads_message(xds_test::resp!(
             n = "6",
-            add = ResourceVec::from_clusters("444".into(), vec![]),
+            ty = ResourceType::Cluster,
             remove = vec!["cooler.example.internal:8008"],
         ));
         conn.handle_ads_message(xds_test::resp!(
-            n = "7",
-            add = ResourceVec::from_listeners("444".into(), vec![]),
-            remove = vec!["cooler.example.internal.lb.jct:8008"],
-        ));
-        conn.handle_ads_message(xds_test::resp!(
             n = "8",
-            add = ResourceVec::from_route_configs(
-                "555".into(),
-                vec![xds_test::route_config!(
-                    "very-cool-route",
-                    vec![xds_test::vhost!(
-                        "an-vhost",
-                        ["cooler.example.org"],
-                        [xds_test::route!(default "cooler.example.internal:8008")]
-                    )]
-                )],
-            ),
+            add = vec![xds_test::route_config!(
+                "very-cool-route",
+                "555",
+                vec![xds_test::vhost!(
+                    "an-vhost",
+                    ["cooler.example.org"],
+                    [xds_test::route!(default "cooler.example.internal:8008")]
+                )]
+            )],
             remove = vec![],
         ));
         let (outgoing, _dns) = conn.outgoing();
@@ -1296,8 +1197,6 @@ mod test_ads_conn {
                     n = "6",
                     add = vec!["cooler.example.internal:8008"]
                 ),
-                // ack the listener
-                xds_test::req!(t = ResourceType::Listener, n = "7"),
                 // ack the route config
                 xds_test::req!(t = ResourceType::RouteConfiguration, n = "8"),
             ],
@@ -1313,33 +1212,33 @@ mod test_ads_conn {
 
         conn.handle_ads_message(xds_test::resp!(
             n = "1",
-            add = ResourceVec::from_listeners(
-                "123".into(),
-                vec![xds_test::listener!("cooler.example.org", "cool-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "cooler.example.org",
+                "123",
+                "cool-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "2",
-            add = ResourceVec::from_listeners(
-                "456".into(),
-                vec![xds_test::listener!("warmer.example.org", "warm-route")],
-            ),
+            add = vec![xds_test::listener!(
+                "warmer.example.org",
+                "456",
+                "warm-route"
+            )],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "3",
-            add = ResourceVec::from_route_configs(
-                "789".into(),
-                vec![xds_test::route_config!(
-                    "cool-route",
-                    vec![xds_test::vhost!(
-                        "an-vhost",
-                        ["cooler.example.org"],
-                        [xds_test::route!(default "cooler.example.internal:8008")]
-                    )]
-                )],
-            ),
+            add = vec![xds_test::route_config!(
+                "cool-route",
+                "789",
+                vec![xds_test::vhost!(
+                    "an-vhost",
+                    ["cooler.example.org"],
+                    [xds_test::route!(default "cooler.example.internal:8008")]
+                )]
+            )],
             remove = vec![],
         ));
 
@@ -1369,7 +1268,7 @@ mod test_ads_conn {
         // the server gets a delete for the listener we already have
         conn.handle_ads_message(xds_test::resp!(
             n = "4",
-            add = ResourceVec::from_listeners("123".into(), vec![]),
+            ty = ResourceType::Listener,
             remove = vec!["warmer.example.org"],
         ));
 
@@ -1398,41 +1297,19 @@ mod test_ads_conn {
 
         conn.handle_ads_message(xds_test::resp!(
             n = "1",
-            add = ResourceVec::from_clusters(
-                "123".into(),
-                vec![
-                    xds_test::cluster!("cooler.example.org:2345"),
-                    xds_test::cluster!("thing.default.svc.cluster.local:9876"),
-                ],
-            ),
+            add = vec![
+                xds_test::cluster!(logical_dns => "cooler.example.org", 2345, "123"),
+                xds_test::cluster!(eds => "thing.default.svc.cluster.local:9876", "123"),
+            ],
             remove = vec![],
         ));
         conn.handle_ads_message(xds_test::resp!(
             n = "2",
-            add = ResourceVec::from_load_assignments(
-                "123".into(),
-                vec![xds_test::cla!(
-                    "thing.default.svc.cluster.local:9876" => {
-                        "zone1" => ["1.1.1.1"]
-                    }
-                )],
-            ),
-            remove = vec![],
-        ));
-        conn.handle_ads_message(xds_test::resp!(
-            n = "3",
-            add = ResourceVec::from_listeners("555".into(), vec![
-                xds_test::listener!("cooler.example.org.lb.jct:2345", "lb-route" => [xds_test::vhost!(
-                    "lb-vhost",
-                    ["cooler.example.org.lb.jct:2345"],
-                    [xds_test::route!(default ring_hash = "x-user", "cooler.example.org:2345")],
-                )]),
-                xds_test::listener!("thing.default.svc.cluster.local.lb.jct:9876", "lb-route" => [xds_test::vhost!(
-                    "lb-vhost",
-                    ["cooler.example.org.lb.jct:2345"],
-                    [xds_test::route!(default ring_hash = "x-user", "thing.default.svc.cluster.local:9876")],
-                )])
-            ]),
+            add = vec![xds_test::cla!(
+                "thing.default.svc.cluster.local:9876", "123" => {
+                    "zone1" => ["1.1.1.1"]
+                }
+            )],
             remove = vec![],
         ));
 
@@ -1441,9 +1318,7 @@ mod test_ads_conn {
         assert_eq!(
             dns,
             DnsUpdates {
-                add: [(Hostname::from_static("cooler.example.org"), 2345)]
-                    .into_iter()
-                    .collect(),
+                add: BTreeSet::from_iter([Hostname::from_static("cooler.example.org")]),
                 ..Default::default()
             }
         );
@@ -1453,7 +1328,6 @@ mod test_ads_conn {
             vec![
                 xds_test::req!(t = ResourceType::Cluster, n = "1"),
                 xds_test::req!(t = ResourceType::ClusterLoadAssignment, n = "2"),
-                xds_test::req!(t = ResourceType::Listener, n = "3"),
             ]
         );
     }
@@ -1468,11 +1342,20 @@ mod test_ads_conn {
         let (mut conn, outgoing) = new_conn(&mut cache);
         assert!(outgoing.is_empty());
 
-        let svc = Service::dns("website.internal").unwrap().as_backend_id(80);
-        conn.handle_subscription_update(SubscriptionUpdate::AddBackends(vec![svc]));
+        conn.handle_subscription_update(SubscriptionUpdate::Add(
+            ResourceType::Cluster,
+            ResourceName::from("foo.bar:443"),
+        ));
+        conn.handle_subscription_update(SubscriptionUpdate::Add(
+            ResourceType::Listener,
+            ResourceName::from("foo.bar:443"),
+        ));
 
         let (outgoing, _) = conn.outgoing();
         assert_eq!(outgoing[0].node.as_ref(), Some(&*TEST_NODE));
+        for msg in &outgoing[1..] {
+            assert_eq!(msg.node, None);
+        }
     }
 
     #[test]
@@ -1534,15 +1417,19 @@ mod test_ads_conn {
         let mut cache = Cache::default();
         let (mut conn, _) = new_conn(&mut cache);
 
+        let not_found = ResourceName::from("website.internal");
+
         // handle a subscription update
-        let does_not_exist = Service::dns("website.internal").unwrap().name();
-        conn.handle_subscription_update(SubscriptionUpdate::AddHosts(vec![does_not_exist.clone()]));
+        conn.handle_subscription_update(SubscriptionUpdate::Add(
+            ResourceType::Listener,
+            not_found.clone(),
+        ));
         let _ = conn.outgoing();
 
         conn.handle_ads_message(DeltaDiscoveryResponse {
             nonce: "boo".to_string(),
             type_url: ResourceType::Listener.type_url().to_string(),
-            removed_resources: vec![does_not_exist.clone()],
+            removed_resources: vec![not_found.to_string()],
             ..Default::default()
         });
 
@@ -1554,12 +1441,12 @@ mod test_ads_conn {
             vec![xds_test::req!(t = ResourceType::Listener, n = "boo")],
         );
 
-        // route should be tombstoned
-        let route = cache
+        // listener should be tombstoned
+        let listener = cache
             .reader()
-            .get_route("website.internal")
+            .get_listener(&not_found)
             .now_or_never()
             .unwrap();
-        assert_eq!(route, None);
+        assert!(listener.is_none());
     }
 }

--- a/crates/junction-core/src/xds/cache.rs
+++ b/crates/junction-core/src/xds/cache.rs
@@ -83,41 +83,59 @@
 
 use std::{
     collections::{BTreeSet, HashMap},
-    str::FromStr,
     sync::Arc,
 };
 
-use crossbeam_skiplist::SkipMap;
+use dashmap::DashMap;
 use enum_map::EnumMap;
-use junction_api::{backend::BackendId, http::Route, Hostname};
+use junction_api::Hostname;
 use petgraph::{
     graph::{DiGraph, NodeIndex},
     visit::{EdgeRef, Visitable},
     Direction,
 };
 use tokio::sync::Notify;
-use xds_api::pb::envoy::config::{
-    cluster::v3 as xds_cluster, endpoint::v3 as xds_endpoint, listener::v3 as xds_listener,
-    route::v3 as xds_route,
-};
+use xds_api::pb::envoy::service::discovery::v3 as xds_discovery;
 use xds_api::pb::google::protobuf;
-
-use crate::{endpoints::EndpointGroup, BackendLb};
 
 use super::{
     resources::{
-        ApiListener, ApiListenerData, Cluster, LoadAssignment, ResourceError, RouteConfig,
-        RouteConfigData,
+        ApiListener, Cluster, LoadAssignment, Resource, ResourceError, ResourceName,
+        RouteConfiguration,
     },
-    ConfigCache, DnsUpdates, ResourceType, ResourceVec, ResourceVersion, XdsConfig,
+    DnsUpdates, ResourceType, ResourceVersion, XdsConfig,
 };
 
 /// A concurrent map of resources, bundled together with an Arc<Notify> so that
 /// callers can wait on changes.
 #[derive(Debug)]
 struct ResourceMap<T> {
-    changed: Arc<Notify>,
-    map: SkipMap<String, CacheEntry<T>>,
+    changed: Notify,
+    // TODO: use ahash for keys, see if it matters
+    map: DashMap<ResourceName, ResourceData<T>>,
+}
+
+type ResourceMapEntryRef<'a, T> = dashmap::mapref::one::Ref<'a, ResourceName, ResourceData<T>>;
+type ResourceMapEntryIterRef<'a, T> =
+    dashmap::mapref::multiple::RefMulti<'a, ResourceName, ResourceData<T>>;
+
+#[derive(Clone, Debug)]
+struct ResourceData<T> {
+    version: Option<ResourceVersion>,
+    last_error: Option<(ResourceVersion, ResourceError)>,
+    data: Option<Arc<T>>,
+    raw_msg: Option<protobuf::Any>,
+}
+
+impl<T> Default for ResourceData<T> {
+    fn default() -> Self {
+        Self {
+            version: None,
+            last_error: None,
+            data: None,
+            raw_msg: None,
+        }
+    }
 }
 
 // NOTE: manually derived because the Derive macro requires `T: Default`, and
@@ -125,25 +143,25 @@ struct ResourceMap<T> {
 impl<T> Default for ResourceMap<T> {
     fn default() -> Self {
         Self {
-            changed: Arc::new(Notify::new()),
+            changed: Notify::new(),
             map: Default::default(),
         }
     }
 }
 
-impl<T: Send + 'static> ResourceMap<T> {
+impl<T> ResourceMap<T> {
     #[cfg(test)]
     fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
 
-    fn get<'a>(&'a self, name: &str) -> Option<ResourceEntry<'a, T>> {
-        self.map.get(name).map(ResourceEntry)
+    fn get<'a>(&'a self, name: &ResourceName) -> Option<ResourceMapEntryRef<'a, T>> {
+        self.map.get(name).map(|r| r)
     }
 
-    async fn get_await<'a>(&'a self, name: &str) -> Option<ResourceEntry<'a, T>> {
+    async fn get_await<'a>(&'a self, name: &ResourceName) -> Option<ResourceMapEntryRef<'a, T>> {
         // fast path: try a get and return it if it works out.
-        if let Some(entry) = self.map.get(name).map(ResourceEntry) {
+        if let Some(entry) = self.map.get(name) {
             return Some(entry);
         }
 
@@ -169,7 +187,7 @@ impl<T: Send + 'static> ResourceMap<T> {
         tokio::pin!(changed);
         loop {
             // check the map
-            if let Some(entry) = self.map.get(name).map(ResourceEntry) {
+            if let Some(entry) = self.map.get(name) {
                 return Some(entry);
             }
 
@@ -182,191 +200,75 @@ impl<T: Send + 'static> ResourceMap<T> {
         }
     }
 
-    fn iter(&self) -> impl Iterator<Item = ResourceEntry<T>> + '_ {
-        self.map.iter().map(ResourceEntry)
+    fn iter(&self) -> impl Iterator<Item = ResourceMapEntryIterRef<T>> + '_ {
+        self.map.iter()
     }
 
-    fn has_data(&self, k: &str) -> bool {
+    fn has_data(&self, k: &ResourceName) -> bool {
         match self.get(k) {
             None => false,
-            Some(entry) => entry.data().is_some(),
+            Some(entry) => entry.data.is_some(),
         }
     }
 
-    fn versions(&self) -> HashMap<String, String> {
+    fn versions(&self) -> HashMap<ResourceName, ResourceVersion> {
         let mut versions = HashMap::new();
-        for entry in self.iter() {
-            if entry.data().is_none() {
+        for entry in self.map.iter() {
+            if entry.data.is_none() {
                 continue;
             };
-            let Some(version) = entry.version() else {
+            let Some(version) = &entry.version else {
                 continue;
             };
 
-            let name = entry.name().to_string();
-            let version = version.to_string();
+            let name = entry.key().clone();
+            let version = version.clone();
             versions.insert(name, version);
         }
 
         versions
     }
 
-    fn remove(&self, name: &str) -> Option<ResourceEntry<T>> {
+    fn remove(&self, name: &ResourceName) -> Option<(ResourceName, ResourceData<T>)> {
         let entry = self.map.remove(name);
         self.changed.notify_waiters();
-        entry.map(ResourceEntry)
+        entry
     }
 
-    fn remove_all<I>(&self, names: I)
+    fn remove_all<'a, I>(&self, names: I)
     where
-        I: IntoIterator<Item: AsRef<str>>,
+        I: IntoIterator<Item = &'a ResourceName>,
     {
         for name in names {
-            self.remove(name.as_ref());
+            self.remove(name);
         }
     }
-}
 
-impl<X, T> ResourceMap<T>
-where
-    T: CacheEntryData<Xds = X> + Clone + Send + 'static,
-    X: PartialEq + prost::Name,
-{
-    fn insert_ok(&self, name: String, version: ResourceVersion, t: T) {
+    fn insert_ok(&self, name: ResourceName, version: ResourceVersion, resource: T) {
         self.map.insert(
             name,
-            CacheEntry {
+            ResourceData {
                 version: Some(version),
                 last_error: None,
-                data: Some(t),
+                data: Some(Arc::new(resource)),
+                raw_msg: None,
             },
         );
         self.changed.notify_waiters();
     }
 
-    fn insert_tombstone(&self, name: String) {
+    fn insert_tombstone(&self, name: ResourceName) {
         self.map.insert(
             name,
-            CacheEntry {
+            ResourceData {
                 version: None,
                 last_error: None,
                 data: None,
+                raw_msg: None,
             },
         );
         self.changed.notify_waiters();
     }
-
-    fn insert_error<E: Into<ResourceError>>(
-        &self,
-        name: String,
-        version: ResourceVersion,
-        error: E,
-    ) {
-        match self.map.get(&name) {
-            Some(entry) => {
-                let mut updated_entry = entry.value().clone();
-                updated_entry.last_error = Some((version, error.into()));
-                self.map.insert(name, updated_entry);
-                self.changed.notify_waiters();
-            }
-            None => {
-                self.map.insert(
-                    name,
-                    CacheEntry {
-                        version: None,
-                        last_error: Some((version, error.into())),
-                        data: None,
-                    },
-                );
-                self.changed.notify_waiters();
-            }
-        }
-    }
-
-    // TDODO: should this compare version to short-circuit full eq?
-    fn is_changed(&self, name: &str, t: &X) -> bool {
-        let Some(entry) = self.map.get(name) else {
-            return true;
-        };
-
-        let Some(entry_data) = &entry.value().data else {
-            return true;
-        };
-        entry_data.xds() != t
-    }
-}
-
-/// Wrap a crossbeam_skiplist Entry to make some signatures and reference things
-/// less gnarly.
-struct ResourceEntry<'a, T>(crossbeam_skiplist::map::Entry<'a, String, CacheEntry<T>>);
-
-impl<T> ResourceEntry<'_, T> {
-    fn name(&self) -> &str {
-        self.0.key()
-    }
-
-    fn version(&self) -> Option<&ResourceVersion> {
-        self.0.value().version.as_ref()
-    }
-
-    fn last_error(&self) -> Option<&(ResourceVersion, ResourceError)> {
-        self.0.value().last_error.as_ref()
-    }
-
-    fn data(&self) -> Option<&T> {
-        self.0.value().data.as_ref()
-    }
-}
-
-#[derive(Clone, Debug)]
-struct CacheEntry<T> {
-    version: Option<ResourceVersion>,
-    last_error: Option<(ResourceVersion, ResourceError)>,
-    data: Option<T>,
-}
-
-impl<T> Default for CacheEntry<T> {
-    fn default() -> Self {
-        Self {
-            version: None,
-            last_error: None,
-            data: None,
-        }
-    }
-}
-
-impl<T: CacheEntryData> CacheEntry<T> {}
-
-// TODO: kill this, move xds into CacheEntry
-trait CacheEntryData {
-    type Xds;
-
-    fn xds(&self) -> &Self::Xds;
-}
-
-macro_rules! impl_cache_entry {
-    ($entry_ty:ty, $xds_ty:ty) => {
-        impl CacheEntryData for $entry_ty {
-            type Xds = $xds_ty;
-
-            fn xds(&self) -> &$xds_ty {
-                &self.xds
-            }
-        }
-    };
-}
-
-impl_cache_entry!(ApiListener, xds_listener::Listener);
-impl_cache_entry!(RouteConfig, xds_route::RouteConfiguration);
-impl_cache_entry!(Cluster, xds_cluster::Cluster);
-impl_cache_entry!(LoadAssignment, xds_endpoint::ClusterLoadAssignment);
-
-#[derive(Debug, Default)]
-struct CacheData {
-    listeners: ResourceMap<ApiListener>,
-    route_configs: ResourceMap<RouteConfig>,
-    clusters: ResourceMap<Cluster>,
-    load_assignments: ResourceMap<LoadAssignment>,
 }
 
 /// The set of subscription changes for a single resource type.
@@ -374,11 +276,11 @@ struct CacheData {
 pub(crate) struct Changes {
     /// The names of any newly added subscriptions. Newly added subscriptions
     /// may or may not be in cache, and must be requested from the xDS server.
-    pub(crate) added: BTreeSet<String>,
+    pub(crate) added: BTreeSet<ResourceName>,
 
     /// The names of any removed subscriptions. Callers should assume that any
     /// removed names are also removed from cache.
-    pub(crate) removed: BTreeSet<String>,
+    pub(crate) removed: BTreeSet<ResourceName>,
 }
 
 impl Changes {
@@ -421,7 +323,7 @@ struct SubscriptionInfo {
     resource_type: ResourceType,
 
     // the name of the resource
-    name: String,
+    name: ResourceName,
 
     // true if there is explicit interest in this resource via subscribe.
     explicit: bool,
@@ -432,33 +334,33 @@ struct SubscriptionInfo {
 }
 
 impl Subscriptions {
-    fn explicit(&self, rtype: ResourceType) -> impl Iterator<Item = &str> + '_ {
+    fn explicit(&self, rtype: ResourceType) -> impl Iterator<Item = &ResourceName> + '_ {
         self.subs
             .node_weights()
             .filter(move |w| w.resource_type == rtype && !w.wildcard)
-            .map(|w| &w.name[..])
+            .map(|w| &w.name)
     }
 
-    fn subscribe(&mut self, rtype: ResourceType, name: &str) {
+    fn subscribe(&mut self, rtype: ResourceType, name: &ResourceName) {
         // explicit subscription means never a wildcard
         let sub = self.find_or_create(rtype, name, false);
         self.subs[sub].explicit = true;
     }
 
-    fn unsubscribe(&mut self, rtype: ResourceType, name: &str) {
+    fn unsubscribe(&mut self, rtype: ResourceType, name: &ResourceName) {
         if let Some(sub) = self.find(rtype, name) {
             self.subs[sub].explicit = false;
         }
     }
 
-    fn remove(&mut self, rtype: ResourceType, name: &str) {
+    fn remove(&mut self, rtype: ResourceType, name: &ResourceName) {
         if let Some(sub) = self.find(rtype, name) {
             self.reset_refs(sub);
         }
     }
 
     #[inline]
-    fn clear_changes(&mut self, rtype: ResourceType, name: &str) {
+    fn clear_changes(&mut self, rtype: ResourceType, name: &ResourceName) {
         self.changes[rtype].added.remove(name);
         self.changes[rtype].removed.remove(name);
     }
@@ -469,7 +371,7 @@ impl Subscriptions {
         self.changes[sub.resource_type].removed.insert(sub.name);
     }
 
-    fn find_or_subscribe(&mut self, rtype: ResourceType, name: &str) -> Option<NodeIndex> {
+    fn find_or_subscribe(&mut self, rtype: ResourceType, name: &ResourceName) -> Option<NodeIndex> {
         // if this is a wildcard subscription, any name is subscribed. create it
         // and move on.
         if self.wildcard[rtype] {
@@ -483,19 +385,24 @@ impl Subscriptions {
         self.find(rtype, name)
     }
 
-    fn find(&self, rtype: ResourceType, name: &str) -> Option<NodeIndex> {
+    fn find(&self, rtype: ResourceType, name: &ResourceName) -> Option<NodeIndex> {
         self.subs.node_indices().find(|idx| {
             let sub = &self.subs[*idx];
-            sub.resource_type == rtype && sub.name == name
+            sub.resource_type == rtype && sub.name == *name
         })
     }
 
-    fn find_or_create(&mut self, rtype: ResourceType, name: &str, wildcard: bool) -> NodeIndex {
+    fn find_or_create(
+        &mut self,
+        rtype: ResourceType,
+        name: &ResourceName,
+        wildcard: bool,
+    ) -> NodeIndex {
         match self.find(rtype, name) {
             Some(idx) => idx,
             None => {
                 let idx = self.subs.add_node(SubscriptionInfo {
-                    name: name.to_string(),
+                    name: name.clone(),
                     resource_type: rtype,
                     explicit: false,
                     wildcard,
@@ -503,7 +410,7 @@ impl Subscriptions {
 
                 // track that this is a newly created sub
                 if !wildcard {
-                    self.changes[rtype].added.insert(name.to_string());
+                    self.changes[rtype].added.insert(name.clone());
                 }
 
                 idx
@@ -531,7 +438,7 @@ impl Subscriptions {
     /// Add a reference from `from_sub` to a node of with a given resource type
     /// and name. Creates the destination subscription if it doesn't already
     /// exist.
-    fn add_ref(&mut self, from_sub: NodeIndex, rtype: ResourceType, name: &str) {
+    fn add_ref(&mut self, from_sub: NodeIndex, rtype: ResourceType, name: &ResourceName) {
         // when adding a reference that creates a new subscription, even if the
         // destination type is a wildcard, we want a non-wildcard reference to
         // it so that the cache can switch to explicit mode and keep this
@@ -588,13 +495,76 @@ impl Subscriptions {
     }
 }
 
+/// A counted set of DNS names.
+///
+/// Keeps track of the number of times a name is used and builds up
+/// a set of tracked updates. Updates are cleared and returned when
+/// `collect` is called.
+#[derive(Clone, Debug, Default)]
+struct DnsNames {
+    names: HashMap<Hostname, usize>,
+    changes: DnsUpdates,
+}
+
+impl DnsNames {
+    /// Add a name to the set.
+    /// present.
+    fn add_name(&mut self, name: Hostname) {
+        use std::collections::hash_map::Entry;
+
+        match self.names.entry(name) {
+            Entry::Occupied(mut entry) => {
+                *entry.get_mut() += 1;
+            }
+            Entry::Vacant(entry) => {
+                let name = entry.key().clone();
+
+                // add one
+                entry.insert(1);
+                // update changes
+                self.changes.remove.remove(&name);
+                self.changes.add.insert(name);
+            }
+        }
+    }
+
+    /// Remove a name from the tracked set.
+    fn remove_name(&mut self, name: &Hostname) {
+        let Some(val) = self.names.get_mut(name) else {
+            return;
+        };
+
+        if *val == 1 {
+            self.names.remove(name);
+            self.changes.add.remove(name);
+            self.changes.remove.insert(name.clone());
+        } else {
+            *val -= 1;
+        }
+    }
+
+    /// Clear and return the set of names that have changed since the last call
+    /// to `collect`.
+    fn collect(&mut self) -> DnsUpdates {
+        std::mem::take(&mut self.changes)
+    }
+}
+
 /// A persistent cache of Junction xDS state. See the module documentation for
 /// more information on what's in a cache and how to use one.
 #[derive(Debug, Default)]
 pub(super) struct Cache {
     subs: Subscriptions,
     data: Arc<CacheData>,
-    dns: DnsUpdates,
+    dns: DnsNames,
+}
+
+#[derive(Debug, Default)]
+struct CacheData {
+    listeners: ResourceMap<ApiListener>,
+    route_configs: ResourceMap<RouteConfiguration>,
+    clusters: ResourceMap<Cluster>,
+    load_assignments: ResourceMap<LoadAssignment>,
 }
 
 impl Cache {
@@ -624,47 +594,37 @@ impl Cache {
     }
 
     /// Subscribe to a resource by name.
-    pub(crate) fn subscribe(&mut self, rtype: ResourceType, name: &str) {
+    pub(crate) fn subscribe(&mut self, rtype: ResourceType, name: &ResourceName) {
         self.subs.subscribe(rtype, name);
     }
 
     /// Unsubscribe from a resource by name.
-    pub(crate) fn unsubscribe(&mut self, rtype: ResourceType, name: &str) {
+    pub(crate) fn unsubscribe(&mut self, rtype: ResourceType, name: &ResourceName) {
         self.subs.unsubscribe(rtype, name);
-    }
-
-    /// Subscribe to a DNS name.
-    pub(crate) fn subscribe_dns(&mut self, hostname: Hostname, port: u16) {
-        self.dns.add.insert((hostname, port));
-    }
-
-    /// Unsubscribe from a DNS name.
-    pub(crate) fn unsubscribe_dns(&mut self, hostname: Hostname, port: u16) {
-        self.dns.remove.insert((hostname, port));
     }
 
     /// Return the current list of subscriptions for this resource type.
     #[cfg(test)]
-    pub(crate) fn subscriptions(&self, rtype: ResourceType) -> Vec<String> {
-        self.subs.explicit(rtype).map(|s| s.to_string()).collect()
+    pub(crate) fn subscriptions(&self, rtype: ResourceType) -> Vec<ResourceName> {
+        self.subs.explicit(rtype).map(|s| s.clone()).collect()
     }
 
-    pub(crate) fn dns_names(&self) -> impl Iterator<Item = (Hostname, u16)> + '_ {
+    pub(crate) fn dns_names(&self) -> impl Iterator<Item = Hostname> + '_ {
         self.data
             .clusters
             .iter()
-            .filter_map(|e| e.data().and_then(|c| c.dns_name()))
+            .filter_map(|e| e.data.as_ref().and_then(|c| c.dns_name().cloned()))
     }
 
     /// Return the list of resources the cache has a registered subscription for
     /// but contains no data for.
-    pub(crate) fn initial_subscriptions(&self, rtype: ResourceType) -> Vec<String> {
+    pub(crate) fn initial_subscriptions(&self, rtype: ResourceType) -> Vec<ResourceName> {
         macro_rules! missing_from {
             ($m:expr) => {
                 self.subs
                     .explicit(rtype)
                     .filter(|k| !$m.has_data(k))
-                    .map(|s| s.to_string())
+                    .map(|s| s.clone())
                     .collect()
             };
         }
@@ -678,7 +638,7 @@ impl Cache {
     }
 
     /// Get the versions of all resources currently in cache.
-    pub(crate) fn versions(&self, rtype: ResourceType) -> HashMap<String, String> {
+    pub(crate) fn versions(&self, rtype: ResourceType) -> HashMap<ResourceName, ResourceVersion> {
         match rtype {
             ResourceType::Cluster => self.data.clusters.versions(),
             ResourceType::ClusterLoadAssignment => self.data.load_assignments.versions(),
@@ -712,15 +672,17 @@ impl Cache {
 
         // when removing clusters based on changes, we also have to remove
         // any DNS names for removed clusters.
-        let mut dns = std::mem::take(&mut self.dns);
         for cluster_name in &changes[ResourceType::Cluster].removed {
-            if let Some(entry) = self.data.clusters.remove(cluster_name) {
-                let dns_name = entry.data().and_then(|c| c.dns_name());
-                if let Some(dns_name) = dns_name {
-                    dns.remove.insert(dns_name);
+            // NOTE: this can be an if-let chain once we upgrade to the 2024 edition.
+            if let Some((_, entry)) = self.data.clusters.remove(cluster_name) {
+                if let Some(cluster) = entry.data {
+                    for dns_name in cluster.dns_names() {
+                        self.dns.remove_name(dns_name);
+                    }
                 }
             }
         }
+        let dns = self.dns.collect();
 
         (changes, dns)
     }
@@ -730,13 +692,33 @@ impl Cache {
     /// Returns an error for each resource that could not be inserted.
     /// Successfully parsed resources are visible to readers as soon as they're
     /// inserted.
-    pub(crate) fn insert(&mut self, resources: ResourceVec) -> Vec<ResourceError> {
-        match resources {
-            ResourceVec::Cluster(clusters) => self.insert_clusters(clusters),
-            ResourceVec::ClusterLoadAssignment(clas) => self.insert_load_assignments(clas),
-            ResourceVec::Listener(listeners) => self.insert_listeners(listeners),
-            ResourceVec::RouteConfiguration(rcs) => self.insert_route_configs(rcs),
+    pub(crate) fn insert(
+        &mut self,
+        rtype: ResourceType,
+        resources: Vec<xds_discovery::Resource>,
+    ) -> Vec<ResourceError> {
+        macro_rules! dispatch {
+            ($($variant:pat => $field:ident),* $(,)*) => {
+                match rtype {
+                    $(
+                        $variant => insert_resources(
+                            &mut self.subs,
+                            &mut self.dns,
+                            &self.data.$field,
+                            rtype,
+                            resources,
+                        ),
+                    )*
+                }
+            }
         }
+
+        dispatch!(
+            ResourceType::Cluster => clusters,
+            ResourceType::ClusterLoadAssignment => load_assignments,
+            ResourceType::Listener => listeners,
+            ResourceType::RouteConfiguration => route_configs,
+        )
     }
 
     /// Remove a list of resources from cache by name.
@@ -750,7 +732,7 @@ impl Cache {
     /// that it may have subscribed us to. Note that newly-orphaned resources
     /// may not be fully removed from cache until the next call to
     /// [Cache::collect].
-    pub(crate) fn remove(&mut self, rtype: ResourceType, names: &[String]) {
+    pub(crate) fn remove(&mut self, rtype: ResourceType, names: &[ResourceName]) {
         macro_rules! tombstone_all {
             ($data:ident, $rtype:expr, $names:expr) => {{
                 for name in $names {
@@ -767,304 +749,66 @@ impl Cache {
             ResourceType::ClusterLoadAssignment => tombstone_all!(load_assignments, rtype, names),
         }
     }
+}
 
-    fn insert_listeners(
-        &mut self,
-        listeners: Vec<(ResourceVersion, xds_listener::Listener)>,
-    ) -> Vec<ResourceError> {
-        let mut errors = Vec::new();
+// NOTE: this is not a method on Cache because borrowck can't be bothered to
+// figure out that data and subs are disjoint. it should be
+fn insert_resources<T>(
+    subs: &mut Subscriptions,
+    dns: &mut DnsNames,
+    data: &ResourceMap<T>,
+    rtype: ResourceType,
+    resources: Vec<xds_discovery::Resource>,
+) -> Vec<ResourceError>
+where
+    T: Resource,
+{
+    let mut errors = Vec::new();
 
-        for (version, listener) in listeners {
-            if !self.data.listeners.is_changed(&listener.name, &listener) {
-                continue;
-            }
-            let Some(sub) = self
-                .subs
-                .find_or_subscribe(ResourceType::Listener, &listener.name)
-            else {
-                continue;
-            };
-
-            let listener_name = listener.name.clone();
-            let api_listener = match ApiListener::from_xds(&listener_name, listener) {
-                Ok(l) => l,
-                Err(e) => {
-                    self.data
-                        .listeners
-                        .insert_error(listener_name, version.clone(), e.clone());
-                    errors.push(e);
-                    continue;
-                }
-            };
-
-            // reset all outgoing references
-            self.subs.reset_refs(sub);
-
-            match &api_listener.route_config {
-                // RDS: add a reference from this Listener to a RouteConfiguration
-                ApiListenerData::Rds(rc_name) => {
-                    self.subs
-                        .add_ref(sub, ResourceType::RouteConfiguration, rc_name.as_str());
-                }
-                // with an inline RouteConfiguration, add a reference to all of
-                // the clusters that this Listener points to.
-                ApiListenerData::Inlined(RouteConfigData::Route { clusters, .. }) => {
-                    for cluster in clusters {
-                        self.subs
-                            .add_ref(sub, ResourceType::Cluster, cluster.as_str());
-                    }
-                }
-                // policy RouteConfigurations are the *targets* of references,
-                // and shouldn't actually reference any resources themselves.
-                // the only thing we should do here is update the clusters that
-                // point at this policy.
-                ApiListenerData::Inlined(RouteConfigData::LbPolicy { action, cluster }) => {
-                    // inserting the cluster should have already subscribed to
-                    // this route implicitly! don't recreate the edge in the
-                    // other direction.
-                    //
-                    // rebuild the cluster with the new LbPolicy from this
-                    // listener. we don't have to use the ref graph here, since
-                    // we have the cluster name (effectively the parent-pointer)
-                    // in the LbPolicy.
-                    //
-                    // TODO: remove this from Listener and only have Routes serve this purpose.
-                    let version_and_xds = self.data.clusters.get(cluster.as_str()).and_then(|e| {
-                        let version = e.version();
-                        let data = e.data();
-                        version.zip(data).map(|(v, d)| (v.clone(), d.xds.clone()))
-                    });
-                    let res = match version_and_xds {
-                        Some((version, xds)) => {
-                            self.insert_cluster(version, xds, Some(Arc::clone(action)))
-                        }
-                        None => Ok(()),
-                    };
-                    if let Err(e) = res {
-                        self.data
-                            .listeners
-                            .insert_error(listener_name, version, e.clone());
-                        errors.push(e);
-                        continue;
-                    }
-                }
-            }
-
-            // do the update
-            self.subs
-                .clear_changes(ResourceType::Listener, &listener_name);
-            self.data
-                .listeners
-                .insert_ok(listener_name, version, api_listener);
-        }
-
-        errors
-    }
-
-    fn insert_clusters(
-        &mut self,
-        clusters: Vec<(ResourceVersion, xds_cluster::Cluster)>,
-    ) -> Vec<ResourceError> {
-        let mut errors = Vec::new();
-
-        for (version, cluster) in clusters {
-            if !self.data.clusters.is_changed(&cluster.name, &cluster) {
-                continue;
-            }
-
-            let lb_action = self.find_lb_action(&cluster.name);
-            if let Err(e) = self.insert_cluster(version, cluster, lb_action) {
-                errors.push(e);
-            }
-        }
-
-        errors
-    }
-
-    fn insert_cluster(
-        &mut self,
-        version: ResourceVersion,
-        cluster: xds_cluster::Cluster,
-        lb_policy: Option<Arc<xds_route::RouteAction>>,
-    ) -> Result<(), ResourceError> {
-        let Some(sub) = self
-            .subs
-            .find_or_subscribe(ResourceType::Cluster, &cluster.name)
-        else {
-            return Ok(());
+    for raw_resource in resources {
+        let Some(any) = raw_resource.resource else {
+            continue;
+        };
+        let name = raw_resource.name.into();
+        let version = raw_resource.version.into();
+        let Some(sub) = subs.find_or_subscribe(rtype, &name) else {
+            continue;
         };
 
-        let cluster_name = cluster.name.clone();
-        let cluster = match Cluster::from_xds(cluster, lb_policy.as_deref()) {
-            Ok(c) => c,
+        // parse and validate
+        let resource = match T::from_any(&any) {
+            Ok(r) => r,
             Err(e) => {
-                self.data
-                    .clusters
-                    .insert_error(cluster_name, version.clone(), e.clone());
-                return Err(e);
+                errors.push(e);
+                continue;
             }
         };
 
-        // reset all outgoing references since we know we're updating
-        self.subs.reset_refs(sub);
-
-        // point to the CLA for this cluster or start a DNS subscription for it.
-        match cluster.dns_name() {
-            Some(dns_name) => {
-                self.dns.add.insert(dns_name);
-            }
-            None => self
-                .subs
-                .add_ref(sub, ResourceType::ClusterLoadAssignment, &cluster_name),
+        // reset all outgoing edges and replace them with the new reources
+        subs.reset_refs(sub);
+        for (ref_type, name) in resource.references() {
+            subs.add_ref(sub, ref_type, &name);
         }
 
-        // point to the LB config Listener for this cluster. pointing to the Listener
-        // means that the control plane has the option of sending us either a Listener
-        // or a RouteConfig for the Lb Config.
+        // add any new DNS names to the set of tracked names.
         //
-        // TODO: make this a RouteConfig instead of a listener?
-        let lb_config_name = cluster.backend_lb.config.id.lb_config_route_name();
-        self.subs
-            .add_ref(sub, ResourceType::Listener, &lb_config_name);
-
-        // actually insert the data
-        self.subs
-            .clear_changes(ResourceType::Cluster, &cluster_name);
-        self.data.clusters.insert_ok(cluster_name, version, cluster);
-
-        Ok(())
-    }
-
-    fn find_lb_action(&self, cluster_name: &str) -> Option<Arc<xds_route::RouteAction>> {
-        let target = BackendId::from_str(cluster_name).ok()?;
-        let listener = self.data.listeners.get(&target.lb_config_route_name())?;
-
-        match &listener.data()?.route_config {
-            ApiListenerData::Rds(name) => {
-                let route_config = self.data.route_configs.get(name.as_str())?;
-                route_config.data().and_then(|rc| match &rc.data {
-                    RouteConfigData::LbPolicy { action, .. } => Some(action.clone()),
-                    _ => None,
-                })
-            }
-            ApiListenerData::Inlined(data) => match &data {
-                RouteConfigData::LbPolicy { action, .. } => Some(action.clone()),
-                _ => None,
-            },
-        }
-    }
-
-    fn insert_route_configs(
-        &mut self,
-        route_configs: Vec<(ResourceVersion, xds_route::RouteConfiguration)>,
-    ) -> Vec<ResourceError> {
-        let mut errors = Vec::new();
-
-        for (version, route_config) in route_configs {
-            let Some(sub) = self
-                .subs
-                .find_or_subscribe(ResourceType::RouteConfiguration, &route_config.name)
-            else {
-                continue;
-            };
-
-            let route_name = route_config.name.clone();
-            let route_config = match RouteConfig::from_xds(route_config) {
-                Ok(route_config) => route_config,
-                Err(e) => {
-                    self.data
-                        .route_configs
-                        .insert_error(route_name, version, e.clone());
-                    errors.push(e);
-                    continue;
-                }
-            };
-
-            match &route_config.data {
-                // add a ref to all downstream clusters
-                RouteConfigData::Route { clusters, .. } => {
-                    for cluster in clusters {
-                        self.subs
-                            .add_ref(sub, ResourceType::Cluster, cluster.as_str());
-                    }
-                }
-                // this is Lb policy, update the cluster it's attached to.
-                RouteConfigData::LbPolicy { action, cluster } => {
-                    // inserting the cluster should have already subscribed to
-                    // this route implicitly! don't recreate the edge in the
-                    // other direction.
-                    //
-                    // rebuild the cluster with the new LbPolicy from this
-                    // route. we don't have to use the ref graph here, since
-                    // we have the cluster name (effectively the parent-pointer)
-                    // in the LbPolicy.
-                    //
-                    // TODO: remove this from Listener and only have Routes serve this purpose.
-                    let version_and_xds = self.data.clusters.get(cluster.as_str()).and_then(|e| {
-                        let version = e.version();
-                        let data = e.data();
-                        version.zip(data).map(|(v, d)| (v.clone(), d.xds.clone()))
-                    });
-                    let res = match version_and_xds {
-                        Some((version, xds)) => {
-                            self.insert_cluster(version, xds, Some(Arc::clone(action)))
-                        }
-                        None => Ok(()),
-                    };
-                    if let Err(e) = res {
-                        self.data
-                            .route_configs
-                            .insert_error(route_name, version, e.clone());
-                        errors.push(e);
-                        continue;
-                    }
-                }
-            }
-
-            // complete the insert
-            self.subs
-                .clear_changes(ResourceType::RouteConfiguration, &route_name);
-            self.data
-                .route_configs
-                .insert_ok(route_name, version, route_config);
+        // NOTE: we know this is almost certainly only going to happen for
+        // clusters, but it's less annoying to do the serialization here, once,
+        // for all of these types than it is to figure out how to split the
+        // cluster-specific steps. we could pass a callback in, but that seems
+        // like basically the same thing. just accept the Vec::new call and call
+        // it a day.
+        for dns_name in resource.dns_names() {
+            dns.add_name(dns_name.clone())
         }
 
-        errors
+        // clear any pending changes for this resource - it's no longer pending
+        subs.clear_changes(rtype, &name);
+        // actually insert the thing
+        data.insert_ok(name, version, resource);
     }
 
-    fn insert_load_assignments(
-        &mut self,
-        load_assignments: Vec<(ResourceVersion, xds_endpoint::ClusterLoadAssignment)>,
-    ) -> Vec<ResourceError> {
-        let mut errors = Vec::new();
-
-        for (version, load_assignment) in load_assignments {
-            let sub = self.subs.find_or_subscribe(
-                ResourceType::ClusterLoadAssignment,
-                &load_assignment.cluster_name,
-            );
-            if sub.is_none() {
-                continue;
-            };
-
-            let cla_name = load_assignment.cluster_name.clone();
-            match LoadAssignment::from_xds(load_assignment) {
-                Ok(cla) => {
-                    self.subs
-                        .clear_changes(ResourceType::ClusterLoadAssignment, &cla_name);
-                    self.data.load_assignments.insert_ok(cla_name, version, cla);
-                }
-                Err(e) => {
-                    self.data
-                        .load_assignments
-                        .insert_error(cla_name, version, e.clone());
-                    errors.push(e);
-                }
-            };
-        }
-
-        errors
-    }
+    errors
 }
 
 /// A read-only handle to a [Cache]. `CacheReader`s are cheap to clone and
@@ -1074,112 +818,49 @@ pub(super) struct CacheReader {
     data: Arc<CacheData>,
 }
 
-impl ConfigCache for CacheReader {
-    async fn get_route<S: AsRef<str>>(&self, host: S) -> Option<Arc<Route>> {
-        let listener = self.data.listeners.get_await(host.as_ref()).await?;
-
-        match &listener.data()?.route_config {
-            ApiListenerData::Rds(name) => {
-                let route_config = self.data.route_configs.get_await(name.as_str()).await?;
-
-                match &route_config.data()?.data {
-                    RouteConfigData::Route { route, .. } => Some(route.clone()),
-                    _ => None,
-                }
+macro_rules! impl_get {
+    ($method_name:ident($field_name:ident)=>$ret:ty) => {
+        impl CacheReader {
+            pub async fn $method_name(&self, name: &ResourceName) -> Option<Arc<$ret>> {
+                self.data
+                    .$field_name
+                    .get_await(name)
+                    .await
+                    .and_then(|e| e.data.as_ref().map(|d| Arc::clone(&d)))
             }
-            ApiListenerData::Inlined(data) => match &data {
-                RouteConfigData::Route { route, .. } => Some(route.clone()),
-                _ => None,
-            },
         }
-    }
-
-    async fn get_backend(&self, id: &BackendId) -> Option<Arc<BackendLb>> {
-        let cluster = self.data.clusters.get_await(&id.name()).await?;
-        let cluster_data = cluster.data()?;
-        Some(cluster_data.backend_lb.clone())
-    }
-
-    async fn get_endpoints(&self, id: &BackendId) -> Option<Arc<EndpointGroup>> {
-        let la = self.data.load_assignments.get_await(&id.name()).await?;
-        let la_data = la.data()?;
-        Some(la_data.endpoint_group.clone())
-    }
+    };
 }
 
+impl_get!(get_listener(listeners)=>ApiListener);
+impl_get!(get_route_config(route_configs)=>RouteConfiguration);
+impl_get!(get_cluster(clusters)=>Cluster);
+impl_get!(get_load_assignment(load_assignments)=>LoadAssignment);
+
 impl CacheReader {
-    /// Iterate over all routes currently in cache.
-    pub(super) fn iter_routes(&self) -> impl Iterator<Item = Arc<Route>> + '_ {
-        let listener_routes = self.data.listeners.iter().filter_map(|entry| {
-            entry
-                .data()
-                .and_then(|api_listener| match &api_listener.route_config {
-                    ApiListenerData::Inlined(RouteConfigData::Route { route, .. }) => {
-                        Some(route.clone())
-                    }
-                    _ => None,
-                })
-        });
-
-        let route_config_routes = self.data.route_configs.iter().filter_map(|entry| {
-            entry.data().and_then(|rc| match &rc.data {
-                RouteConfigData::Route { route, .. } => Some(route.clone()),
-                _ => None,
-            })
-        });
-
-        listener_routes.chain(route_config_routes)
-    }
-
-    /// Iterate over all backends currently in cache.
-    pub(super) fn iter_backends(&self) -> impl Iterator<Item = Arc<BackendLb>> + '_ {
-        self.data
-            .clusters
-            .iter()
-            .filter_map(|entry| entry.data().map(|cluster| cluster.backend_lb.clone()))
-    }
-
-    /// Iterate over all xDS currently in cache.
     pub(super) fn iter_xds(&self) -> impl Iterator<Item = XdsConfig> + '_ {
-        use prost::Name;
+        self.data.listeners.iter().map(|entry| {
+            let name = entry.key().to_string();
+            let type_url = ResourceType::Listener.type_url().to_string();
+            let version = entry.version.clone();
+            let xds = entry.raw_msg.clone();
+            let last_error = entry.last_error.clone().map(|(v, e)| (v, e.to_string()));
 
-        macro_rules! any_iter {
-            ($field:ident, $xds_type:ty) => {
-                self.data.$field.iter().map(|entry| {
-                    let name = entry.name().to_string();
-                    let type_url = <$xds_type>::type_url();
-                    let version = entry.version().cloned();
-
-                    let xds = entry.data().map(|data| {
-                        protobuf::Any::from_msg(data.xds()).expect("generated invalid protobuf")
-                    });
-                    let last_error = entry.last_error().map(|(v, e)| (v.clone(), e.to_string()));
-
-                    XdsConfig {
-                        name,
-                        type_url,
-                        version,
-                        xds,
-                        last_error,
-                    }
-                })
-            };
-        }
-
-        any_iter!(listeners, xds_listener::Listener)
-            .chain(any_iter!(route_configs, xds_route::RouteConfiguration))
-            .chain(any_iter!(clusters, xds_cluster::Cluster))
-            .chain(any_iter!(
-                load_assignments,
-                xds_endpoint::ClusterLoadAssignment
-            ))
+            XdsConfig {
+                name,
+                type_url,
+                version,
+                xds,
+                last_error,
+            }
+        })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use junction_api::Service;
     use pretty_assertions::assert_eq;
+    use xds_api::pb::envoy::config::listener::v3 as xds_listener;
 
     use super::*;
     use crate::xds::test as xds_test;
@@ -1199,25 +880,39 @@ mod test {
         assert_sync::<Cache>();
     }
 
-    macro_rules! collect_str {
+    macro_rules! resource_names {
         ($($arg:expr),* $(,)?) => {
             [$(
-                    $arg.to_string(),
+                ResourceName::from($arg.to_string()),
             )*].into_iter().collect()
         }
     }
 
-    macro_rules! collect_kv_str {
+    macro_rules! versions {
         ($(($k:expr, $v:expr)),* $(,)?) => {
             [$(
-                ($k.to_string(), $v.to_string()),
+                (ResourceName::from($k.to_string()), ResourceVersion::from($v.to_string())),
             )*].into_iter().collect()
         }
     }
 
     #[track_caller]
-    fn assert_insert(errors: Vec<ResourceError>) {
-        assert!(errors.is_empty(), "errors is not empty: {errors:?}");
+    fn assert_insert(cache: &mut Cache, resources: Vec<xds_discovery::Resource>) {
+        let first = resources.first().expect("expected a non-empty vec");
+        let rtype = ResourceType::from_type_url(
+            &first
+                .resource
+                .as_ref()
+                .expect("expected a Resource")
+                .type_url,
+        )
+        .expect("expected a valid type url");
+
+        assert_eq!(
+            cache.insert(rtype, resources),
+            vec![],
+            "errors is not empty",
+        );
     }
 
     #[test]
@@ -1240,36 +935,44 @@ mod test {
 
     #[test]
     fn test_insert_listener_lds_explicit() {
-        let listeners = ResourceVec::from_listeners(
-            "123".into(),
+        let mut cache = Cache::default();
+        cache.set_wildcard(ResourceType::Listener, false);
+
+        // insert with no errors, and no effects
+        assert_insert(
+            &mut cache,
             vec![xds_test::listener!(
                 "listener.example.svc.cluster.local",
                 "example-route",
             )],
         );
-
-        let mut cache = Cache::default();
-        cache.set_wildcard(ResourceType::Listener, false);
-
-        // insert with no errors, and no effects
-        assert_insert(cache.insert(listeners.clone()));
         let (resources, dns) = cache.collect();
         assert_eq!(resources, EnumMap::default());
         assert!(dns.is_noop());
 
-        // subscribe and clear the resulting subs for the listener
-        cache.subscribe(ResourceType::Listener, "listener.example.svc.cluster.local");
+        // subscribe and clear the resulting subs for the listener. should be
+        // able to insert with no errors and generate the subscription to the
+        // cluster
+        cache.subscribe(
+            ResourceType::Listener,
+            &ResourceName::from("listener.example.svc.cluster.local"),
+        );
         let _ = cache.collect();
 
-        // insert with no errors and generate the subscription to the cluster
-        assert_insert(cache.insert(listeners));
+        assert_insert(
+            &mut cache,
+            vec![xds_test::listener!(
+                "listener.example.svc.cluster.local",
+                "example-route",
+            )],
+        );
         let (resources, dns) = cache.collect();
         assert!(dns.is_noop());
         assert_eq!(
             resources,
             enum_map::enum_map! {
                 ResourceType::RouteConfiguration => Changes {
-                    added: collect_str!["example-route"],
+                    added: resource_names!["example-route"],
                     removed: BTreeSet::new(),
                  },
                 _ => Changes::default(),
@@ -1278,13 +981,13 @@ mod test {
 
         // listener subscriptions should be the listener subscribed to versions
         // and should report the version of the listener we have.
-        assert_eq!(
-            cache.subscriptions(ResourceType::Listener),
-            vec!["listener.example.svc.cluster.local"]
-        );
+        assert_eq!(cache.subscriptions(ResourceType::Listener), {
+            let names: Vec<_> = resource_names!["listener.example.svc.cluster.local"];
+            names
+        });
         assert_eq!(
             cache.versions(ResourceType::Listener),
-            collect_kv_str![("listener.example.svc.cluster.local", "123")]
+            versions![("listener.example.svc.cluster.local", "v123")]
         );
     }
 
@@ -1292,13 +995,13 @@ mod test {
     fn test_insert_listener_lds_wildcard() {
         let mut cache = Cache::default();
 
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![xds_test::listener!(
                 "listener.example.svc.cluster.local",
                 "example-route",
             )],
-        )));
+        );
 
         // check that we've added an explicit subscription to the new cluster
         // and that there are no DNS updates.
@@ -1308,7 +1011,7 @@ mod test {
             resources,
             enum_map::enum_map! {
                 ResourceType::RouteConfiguration => Changes {
-                    added: collect_str!["example-route"],
+                    added: resource_names!["example-route"],
                     removed: BTreeSet::new(),
                  },
                 _ => Changes::default(),
@@ -1321,7 +1024,7 @@ mod test {
         assert!(cache.subscriptions(ResourceType::Listener).is_empty());
         assert_eq!(
             cache.versions(ResourceType::Listener),
-            collect_kv_str![("listener.example.svc.cluster.local", "123")]
+            versions![("listener.example.svc.cluster.local", "v123")]
         );
     }
 
@@ -1329,8 +1032,8 @@ mod test {
     fn test_insert_listener_lds_inline_rds() {
         let mut cache = Cache::default();
 
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![xds_test::listener!(
                 "listener.example.svc.cluster.local:80",
                 "example-route" => [xds_test::vhost!(
@@ -1339,7 +1042,7 @@ mod test {
                     [xds_test::route!(default "cluster.example:8008")],
                 )],
             )],
-        )));
+        );
 
         // check that we've added an explicit subscription to the new cluster
         // and that there are no DNS updates.
@@ -1349,7 +1052,7 @@ mod test {
             resources,
             enum_map::enum_map! {
                 ResourceType::Cluster => Changes {
-                    added: collect_str!["cluster.example:8008"],
+                    added: resource_names!["cluster.example:8008"],
                     removed: BTreeSet::new(),
                  },
                 _ => Changes::default(),
@@ -1360,22 +1063,24 @@ mod test {
     #[test]
     fn test_insert_listener_invalid() {
         let mut cache = Cache::default();
-        cache.subscribe(ResourceType::Listener, "potato");
+        cache.subscribe(ResourceType::Listener, &ResourceName::from("potato"));
         // clear subscription changes
         let _ = cache.collect();
 
         // the invalid insert should return an error
-        let errors = cache.insert(ResourceVec::from_listeners(
-            "123".into(),
-            [xds_listener::Listener {
-                name: "potato".to_string(),
-                ..Default::default()
-            }],
-        ));
+        let invalid_listener = xds_test::xds_resource(
+            "potato".to_string(),
+            "v123".to_string(),
+            xds_listener::Listener::default(),
+        );
+        let errors = cache.insert(ResourceType::Listener, vec![invalid_listener]);
         assert_eq!(errors.len(), 1);
 
         // should not have changed the cache
-        assert_eq!(cache.subscriptions(ResourceType::Listener), vec!["potato"]);
+        assert_eq!(cache.subscriptions(ResourceType::Listener), {
+            let names: Vec<_> = resource_names!["potato"];
+            names
+        });
         assert!(cache.versions(ResourceType::Listener).is_empty());
         let (resources, dns) = cache.collect();
         assert_eq!(resources, Default::default());
@@ -1386,36 +1091,20 @@ mod test {
     fn test_insert_cluster_cds_wildcard() {
         let mut cache = Cache::default();
 
-        let kube_backend = BackendId {
-            service: Service::kube("default", "whatever").unwrap(),
-            port: 7890,
-        };
-        let dns_backend = BackendId {
-            service: Service::dns("cluster.example").unwrap(),
-            port: 4433,
-        };
-
-        assert_insert(cache.insert(ResourceVec::from_clusters(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![
-                xds_test::cluster!(dns_backend.name().leak()),
-                xds_test::cluster!(kube_backend.name().leak()),
+                xds_test::cluster!(logical_dns => "cluster.example", 7890),
+                xds_test::cluster!(eds => "whatever.default.svc.cluster.local:4433"),
             ],
-        )));
+        );
 
         let (resources, dns) = cache.collect();
         assert_eq!(
             resources,
             enum_map::enum_map! {
-                ResourceType::Listener => Changes {
-                    added: collect_str!(
-                        kube_backend.lb_config_route_name(),
-                        dns_backend.lb_config_route_name(),
-                    ),
-                    ..Default::default()
-                },
                 ResourceType::ClusterLoadAssignment => Changes {
-                    added: collect_str![kube_backend.name()],
+                    added: resource_names!["whatever.default.svc.cluster.local:4433"],
                     ..Default::default()
                  },
                 _ => Changes::default(),
@@ -1424,7 +1113,7 @@ mod test {
         assert_eq!(
             dns,
             DnsUpdates {
-                add: BTreeSet::from_iter([(Hostname::from_static("cluster.example"), 4433)]),
+                add: BTreeSet::from_iter([Hostname::from_static("cluster.example")]),
                 ..Default::default()
             },
         );
@@ -1433,65 +1122,52 @@ mod test {
         assert!(cache.subscriptions(ResourceType::Cluster).is_empty());
         assert_eq!(
             cache.versions(ResourceType::Cluster),
-            collect_kv_str![(kube_backend.name(), "123"), (dns_backend.name(), "123"),]
+            versions![
+                ("cluster.example:7890", "v123"),
+                ("whatever.default.svc.cluster.local:4433", "v123"),
+            ]
         );
     }
 
     #[test]
-    fn test_insert_cluster_cds_explicit() {
+    fn insert_cluster_cds_no_wildcard() {
         let mut cache = Cache::default();
         cache.set_wildcard(ResourceType::Cluster, false);
 
-        let kube_backend = BackendId {
-            service: Service::kube("default", "whatever").unwrap(),
-            port: 7890,
-        };
-        let dns_backend = BackendId {
-            service: Service::dns("cluster.example").unwrap(),
-            port: 4433,
-        };
-
         // subscribe only to the kube backend, clear changes
-        cache.subscribe(ResourceType::Cluster, &kube_backend.name());
+        cache.subscribe(
+            ResourceType::Cluster,
+            &ResourceName::from("whatever.default.svc.cluster.local:8008"),
+        );
         let _ = cache.collect();
 
         // insert both clusters at the same version
-        assert_insert(cache.insert(ResourceVec::from_clusters(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![
-                xds_test::cluster!(dns_backend.name().leak()),
-                xds_test::cluster!(kube_backend.name().leak()),
+                xds_test::cluster!(eds => "whatever.default.svc.cluster.local:8008"),
+                xds_test::cluster!(logical_dns => "example.com", 80),
             ],
-        )));
+        );
 
-        // only the kbue cluster should have had an effect, no DNS updates
+        // only the subscribed cluster should have had an effect
         let (resources, dns) = cache.collect();
         assert_eq!(
             resources,
             enum_map::enum_map! {
-                ResourceType::Listener => Changes {
-                    added: collect_str!(
-                        kube_backend.lb_config_route_name(),
-                    ),
-                    ..Default::default()
-                },
                 ResourceType::ClusterLoadAssignment => Changes {
-                    added: collect_str![kube_backend.name()],
+                    added: resource_names!("whatever.default.svc.cluster.local:8008"),
                     ..Default::default()
                  },
                 _ => Changes::default(),
             }
         );
         assert!(dns.is_noop());
-
-        // should have the explicit subscription to one cluster and one version
-        assert_eq!(
-            cache.subscriptions(ResourceType::Cluster),
-            vec![kube_backend.name()],
-        );
+        let expected: Vec<_> = resource_names!["whatever.default.svc.cluster.local:8008"];
+        assert_eq!(cache.subscriptions(ResourceType::Cluster), expected);
         assert_eq!(
             cache.versions(ResourceType::Cluster),
-            collect_kv_str![(kube_backend.name(), "123")]
+            versions![("whatever.default.svc.cluster.local:8008", "v123")],
         );
     }
 
@@ -1509,35 +1185,29 @@ mod test {
         let mut cache = Cache::default();
 
         // inserting with no subscription is empty
-        assert_insert(cache.insert(ResourceVec::from_route_configs(
-            "123".into(),
-            vec![route_config.clone()],
-        )));
+        assert_insert(&mut cache, vec![route_config.clone()]);
         let (resources, dns) = cache.collect();
         assert!(resources.values().all(|c| c.is_empty()));
         assert!(dns.is_noop());
         assert!(cache.data.route_configs.is_empty());
 
         // insert listener, should now be able to insert the route config
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![xds_test::listener!(
                 "listener.example.svc.cluster.local",
                 "example-route"
             )],
-        )));
+        );
 
         // should now have a new reference to a cluster
-        assert_insert(cache.insert(ResourceVec::from_route_configs(
-            "123".into(),
-            vec![route_config],
-        )));
+        assert_insert(&mut cache, vec![route_config]);
         let (resources, dns) = cache.collect();
         assert_eq!(
             resources,
             enum_map::enum_map! {
                 ResourceType::Cluster => Changes {
-                    added: collect_str!["cluster.example:8008"],
+                    added: resource_names!["cluster.example:8008"],
                     ..Default::default()
                 },
                 _ => Changes::default(),
@@ -1545,13 +1215,13 @@ mod test {
         );
         assert!(dns.is_noop());
 
-        assert_eq!(
-            cache.subscriptions(ResourceType::RouteConfiguration),
-            vec!["example-route"],
-        );
+        assert_eq!(cache.subscriptions(ResourceType::RouteConfiguration), {
+            let names: Vec<_> = resource_names!["example-route"];
+            names
+        });
         assert_eq!(
             cache.versions(ResourceType::RouteConfiguration),
-            collect_kv_str![("example-route", 123)],
+            versions![("example-route", "v123")],
         );
     }
 
@@ -1567,136 +1237,132 @@ mod test {
         );
 
         let mut cache = Cache::default();
-        cache.subscribe(ResourceType::RouteConfiguration, "example-route");
+        cache.subscribe(
+            ResourceType::RouteConfiguration,
+            &ResourceName::from("example-route"),
+        );
 
         // add the route
-        assert_insert(cache.insert(ResourceVec::from_route_configs(
-            "123".into(),
-            vec![route_config.clone()],
-        )));
+        assert_insert(&mut cache, vec![route_config.clone()]);
         let (resources, dns) = cache.collect();
         assert_eq!(
             resources,
             enum_map::enum_map! {
                 ResourceType::Cluster => Changes {
-                    added: collect_str!["cluster.example:8008"],
+                    added: resource_names!["cluster.example:8008"],
                     ..Default::default()
                 },
                 _ => Changes::default(),
             }
         );
         assert!(dns.is_noop());
-        assert_eq!(
-            cache.subscriptions(ResourceType::RouteConfiguration),
-            vec!["example-route"],
-        );
-        assert_eq!(
-            cache.subscriptions(ResourceType::Cluster),
-            vec!["cluster.example:8008"],
-        );
+        assert_eq!(cache.subscriptions(ResourceType::RouteConfiguration), {
+            let names: Vec<_> = resource_names!["example-route"];
+            names
+        });
+        assert_eq!(cache.subscriptions(ResourceType::Cluster), {
+            let names: Vec<_> = resource_names!["cluster.example:8008"];
+            names
+        });
         assert_eq!(
             cache.versions(ResourceType::RouteConfiguration),
-            collect_kv_str![("example-route", 123)],
+            versions![("example-route", "v123")],
         );
 
         // remove the route
         cache.remove(
             ResourceType::RouteConfiguration,
-            &["example-route".to_string()],
+            &[ResourceName::from("example-route")],
         );
         let (resources, dns) = cache.collect();
         assert_eq!(
             resources,
             enum_map::enum_map! {
                 ResourceType::Cluster => Changes {
-                    removed: collect_str!["cluster.example:8008"],
+                    removed: resource_names!["cluster.example:8008"],
                     ..Default::default()
                 },
                 _ => Changes::default(),
             }
         );
         assert!(dns.is_noop());
-        assert_eq!(
-            cache.subscriptions(ResourceType::RouteConfiguration),
-            vec!["example-route"],
-        );
+        assert_eq!(cache.subscriptions(ResourceType::RouteConfiguration), {
+            let names: Vec<_> = resource_names!["example-route"];
+            names
+        });
         assert!(cache.subscriptions(ResourceType::Cluster).is_empty());
 
         // remove the cluster
         //
         // NOTE: it doesn't seeem to matter if this cache.collect() is here
-        cache.remove(ResourceType::Cluster, &["cluster.example:8008".to_string()]);
+        cache.remove(
+            ResourceType::Cluster,
+            &[ResourceName::from("cluster.example:8008")],
+        );
         let _ = cache.collect();
 
         // add the route config again
-        assert_insert(cache.insert(ResourceVec::from_route_configs(
-            "123".into(),
-            vec![route_config],
-        )));
+        assert_insert(&mut cache, vec![route_config]);
         let (resources, dns) = cache.collect();
         assert_eq!(
             resources,
             enum_map::enum_map! {
                 ResourceType::Cluster => Changes {
-                    added: collect_str!["cluster.example:8008"],
+                    added: resource_names!["cluster.example:8008"],
                     ..Default::default()
                 },
                 _ => Changes::default(),
             }
         );
         assert!(dns.is_noop());
-        assert_eq!(
-            cache.subscriptions(ResourceType::RouteConfiguration),
-            vec!["example-route"],
-        );
-        assert_eq!(
-            cache.subscriptions(ResourceType::Cluster),
-            vec!["cluster.example:8008"],
-        );
+        assert_eq!(cache.subscriptions(ResourceType::RouteConfiguration), {
+            let names: Vec<_> = resource_names!["example-route"];
+            names
+        });
+        assert_eq!(cache.subscriptions(ResourceType::Cluster), {
+            let names: Vec<_> = resource_names!["cluster.example:8008"];
+            names
+        });
         assert_eq!(
             cache.versions(ResourceType::RouteConfiguration),
-            collect_kv_str![("example-route", 123)],
+            versions![("example-route", "v123")],
         );
     }
 
     #[test]
     fn test_insert_load_assignment() {
-        let kube_backend = BackendId {
-            service: Service::kube("default", "whatever").unwrap(),
-            port: 7890,
-        };
         let mut cache = Cache::default();
 
         // try to insert before being referenced
-        assert_insert(cache.insert(ResourceVec::from_load_assignments(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![xds_test::cla!(
                 "whatever.default.svc.cluster.local:7890" => {
                     "zone1" => ["1.1.1.1"]
                 }
             )],
-        )));
+        );
         let (resources, dns) = cache.collect();
         assert!(resources.values().all(|c| c.is_empty()));
         assert!(dns.is_noop());
         assert!(cache.data.load_assignments.is_empty());
 
         // insert a cluster
-        assert_insert(cache.insert(ResourceVec::from_clusters(
-            "123".into(),
-            vec![xds_test::cluster!(kube_backend.name().leak())],
-        )));
+        assert_insert(
+            &mut cache,
+            vec![xds_test::cluster!(eds => "whatever.default.svc.cluster.local:7890")],
+        );
         let _ = cache.collect();
 
         // try again
-        assert_insert(cache.insert(ResourceVec::from_load_assignments(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![xds_test::cla!(
                 "whatever.default.svc.cluster.local:7890" => {
                     "zone1" => ["1.1.1.1"]
                 }
             )],
-        )));
+        );
 
         // should be inserted, but won't cause changes
         let (resources, dns) = cache.collect();
@@ -1704,31 +1370,37 @@ mod test {
         assert!(dns.is_noop());
         assert_eq!(
             cache.versions(ResourceType::ClusterLoadAssignment),
-            collect_kv_str![("whatever.default.svc.cluster.local:7890", "123")]
+            versions![("whatever.default.svc.cluster.local:7890", "v123")]
         );
     }
 
     #[test]
-    fn test_remove_listener_explicit() {
+    fn test_remove_listener_no_wildcard() {
         let mut cache = Cache::default();
         cache.set_wildcard(ResourceType::Cluster, false);
         cache.set_wildcard(ResourceType::Listener, false);
 
         // subscribe to two listeners
-        cache.subscribe(ResourceType::Listener, "listener.example.svc.cluster.local");
-        cache.subscribe(ResourceType::Listener, "listener.local");
+        cache.subscribe(
+            ResourceType::Listener,
+            &ResourceName::from("listener.example.svc.cluster.local"),
+        );
+        cache.subscribe(
+            ResourceType::Listener,
+            &ResourceName::from("listener.local"),
+        );
         let _ = cache.collect();
 
         // insert a listener -> route -> cluster -> dns chain of configuration
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![xds_test::listener!(
                 "listener.example.svc.cluster.local",
                 "example-route",
             )],
-        )));
-        assert_insert(cache.insert(ResourceVec::from_route_configs(
-            "123".into(),
+        );
+        assert_insert(
+            &mut cache,
             vec![xds_test::route_config!(
                 "example-route",
                 vec![xds_test::vhost!(
@@ -1737,59 +1409,49 @@ mod test {
                     [xds_test::route!(default "cluster.example:8008")]
                 )]
             )],
-        )));
-        assert_insert(cache.insert(ResourceVec::from_clusters(
-            "123".into(),
-            vec![xds_test::cluster!("cluster.example:8008")],
-        )));
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
-            vec![xds_test::listener!(
-                "cluster.example.lb.jct:8008",
-                "lb-route" => [xds_test::vhost!(
-                    "lb-vhost",
-                    ["cluster.example.lb.jct:8080"],
-                    [xds_test::route!(default "cluster.example:8008")],
-                )],
-            )],
-        )));
+        );
+        assert_insert(
+            &mut cache,
+            vec![xds_test::cluster!(logical_dns => "cluster.example", 8008)],
+        );
 
         // check that the first set of resources makes sense
-        let _ = cache.collect();
-        assert_eq!(
-            cache.versions(ResourceType::Cluster),
-            collect_kv_str![("cluster.example:8008", "123")],
-        );
+        let _ = dbg!(cache.collect());
         assert_eq!(
             cache.versions(ResourceType::Listener),
-            collect_kv_str![
-                ("listener.example.svc.cluster.local", "123"),
-                ("cluster.example.lb.jct:8008", "123"),
-            ],
+            versions![("listener.example.svc.cluster.local", "v123")],
         );
         assert_eq!(
             cache.versions(ResourceType::RouteConfiguration),
-            collect_kv_str![("example-route", "123")],
+            versions![("example-route", "v123")],
+        );
+        assert_eq!(
+            cache.versions(ResourceType::Cluster),
+            versions![("cluster.example:8008", "v123")],
         );
         assert!(cache
             .versions(ResourceType::ClusterLoadAssignment)
             .is_empty());
+        assert_eq!(
+            Vec::<ResourceName>::new(),
+            cache.subscriptions(ResourceType::ClusterLoadAssignment),
+        );
 
         // add the second listener/route-config pointing to the same cluster
         // and remove the first one
         cache.remove(
             ResourceType::Listener,
-            &["listener.example.svc.cluster.local".to_string()],
+            &[ResourceName::from("listener.example.svc.cluster.local")],
         );
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![xds_test::listener!(
                 "listener.local",
                 "better-example-route",
             )],
-        )));
-        assert_insert(cache.insert(ResourceVec::from_route_configs(
-            "123".into(),
+        );
+        assert_insert(
+            &mut cache,
             vec![xds_test::route_config!(
                 "better-example-route",
                 vec![xds_test::vhost!(
@@ -1798,7 +1460,7 @@ mod test {
                     [xds_test::route!(default "cluster.example:8008")]
                 )]
             )],
-        )));
+        );
 
         // should add a remove for the RouteConfig. the cache is still subscribed
         // to the removed Listener, so it shouldn't appear here.
@@ -1807,7 +1469,7 @@ mod test {
             resources,
             enum_map::enum_map! {
                 ResourceType::RouteConfiguration => Changes {
-                    removed: collect_str!("example-route"),
+                    removed: resource_names!["example-route"],
                     ..Default::default()
                 },
                 _ => Changes::default()
@@ -1818,40 +1480,37 @@ mod test {
         // cache should only contain the data versions for what's there, but
         // should have subscriptions to the original two listeners and the
         // cluster lb config listener
-        assert_eq!(
-            cache.subscriptions(ResourceType::Listener),
-            vec![
-                "listener.example.svc.cluster.local",
-                "listener.local",
-                "cluster.example.lb.jct:8008",
-            ],
-        );
+        assert_eq!(cache.subscriptions(ResourceType::Listener), {
+            let names: Vec<_> =
+                resource_names!["listener.example.svc.cluster.local", "listener.local",];
+            names
+        },);
 
         assert_eq!(
             cache.versions(ResourceType::Listener),
-            collect_kv_str![
-                ("listener.local", "123"),
-                ("cluster.example.lb.jct:8008", "123"),
-            ],
+            versions![("listener.local", "v123")],
         );
         assert_eq!(
             cache.versions(ResourceType::RouteConfiguration),
-            collect_kv_str![("better-example-route", "123")],
+            versions![("better-example-route", "v123")],
         );
         assert_eq!(
             cache.versions(ResourceType::Cluster),
-            collect_kv_str![("cluster.example:8008", "123")],
+            versions![("cluster.example:8008", "v123")],
         );
 
         // removing the other listener should drop all data from cache,
         // but keep both subscriptions.
-        cache.remove(ResourceType::Listener, &["listener.local".to_string()]);
+        cache.remove(
+            ResourceType::Listener,
+            &[ResourceName::from("listener.local")],
+        );
         let (resources, dns) = cache.collect();
         assert_eq!(
             dns,
             DnsUpdates {
                 add: BTreeSet::new(),
-                remove: [(Hostname::from_static("cluster.example"), 8008)]
+                remove: [Hostname::from_static("cluster.example")]
                     .into_iter()
                     .collect(),
                 sync: false,
@@ -1862,25 +1521,25 @@ mod test {
             resources,
             enum_map::enum_map! {
                 ResourceType::Listener => Changes {
-                    removed: collect_str!("cluster.example.lb.jct:8008"),
                     ..Default::default()
                 },
                 ResourceType::RouteConfiguration => Changes {
-                    removed: collect_str!("better-example-route"),
+                    removed: resource_names!("better-example-route"),
                     ..Default::default()
                 },
                 ResourceType::Cluster => Changes {
-                    removed: collect_str!("cluster.example:8008"),
+                    removed: resource_names!("cluster.example:8008"),
                     ..Default::default()
                 },
                 ResourceType::ClusterLoadAssignment => Changes::default(),
             }
         );
 
-        assert_eq!(
-            cache.subscriptions(ResourceType::Listener),
-            vec!["listener.example.svc.cluster.local", "listener.local"],
-        );
+        assert_eq!(cache.subscriptions(ResourceType::Listener), {
+            let names: Vec<_> =
+                resource_names!["listener.example.svc.cluster.local", "listener.local"];
+            names
+        });
         for &rtype in ResourceType::all() {
             assert_eq!(cache.versions(rtype), HashMap::new());
         }
@@ -1893,19 +1552,22 @@ mod test {
         cache.set_wildcard(ResourceType::Listener, true);
 
         // subscribe to one listener
-        cache.subscribe(ResourceType::Listener, "listener.example.svc.cluster.local");
+        cache.subscribe(
+            ResourceType::Listener,
+            &ResourceName::from("listener.example.svc.cluster.local"),
+        );
         let _ = cache.collect();
 
         // insert two listener->route pairs pointing at the same cluster
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
+        assert_insert(
+            &mut cache,
             vec![
                 xds_test::listener!("listener.example.svc.cluster.local", "example-route"),
                 xds_test::listener!("listener.local", "better-example-route"),
             ],
-        )));
-        assert_insert(cache.insert(ResourceVec::from_route_configs(
-            "123".into(),
+        );
+        assert_insert(
+            &mut cache,
             vec![
                 xds_test::route_config!(
                     "example-route",
@@ -1924,40 +1586,28 @@ mod test {
                     )]
                 ),
             ],
-        )));
-        assert_insert(cache.insert(ResourceVec::from_clusters(
-            "123".into(),
-            vec![xds_test::cluster!("cluster.example:8008")],
-        )));
-        assert_insert(cache.insert(ResourceVec::from_listeners(
-            "123".into(),
-            vec![xds_test::listener!(
-                "cluster.example.lb.jct:8008",
-                "lb-route" => [xds_test::vhost!(
-                    "lb-vhost",
-                    ["cluster.example.lb.jct:8080"],
-                    [xds_test::route!(default "cluster.example:8008")],
-                )],
-            )],
-        )));
+        );
+        assert_insert(
+            &mut cache,
+            vec![xds_test::cluster!(logical_dns => "cluster.example", 8008)],
+        );
 
         // check that the first set of resources makes sense
         let _ = cache.collect();
         assert_eq!(
             cache.versions(ResourceType::Cluster),
-            collect_kv_str![("cluster.example:8008", "123")],
+            versions![("cluster.example:8008", "v123")],
         );
         assert_eq!(
             cache.versions(ResourceType::Listener),
-            collect_kv_str![
-                ("listener.local", "123"),
-                ("listener.example.svc.cluster.local", "123"),
-                ("cluster.example.lb.jct:8008", "123"),
+            versions![
+                ("listener.local", "v123"),
+                ("listener.example.svc.cluster.local", "v123"),
             ],
         );
         assert_eq!(
             cache.versions(ResourceType::RouteConfiguration),
-            collect_kv_str![("example-route", "123"), ("better-example-route", "123")],
+            versions![("example-route", "v123"), ("better-example-route", "v123")],
         );
         assert!(cache
             .versions(ResourceType::ClusterLoadAssignment)
@@ -1966,7 +1616,7 @@ mod test {
         // remove the explicitly subscribed listener
         cache.remove(
             ResourceType::Listener,
-            &["listener.example.svc.cluster.local".to_string()],
+            &[ResourceName::from("listener.example.svc.cluster.local")],
         );
 
         let (resources, dns) = cache.collect();
@@ -1974,7 +1624,7 @@ mod test {
             resources,
             enum_map::enum_map! {
                 ResourceType::RouteConfiguration => Changes {
-                    removed: collect_str!("example-route"),
+                    removed: resource_names!["example-route"],
                     ..Default::default()
                 },
                 _ => Changes::default()
@@ -1982,38 +1632,34 @@ mod test {
         );
         assert!(dns.is_noop());
 
-        assert_eq!(
-            cache.subscriptions(ResourceType::Listener),
-            vec![
-                "listener.example.svc.cluster.local",
-                "cluster.example.lb.jct:8008"
-            ],
-        );
-
+        assert_eq!(cache.subscriptions(ResourceType::Listener), {
+            let name: Vec<_> = resource_names!["listener.example.svc.cluster.local",];
+            name
+        });
         assert_eq!(
             cache.versions(ResourceType::Listener),
-            collect_kv_str![
-                ("listener.local", "123"),
-                ("cluster.example.lb.jct:8008", "123"),
-            ],
+            versions![("listener.local", "v123"),],
         );
         assert_eq!(
             cache.versions(ResourceType::RouteConfiguration),
-            collect_kv_str![("better-example-route", "123")],
+            versions![("better-example-route", "v123")],
         );
         assert_eq!(
             cache.versions(ResourceType::Cluster),
-            collect_kv_str![("cluster.example:8008", "123")],
+            versions![("cluster.example:8008", "v123")],
         );
 
         // removing the wildcard listener should drop the rest of the data
-        cache.remove(ResourceType::Listener, &["listener.local".to_string()]);
+        cache.remove(
+            ResourceType::Listener,
+            &[ResourceName::from("listener.local")],
+        );
         let (resources, dns) = cache.collect();
         assert_eq!(
             dns,
             DnsUpdates {
                 add: BTreeSet::new(),
-                remove: [(Hostname::from_static("cluster.example"), 8008)]
+                remove: [Hostname::from_static("cluster.example")]
                     .into_iter()
                     .collect(),
                 sync: false,
@@ -2023,25 +1669,24 @@ mod test {
             resources,
             enum_map::enum_map! {
                 ResourceType::Listener => Changes {
-                    removed: collect_str!("cluster.example.lb.jct:8008"),
                     ..Default::default()
                 },
                 ResourceType::RouteConfiguration => Changes {
-                    removed: collect_str!("better-example-route"),
+                    removed: resource_names!("better-example-route"),
                     ..Default::default()
                 },
                 ResourceType::Cluster => Changes {
-                    removed: collect_str!("cluster.example:8008"),
+                    removed: resource_names!("cluster.example:8008"),
                     ..Default::default()
                 },
                 ResourceType::ClusterLoadAssignment => Changes::default(),
             }
         );
 
-        assert_eq!(
-            cache.subscriptions(ResourceType::Listener),
-            vec!["listener.example.svc.cluster.local"],
-        );
-        assert_eq!(cache.versions(ResourceType::Listener), collect_kv_str![]);
+        assert_eq!(cache.subscriptions(ResourceType::Listener), {
+            let names: Vec<_> = resource_names!["listener.example.svc.cluster.local"];
+            names
+        },);
+        assert_eq!(cache.versions(ResourceType::Listener), versions![]);
     }
 }

--- a/crates/junction-core/src/xds/load_balancer.rs
+++ b/crates/junction-core/src/xds/load_balancer.rs
@@ -1,5 +1,8 @@
-use crate::{endpoints::EndpointGroup, error::Trace, hash::thread_local_xxhash};
-use junction_api::backend::{Backend, LbPolicy, RequestHashPolicy, RequestHasher, RingHashParams};
+use crate::{
+    error::Trace,
+    hash::thread_local_xxhash,
+    xds::{clusters::LbPolicy, endpoints::EndpointGroup},
+};
 use smol_str::ToSmolStr;
 use std::{
     net::SocketAddr,
@@ -9,16 +12,8 @@ use std::{
     },
 };
 
-/// A [Backend][junction_api::backend::Backend] and the [LoadBalancer] it's
-/// configured with.
 #[derive(Debug)]
-pub struct BackendLb {
-    pub config: Backend,
-    pub load_balancer: LoadBalancer,
-}
-
-#[derive(Debug)]
-pub enum LoadBalancer {
+pub(crate) enum LoadBalancer {
     RoundRobin(RoundRobinLb),
     RingHash(RingHashLb),
 }
@@ -27,18 +22,16 @@ impl LoadBalancer {
     pub(crate) fn load_balance<'e>(
         &self,
         trace: &mut Trace,
+        request_hash: u64,
         endpoints: &'e EndpointGroup,
-        url: &crate::Url,
-        headers: &http::HeaderMap,
         previous_addrs: &[SocketAddr],
     ) -> Option<&'e SocketAddr> {
+        let _ = previous_addrs;
         match self {
             // RoundRobin skips previously picked addrs and ignores context
-            LoadBalancer::RoundRobin(lb) => lb.pick_endpoint(trace, endpoints, previous_addrs),
+            LoadBalancer::RoundRobin(lb) => lb.pick_endpoint(trace, endpoints),
             // RingHash needs context but doesn't care about history
-            LoadBalancer::RingHash(lb) => {
-                lb.pick_endpoint(trace, endpoints, url, headers, &lb.config.hash_params)
-            }
+            LoadBalancer::RingHash(lb) => lb.pick_endpoint(trace, endpoints, request_hash),
         }
     }
 }
@@ -47,7 +40,9 @@ impl LoadBalancer {
     pub(crate) fn from_config(config: &LbPolicy) -> Self {
         match config {
             LbPolicy::RoundRobin => LoadBalancer::RoundRobin(RoundRobinLb::default()),
-            LbPolicy::RingHash(x) => LoadBalancer::RingHash(RingHashLb::new(x)),
+            LbPolicy::RingHash { min_ring_size } => {
+                LoadBalancer::RingHash(RingHashLb::new(*min_ring_size))
+            }
             LbPolicy::Unspecified => LoadBalancer::RoundRobin(RoundRobinLb::default()),
         }
     }
@@ -69,7 +64,6 @@ impl RoundRobinLb {
         &self,
         trace: &mut Trace,
         endpoint_group: &'e EndpointGroup,
-        previous_addrs: &[SocketAddr],
     ) -> Option<&'e SocketAddr> {
         // TODO: actually use previous addrs to pick a new address. have to
         // decide if we return anything if all addresses have previously been
@@ -77,7 +71,6 @@ impl RoundRobinLb {
         // but we'd prefer to do something simpler by default.
         //
         // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-retrypolicy
-        let _ = previous_addrs;
 
         let idx = self.idx.fetch_add(1, Ordering::SeqCst) % endpoint_group.len();
         let addr = endpoint_group.nth(idx);
@@ -97,7 +90,7 @@ impl RoundRobinLb {
 ///
 #[derive(Debug)]
 pub struct RingHashLb {
-    config: RingHashParams,
+    min_ring_size: u32,
     ring: RwLock<Ring>,
 }
 
@@ -108,12 +101,12 @@ struct RingEntry {
 }
 
 impl RingHashLb {
-    fn new(config: &RingHashParams) -> Self {
+    fn new(min_ring_size: u32) -> Self {
         Self {
-            config: config.clone(),
+            min_ring_size,
             ring: RwLock::new(Ring {
-                eg_hash: 0,
-                entries: Vec::with_capacity(config.min_ring_size as usize),
+                hash: 0,
+                entries: Vec::with_capacity(min_ring_size as usize),
             }),
         }
     }
@@ -122,13 +115,8 @@ impl RingHashLb {
         &self,
         trace: &mut Trace,
         endpoints: &'e EndpointGroup,
-        url: &crate::Url,
-        headers: &http::HeaderMap,
-        hash_params: &Vec<RequestHashPolicy>,
+        request_hash: u64,
     ) -> Option<&'e SocketAddr> {
-        let request_hash =
-            hash_request(hash_params, url, headers).unwrap_or_else(crate::rand::random);
-
         let endpoint_idx = self.with_ring(endpoints, |r| r.pick(request_hash))?;
         let addr = endpoints.nth(endpoint_idx);
 
@@ -154,14 +142,14 @@ impl RingHashLb {
         // explicitly drop the guard at the end so we can't get confused and
         // try to upgrade and deadlock ourselves.
         let ring = self.ring.read().unwrap();
-        if ring.eg_hash == endpoint_group.hash {
+        if ring.hash == endpoint_group.hash {
             return cb(&ring);
         }
         std::mem::drop(ring);
 
         // write path:
         let mut ring = self.ring.write().unwrap();
-        ring.rebuild(self.config.min_ring_size as usize, endpoint_group);
+        ring.rebuild(self.min_ring_size as usize, endpoint_group);
         cb(&ring)
     }
 }
@@ -170,7 +158,7 @@ impl RingHashLb {
 struct Ring {
     // The hash of the EndpointGroup used to build the Ring. This is slightly
     // more stable than ResourceVersion, but could be changed to that.
-    eg_hash: u64,
+    hash: u64,
     entries: Vec<RingEntry>,
 }
 
@@ -202,7 +190,7 @@ impl Ring {
             }
         }
 
-        self.eg_hash = endpoint_group.hash;
+        self.hash = endpoint_group.hash;
         self.entries.sort_by_key(|e| e.hash);
     }
 
@@ -223,84 +211,23 @@ impl Ring {
     }
 }
 
-/// Hash an outgoing request based on a set of hash policies.
-///
-/// Like Envoy and gRPC, multiple hash policies are combined by applying a
-/// bitwise left-rotate to the previous value and xor-ing the new value into
-/// the previous value.
-///
-/// See:
-/// - https://github.com/grpc/proposal/blob/master/A42-xds-ring-hash-lb-policy.md#xds-api-fields
-/// - https://github.com/envoyproxy/envoy/blob/main/source/common/http/hash_policy.cc#L236-L257
-pub(crate) fn hash_request(
-    hash_policies: &Vec<RequestHashPolicy>,
-    url: &crate::Url,
-    headers: &http::HeaderMap,
-) -> Option<u64> {
-    let mut hash: Option<u64> = None;
-
-    for hash_policy in hash_policies {
-        if let Some(new_hash) = hash_component(hash_policy, url, headers) {
-            hash = Some(match hash {
-                Some(hash) => hash.rotate_left(1) ^ new_hash,
-                None => new_hash,
-            });
-
-            if hash_policy.terminal {
-                break;
-            }
-        }
-    }
-
-    hash
-}
-
-fn hash_component(
-    policy: &RequestHashPolicy,
-    url: &crate::Url,
-    headers: &http::HeaderMap,
-) -> Option<u64> {
-    match &policy.hasher {
-        RequestHasher::Header { name } => {
-            let mut header_values: Vec<_> = headers
-                .get_all(name)
-                .iter()
-                .map(http::HeaderValue::as_bytes)
-                .collect();
-
-            if header_values.is_empty() {
-                None
-            } else {
-                // sort values so that "foo,bar" and "bar,foo" hash to the same value
-                header_values.sort();
-                Some(thread_local_xxhash::hash_iter(header_values))
-            }
-        }
-        RequestHasher::QueryParam { ref name } => url.query().map(|query| {
-            let matching_vals = form_urlencoded::parse(query.as_bytes())
-                .filter_map(|(param, value)| (&param == name).then_some(value));
-            thread_local_xxhash::hash_iter(matching_vals)
-        }),
-    }
-}
-
 #[cfg(test)]
 mod test_ring_hash {
-    use crate::endpoints::Locality;
+    use crate::xds::endpoints::Locality;
 
     use super::*;
 
     #[test]
     fn test_rebuild_ring() {
         let mut ring = Ring {
-            eg_hash: 0,
+            hash: 0,
             entries: Vec::new(),
         };
 
         // rebuild a ring with no min size
         ring.rebuild(0, &endpoint_group(123, ["1.1.1.1:80", "1.1.1.2:80"]));
 
-        assert_eq!(ring.eg_hash, 123);
+        assert_eq!(ring.hash, 123);
         assert_eq!(ring.entries.len(), 2);
         assert_eq!(ring_indexes(&ring), (0..2).collect::<Vec<_>>());
         assert_hashes_unique(&ring);
@@ -313,7 +240,7 @@ mod test_ring_hash {
             &endpoint_group(123, ["1.1.1.1:80", "1.1.1.2:80", "1.1.1.3:80"]),
         );
 
-        assert_eq!(ring.eg_hash, 123);
+        assert_eq!(ring.hash, 123);
         assert_eq!(ring.entries.len(), 3);
         assert_eq!(ring_indexes(&ring), (0..3).collect::<Vec<_>>());
         assert_hashes_unique(&ring);
@@ -332,7 +259,7 @@ mod test_ring_hash {
     #[test]
     fn test_rebuild_ring_min_size() {
         let mut ring = Ring {
-            eg_hash: 0,
+            hash: 0,
             entries: Vec::new(),
         };
 
@@ -359,14 +286,15 @@ mod test_ring_hash {
     #[test]
     fn test_pick() {
         let mut ring = Ring {
-            eg_hash: 0,
+            hash: 0,
             entries: vec![],
         };
         ring.rebuild(
             0,
             &EndpointGroup::new(
+                0,
                 [(
-                    Locality::Unknown,
+                    Locality::empty(),
                     vec![
                         "1.1.1.1:80".parse().unwrap(),
                         "1.1.1.2:80".parse().unwrap(),
@@ -399,9 +327,8 @@ mod test_ring_hash {
     fn endpoint_group(hash: u64, addrs: impl IntoIterator<Item = &'static str>) -> EndpointGroup {
         let addrs = addrs.into_iter().map(|s| s.parse().unwrap()).collect();
 
-        let mut eg = EndpointGroup::new([(Locality::Unknown, addrs)].into());
+        let mut eg = EndpointGroup::new(123, [(Locality::empty(), addrs)].into());
         eg.hash = hash;
-
         eg
     }
 

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -1,55 +1,220 @@
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::net::SocketAddr;
-use std::ops::Deref;
-use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
-
-use junction_api::backend::Backend;
-use junction_api::backend::BackendId;
-use junction_api::http::Route;
+pub(crate) mod clusters;
+pub(crate) mod endpoints;
+pub(crate) mod listeners;
+pub(crate) mod route_configs;
+pub(crate) use clusters::Cluster;
+pub(crate) use endpoints::LoadAssignment;
 use junction_api::Hostname;
+pub(crate) use listeners::ApiListener;
+pub(crate) use route_configs::RouteConfiguration;
+
 use smol_str::SmolStr;
+use std::borrow::Cow;
+use std::fmt::Write;
+use std::ops::Deref;
+use std::sync::Arc;
+
 use xds_api::{
-    pb::envoy::{
-        config::{
-            cluster::v3 as xds_cluster, core::v3 as xds_core, endpoint::v3 as xds_endpoint,
-            listener::v3 as xds_listener, route::v3 as xds_route,
-        },
-        extensions::filters::network::http_connection_manager::v3 as xds_http,
-        service::discovery::v3 as xds_discovery,
-    },
+    pb::{envoy::config::core::v3 as xds_core, google::protobuf},
     WellKnownTypes,
 };
 
-use crate::endpoints::{EndpointGroup, Locality, LocalityInfo};
-use crate::load_balancer::{BackendLb, LoadBalancer};
+macro_rules! value_or_default {
+    ($value:expr, $default:expr) => {
+        $value.as_ref().map(|v| v.value).unwrap_or($default)
+    };
+}
+pub(crate) use value_or_default;
 
 // FIXME: validate that the all the EDS config sources use ADS instead of just assuming it everywhere.
 
-#[derive(Clone, Debug, thiserror::Error)]
-pub(crate) enum ResourceError {
-    #[error("{0}")]
-    InvalidResource(#[from] junction_api::Error),
+/// An xDS resource that can be handled, decoded, and cached.
+///
+/// Resources must be able to be decoded from a [protobuf::Any] and from
+/// their associated xDS protobuf type, and should know how to return a
+/// set of other xDS resources they reference.
+pub(crate) trait Resource: Sized {
+    type Xds: prost::Name + Default;
 
-    #[error("invalid xDS: {resource_name}: {message}")]
-    InvalidXds {
-        resource_name: String,
-        message: Cow<'static, str>,
-    },
+    fn from_any(any: &protobuf::Any) -> Result<Self, ResourceError> {
+        let m: Self::Xds = any.to_msg()?;
+        Self::from_xds(&m)
+    }
+
+    fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError>;
+    fn references(&self) -> Vec<(ResourceType, ResourceName)>;
+    fn dns_names(&self) -> Vec<&Hostname> {
+        Vec::new()
+    }
+}
+
+/// An error that occurred while trying to parse and validate an incoming
+/// xDS message.
+#[derive(Clone, Debug, thiserror::Error, PartialEq)]
+pub(crate) struct ResourceError {
+    kind: ResourceErrorKind,
+    path: Vec<PathEntry>,
+}
+
+impl std::fmt::Display for ResourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.path.is_empty() {
+            write!(f, "{}: ", path_str(&self.path))?;
+        }
+
+        write!(f, "{}", self.kind)
+    }
+}
+
+impl From<prost::DecodeError> for ResourceError {
+    fn from(err: prost::DecodeError) -> Self {
+        Self {
+            kind: ResourceErrorKind::Decode(err),
+            path: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+enum ResourceErrorKind {
+    #[error(transparent)]
+    Decode(prost::DecodeError),
+
+    #[error("{0}")]
+    Invalid(Cow<'static, str>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PathEntry {
+    Field(&'static str),
+    Index(usize),
+    MapIndex(String),
+}
+
+impl std::fmt::Display for PathEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PathEntry::Field(field) => f.write_str(field),
+            PathEntry::Index(idx) => write!(f, "[{idx}]"),
+            PathEntry::MapIndex(field) => write!(f, "[{field}]"),
+        }
+    }
+}
+
+fn path_str(path: &[PathEntry]) -> String {
+    let mut buf = String::new();
+
+    let path_iter = path.iter().rev();
+    for (i, path_entry) in path_iter.enumerate() {
+        if i > 0 && matches!(path_entry, PathEntry::Field(_)) {
+            buf.push('.');
+        }
+        let _ = write!(&mut buf, "{}", path_entry);
+    }
+
+    buf
 }
 
 impl ResourceError {
-    fn for_xds(resource_name: String, message: String) -> Self {
-        Self::InvalidXds {
-            resource_name,
-            message: message.into(),
+    pub fn invalid(msg: &'static str) -> Self {
+        Self {
+            kind: ResourceErrorKind::Invalid(Cow::Borrowed(msg)),
+            path: Vec::new(),
         }
     }
 
-    fn for_xds_static(resource_name: String, message: &'static str) -> Self {
-        Self::InvalidXds {
-            resource_name,
-            message: message.into(),
+    pub fn invalid_with(msg: String) -> Self {
+        Self {
+            kind: ResourceErrorKind::Invalid(Cow::Owned(msg)),
+            path: Vec::new(),
+        }
+    }
+
+    pub fn is_decode(&self) -> bool {
+        matches!(&self.kind, ResourceErrorKind::Decode(_))
+    }
+
+    pub fn is_invalid(&self) -> bool {
+        matches!(&self.kind, ResourceErrorKind::Invalid(_))
+    }
+
+    pub fn path(&self) -> String {
+        path_str(&self.path)
+    }
+
+    pub fn with_field(mut self, field: &'static str) -> Self {
+        self.path.push(PathEntry::Field(field));
+        self
+    }
+
+    pub fn with_index(mut self, idx: usize) -> Self {
+        self.path.push(PathEntry::Index(idx));
+        self
+    }
+
+    #[inline(always)]
+    pub fn with_field_index(self, field: &'static str, index: usize) -> Self {
+        self.with_index(index).with_field(field)
+    }
+
+    pub fn with_map_key(mut self, key: String) -> Self {
+        self.path.push(PathEntry::MapIndex(key));
+        self
+    }
+
+    #[inline(always)]
+    pub fn with_field_key<T: std::fmt::Display>(self, field: &'static str, key: T) -> Self {
+        self.with_map_key(key.to_string()).with_field(field)
+    }
+}
+
+// use a trait here so we can implement methods on Result<T, Error> instead of
+// on Error directly. this makes life saner when doing ingest.
+pub trait ErrorCtx<T>: Sized {
+    fn with_field(self, field: &'static str) -> Result<T, ResourceError>;
+    fn with_index(self, idx: usize) -> Result<T, ResourceError>;
+    fn with_map_key(self, idx: String) -> Result<T, ResourceError>;
+
+    #[allow(unused)]
+    fn with_fields(self, a: &'static str, b: &'static str) -> Result<T, ResourceError> {
+        self.with_field(b).with_field(a)
+    }
+
+    fn with_field_index(self, field: &'static str, index: usize) -> Result<T, ResourceError> {
+        self.with_index(index).with_field(field)
+    }
+
+    fn with_field_key<F: std::fmt::Display>(
+        self,
+        field: &'static str,
+        key: F,
+    ) -> Result<T, ResourceError> {
+        self.with_map_key(key.to_string()).with_field(field)
+    }
+}
+
+impl<T, E> ErrorCtx<T> for Result<T, E>
+where
+    E: Into<ResourceError>,
+{
+    fn with_field(self, field: &'static str) -> Result<T, ResourceError> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(e) => Err(e.into().with_field(field)),
+        }
+    }
+
+    fn with_index(self, idx: usize) -> Result<T, ResourceError> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(e) => Err(e.into().with_index(idx)),
+        }
+    }
+
+    fn with_map_key(self, idx: String) -> Result<T, ResourceError> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(e) => Err(e.into().with_map_key(idx)),
         }
     }
 }
@@ -157,450 +322,69 @@ impl ResourceType {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) enum ResourceVec {
-    Listener(VersionedVec<xds_listener::Listener>),
-    RouteConfiguration(VersionedVec<xds_route::RouteConfiguration>),
-    Cluster(VersionedVec<xds_cluster::Cluster>),
-    ClusterLoadAssignment(VersionedVec<xds_endpoint::ClusterLoadAssignment>),
-}
-
-type VersionedVec<T> = Vec<(ResourceVersion, T)>;
-
-impl ResourceVec {
-    pub(crate) fn from_resources(
-        rtype: ResourceType,
-        resources: Vec<xds_discovery::Resource>,
-    ) -> Result<Self, prost::DecodeError> {
-        match rtype {
-            ResourceType::Cluster => from_resource_vec(resources).map(Self::Cluster),
-            ResourceType::ClusterLoadAssignment => {
-                from_resource_vec(resources).map(Self::ClusterLoadAssignment)
-            }
-            ResourceType::Listener => from_resource_vec(resources).map(Self::Listener),
-            ResourceType::RouteConfiguration => {
-                from_resource_vec(resources).map(Self::RouteConfiguration)
-            }
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn resource_type(&self) -> ResourceType {
-        match self {
-            ResourceVec::Listener(_) => ResourceType::Listener,
-            ResourceVec::RouteConfiguration(_) => ResourceType::RouteConfiguration,
-            ResourceVec::Cluster(_) => ResourceType::Cluster,
-            ResourceVec::ClusterLoadAssignment(_) => ResourceType::ClusterLoadAssignment,
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn to_resources(&self) -> Result<Vec<xds_discovery::Resource>, prost::EncodeError> {
-        match self {
-            ResourceVec::Listener(vec) => to_resource_vec(vec),
-            ResourceVec::RouteConfiguration(vec) => to_resource_vec(vec),
-            ResourceVec::Cluster(vec) => to_resource_vec(vec),
-            ResourceVec::ClusterLoadAssignment(vec) => to_resource_vec(vec),
-        }
-    }
-}
-
-macro_rules! test_constructor {
-    ($name:ident, $variant:ident, $xds_type:ty) => {
-        impl ResourceVec {
-            #[cfg(test)]
-            pub(crate) fn $name<I: IntoIterator<Item = $xds_type>>(
-                version: ResourceVersion,
-                xs: I,
-            ) -> Self {
-                let data = xs.into_iter().map(|l| (version.clone(), l)).collect();
-                Self::$variant(data)
-            }
-        }
-    };
-}
-
-test_constructor!(from_listeners, Listener, xds_listener::Listener);
-test_constructor!(
-    from_route_configs,
-    RouteConfiguration,
-    xds_route::RouteConfiguration
-);
-test_constructor!(from_clusters, Cluster, xds_cluster::Cluster);
-test_constructor!(
-    from_load_assignments,
-    ClusterLoadAssignment,
-    xds_endpoint::ClusterLoadAssignment
-);
-
-fn from_resource_vec<M: Default + prost::Name>(
-    resources: Vec<xds_discovery::Resource>,
-) -> Result<VersionedVec<M>, prost::DecodeError> {
-    let mut ms = Vec::with_capacity(resources.len());
-    for r in resources {
-        let Some(any) = r.resource else {
-            continue;
-        };
-        ms.push((ResourceVersion::from(r.version), any.to_msg()?));
-    }
-
-    Ok(ms)
-}
-
-#[cfg(test)]
-fn to_resource_vec<M: prost::Name>(
-    xs: &VersionedVec<M>,
-) -> Result<Vec<xds_discovery::Resource>, prost::EncodeError> {
-    use xds_api::pb::google::protobuf;
-
-    let mut resources = Vec::with_capacity(xs.len());
-
-    for (v, msg) in xs {
-        let as_any = protobuf::Any::from_msg(msg)?;
-        resources.push(xds_discovery::Resource {
-            resource: Some(as_any),
-            version: v.to_string(),
-            ..Default::default()
-        })
-    }
-
-    Ok(resources)
-}
-
-/// A typed reference to another resource.
-///
-/// This is functionally a `String` and implements `Clone`, `Ord`, and `Eq`` as
-/// if it was just a string.
-#[derive(Debug)]
-pub(crate) struct ResourceName<T> {
-    _type: PhantomData<T>,
+#[derive(Debug, Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ResourceName {
     name: String,
 }
 
-impl<T> ResourceName<T> {
+impl std::fmt::Display for ResourceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl ResourceName {
     pub fn as_str(&self) -> &str {
+        &self.name
+    }
+
+    pub fn wildcard() -> Self {
+        Self {
+            name: "*".to_string(),
+        }
+    }
+}
+
+impl AsRef<str> for ResourceName {
+    fn as_ref(&self) -> &str {
         &self.name
     }
 }
 
-impl<T> Clone for ResourceName<T> {
-    fn clone(&self) -> Self {
+impl From<&'static str> for ResourceName {
+    fn from(name: &'static str) -> Self {
         Self {
-            _type: PhantomData,
-            name: self.name.clone(),
+            name: name.to_string(),
         }
     }
 }
 
-impl<T> From<String> for ResourceName<T> {
+impl From<String> for ResourceName {
     fn from(name: String) -> Self {
-        Self {
-            _type: PhantomData,
-            name,
-        }
+        Self { name }
     }
 }
 
-impl<T> PartialEq for ResourceName<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
+/// An xDS ConfigSource that specifies a resource is fetchable on the same ADS
+/// connection as the current resource.
+pub(super) const fn ads_config_source() -> xds_core::ConfigSource {
+    xds_core::ConfigSource {
+        config_source_specifier: Some(xds_core::config_source::ConfigSourceSpecifier::Ads(
+            xds_core::AggregatedConfigSource {},
+        )),
+        resource_api_version: xds_core::ApiVersion::V3 as i32,
+        authorities: Vec::new(),
+        initial_fetch_timeout: None,
     }
 }
 
-impl<T> Eq for ResourceName<T> {}
-
-#[allow(clippy::non_canonical_partial_ord_impl)]
-impl<T> PartialOrd for ResourceName<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.name.partial_cmp(&other.name)
-    }
-}
-
-impl<T> Ord for ResourceName<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.name.cmp(&other.name)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct ApiListener {
-    pub xds: xds_listener::Listener,
-    pub route_config: ApiListenerData,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) enum ApiListenerData {
-    Rds(ResourceName<RouteConfig>),
-    Inlined(RouteConfigData),
-}
-
-fn http_connection_manager(
-    listener: &xds_listener::Listener,
-) -> Result<xds_http::HttpConnectionManager, ResourceError> {
-    let api_listener = listener
-        .api_listener
-        .as_ref()
-        .and_then(|l| l.api_listener.as_ref())
-        .ok_or_else(|| {
-            ResourceError::for_xds_static(listener.name.clone(), "Listener has no api_listener")
-        })?;
-
-    api_listener.to_msg().map_err(|e| {
-        ResourceError::for_xds(listener.name.clone(), format!("invalid api_listener: {e}"))
-    })
-}
-
-impl ApiListener {
-    pub(crate) fn from_xds(name: &str, xds: xds_listener::Listener) -> Result<Self, ResourceError> {
-        use xds_http::http_connection_manager::RouteSpecifier;
-
-        let conn_manager = http_connection_manager(&xds)?;
-        let data = match &conn_manager.route_specifier {
-            Some(RouteSpecifier::Rds(rds)) => {
-                let name = rds.route_config_name.clone();
-                ApiListenerData::Rds(name.into())
-            }
-            Some(RouteSpecifier::RouteConfig(route_config)) => {
-                let data = RouteConfigData::from_xds(route_config)?;
-                ApiListenerData::Inlined(data)
-            }
-            _ => {
-                return Err(ResourceError::for_xds_static(
-                    name.to_string(),
-                    "api_listener has no routes configured",
-                ))
-            }
-        };
-
-        Ok(Self {
-            xds,
-            route_config: data,
-        })
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct RouteConfig {
-    pub xds: xds_route::RouteConfiguration,
-    pub data: RouteConfigData,
-}
-
-#[derive(Clone, Debug)]
-pub(super) enum RouteConfigData {
-    Route {
-        route: Arc<Route>,
-        clusters: Vec<ResourceName<Cluster>>,
-    },
-    LbPolicy {
-        action: Arc<xds_route::RouteAction>,
-        cluster: ResourceName<Cluster>,
-    },
-}
-
-impl RouteConfigData {
-    fn from_xds(xds: &xds_route::RouteConfiguration) -> Result<Self, ResourceError> {
-        match BackendId::from_lb_config_route_name(&xds.name) {
-            // it's a normal route
-            Err(_) => {
-                let clusters = RouteConfig::cluster_names(xds);
-                let route = Arc::new(Route::from_xds(xds)?);
-                Ok(RouteConfigData::Route { route, clusters })
-            }
-            // it's an lb config route
-            Ok(_) => RouteConfig::lb_policy_action(xds).ok_or(ResourceError::for_xds_static(
-                xds.name.clone(),
-                "failed to parse LB config route",
-            )),
-        }
-    }
-}
-
-impl RouteConfig {
-    pub(crate) fn from_xds(xds: xds_route::RouteConfiguration) -> Result<Self, ResourceError> {
-        let data = RouteConfigData::from_xds(&xds)?;
-        Ok(Self { xds, data })
-    }
-
-    fn cluster_names(xds: &xds_route::RouteConfiguration) -> Vec<ResourceName<Cluster>> {
-        let mut clusters = BTreeSet::new();
-        for vhost in &xds.virtual_hosts {
-            for route in &vhost.routes {
-                let Some(xds_route::route::Action::Route(route_action)) = &route.action else {
-                    continue;
-                };
-
-                match &route_action.cluster_specifier {
-                    Some(xds_route::route_action::ClusterSpecifier::Cluster(cluster)) => {
-                        clusters.insert(cluster.clone());
-                    }
-                    Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(
-                        weighted_clusters,
-                    )) => {
-                        for w in &weighted_clusters.clusters {
-                            clusters.insert(w.name.clone());
-                        }
-                    }
-                    _ => continue,
-                }
-            }
-        }
-        clusters.into_iter().map(|n| n.into()).collect()
-    }
-
-    fn lb_policy_action(xds: &xds_route::RouteConfiguration) -> Option<RouteConfigData> {
-        let vhost = match &xds.virtual_hosts.as_slice() {
-            &[vhost] => vhost,
-            _ => return None,
-        };
-
-        let route = match &vhost.routes.as_slice() {
-            &[route] => route,
-            _ => return None,
-        };
-
-        let Some(xds_route::route::Action::Route(action)) = &route.action else {
-            return None;
-        };
-        match &action.cluster_specifier {
-            Some(xds_route::route_action::ClusterSpecifier::Cluster(cluster)) => {
-                Some(RouteConfigData::LbPolicy {
-                    action: Arc::new(action.clone()),
-                    cluster: cluster.clone().into(),
-                })
-            }
-            _ => None,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct Cluster {
-    pub(crate) xds: xds_cluster::Cluster,
-    pub(crate) backend_lb: Arc<BackendLb>,
-}
-
-impl Cluster {
-    pub(crate) fn dns_name(&self) -> Option<(Hostname, u16)> {
-        let id = &self.backend_lb.config.id;
-        match &id.service {
-            junction_api::Service::Dns(dns) => Some((dns.hostname.clone(), id.port)),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn from_xds(
-        xds: xds_cluster::Cluster,
-        default_action: Option<&xds_route::RouteAction>,
-    ) -> Result<Self, ResourceError> {
-        let backend = Backend::from_xds(&xds, default_action)?;
-        let load_balancer = LoadBalancer::from_config(&backend.lb);
-
-        let backend_lb = Arc::new(BackendLb {
-            config: backend,
-            load_balancer,
-        });
-
-        Ok(Self { xds, backend_lb })
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct LoadAssignment {
-    pub xds: xds_endpoint::ClusterLoadAssignment,
-    pub endpoint_group: Arc<EndpointGroup>,
-}
-
-impl LoadAssignment {
-    pub(crate) fn from_xds(
-        xds: xds_endpoint::ClusterLoadAssignment,
-    ) -> Result<Self, ResourceError> {
-        let endpoint_group = Arc::new(EndpointGroup::from_xds(&xds)?);
-        Ok(Self {
-            xds,
-            endpoint_group,
-        })
-    }
-}
-
-impl Locality {
-    pub(crate) fn from_xds(locality: &Option<xds_core::Locality>) -> Self {
-        let Some(locality) = locality.as_ref() else {
-            return Self::Unknown;
-        };
-
-        if locality.region.is_empty() && locality.zone.is_empty() {
-            return Self::Unknown;
-        }
-
-        Self::Known(LocalityInfo {
-            region: locality.region.clone(),
-            zone: locality.zone.clone(),
-        })
-    }
-}
-
-impl EndpointGroup {
-    pub(crate) fn from_xds(
-        cla: &xds_endpoint::ClusterLoadAssignment,
-    ) -> Result<Self, ResourceError> {
-        let mut endpoints = BTreeMap::new();
-        for (locality_idx, locality_endpoints) in cla.endpoints.iter().enumerate() {
-            let locality = Locality::from_xds(&locality_endpoints.locality);
-            let locality_endpoints: Result<Vec<_>, _> = locality_endpoints
-                .lb_endpoints
-                .iter()
-                .enumerate()
-                .map(|(endpoint_idx, e)| {
-                    xds_lb_endpoint_socket_addr(&cla.cluster_name, locality_idx, endpoint_idx, e)
-                })
-                .collect();
-
-            endpoints.insert(locality, locality_endpoints?);
-        }
-
-        Ok(EndpointGroup::new(endpoints))
-    }
-}
-
-fn xds_lb_endpoint_socket_addr(
-    eds_name: &str,
-    locality_idx: usize,
-    endpoint_idx: usize,
-    endpoint: &xds_endpoint::LbEndpoint,
-) -> Result<SocketAddr, ResourceError> {
-    macro_rules! make_error {
-        ($msg:expr) => {
-            ResourceError::for_xds_static(
-                format!(
-                    "{}: endpoints[{}].lb_endpoints[{}]",
-                    eds_name, locality_idx, endpoint_idx
-                ),
-                $msg,
-            )
-        };
-    }
-
-    let endpoint = match &endpoint.host_identifier {
-        Some(xds_endpoint::lb_endpoint::HostIdentifier::Endpoint(ep)) => ep,
-        _ => return Err(make_error!("endpoint is missing endpoint data")),
-    };
-
-    let address = endpoint.address.as_ref().and_then(|a| a.address.as_ref());
-    match address {
-        Some(xds_core::address::Address::SocketAddress(addr)) => {
-            let ip = addr
-                .address
-                .parse()
-                .map_err(|_| make_error!("invalid socket address"))?;
-            let port = match &addr.port_specifier {
-                Some(xds_core::socket_address::PortSpecifier::PortValue(p)) => {
-                    (*p).try_into().map_err(|_| make_error!("invalid port"))?
-                }
-                _ => return Err(make_error!("missing port specifier")),
-            };
-
-            Ok(SocketAddr::new(ip, port))
-        }
-        _ => Err(make_error!("endpoint has no socket address")),
+/// Parse a u16 port from an xDS port specifier
+#[inline]
+pub(super) fn xds_port(
+    port_specifier: Option<&xds_core::socket_address::PortSpecifier>,
+) -> Option<u16> {
+    match port_specifier {
+        Some(xds_core::socket_address::PortSpecifier::PortValue(v)) => (*v).try_into().ok(),
+        _ => None,
     }
 }

--- a/crates/junction-core/src/xds/resources/clusters.rs
+++ b/crates/junction-core/src/xds/resources/clusters.rs
@@ -1,0 +1,220 @@
+use crate::xds::{
+    load_balancer::LoadBalancer,
+    resources::{value_or_default, ErrorCtx},
+};
+
+use super::{ads_config_source, xds_port, ResourceError, ResourceName, ResourceType};
+use junction_api::Hostname;
+use xds_api::pb::envoy::config::{
+    cluster::v3 as xds_cluster, core::v3 as xds_core, endpoint::v3 as xds_endpoint,
+};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) enum LbPolicy {
+    RoundRobin,
+    RingHash {
+        min_ring_size: u32,
+    },
+    #[default]
+    Unspecified,
+}
+
+#[derive(Debug)]
+pub(crate) struct Cluster {
+    pub endpoints: Endpoints,
+    // TODO: should we also keep LbPolicy around?
+    pub load_balancer: LoadBalancer,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum Endpoints {
+    Eds(ResourceName),
+    LogicalDns { hostname: Hostname, port: u16 },
+    // TODO: Aggregate clusters
+}
+
+impl Cluster {
+    pub(crate) fn dns_name(&self) -> Option<&Hostname> {
+        match &self.endpoints {
+            Endpoints::LogicalDns { hostname, .. } => Some(hostname),
+            _ => None,
+        }
+    }
+}
+
+impl super::Resource for Cluster {
+    type Xds = xds_cluster::Cluster;
+
+    fn from_xds(xds: &Self::Xds) -> std::result::Result<Self, ResourceError> {
+        let lb_policy = LbPolicy::from_xds(xds)?;
+
+        let load_balancer = LoadBalancer::from_config(&lb_policy);
+        let endpoints = Endpoints::from_xds(xds)?;
+        Ok(Self {
+            load_balancer,
+            endpoints,
+        })
+    }
+
+    fn references(&self) -> Vec<(super::ResourceType, ResourceName)> {
+        match &self.endpoints {
+            Endpoints::Eds(name) => vec![(ResourceType::ClusterLoadAssignment, name.clone())],
+            _ => vec![],
+        }
+    }
+
+    fn dns_names(&self) -> Vec<&Hostname> {
+        match &self.endpoints {
+            Endpoints::LogicalDns { hostname, .. } => vec![hostname],
+            _ => vec![],
+        }
+    }
+}
+
+impl Endpoints {
+    fn from_xds(cluster: &xds_cluster::Cluster) -> Result<Self, ResourceError> {
+        let cluster_discovery_type = match cluster.cluster_discovery_type {
+            Some(xds_cluster::cluster::ClusterDiscoveryType::Type(cdt)) => {
+                xds_cluster::cluster::DiscoveryType::try_from(cdt).ok()
+            }
+            _ => None,
+        };
+
+        match &cluster_discovery_type {
+            Some(xds_cluster::cluster::DiscoveryType::Eds) => {
+                let cla_name = eds_service_name(cluster).with_field("eds_cluster_config")?;
+                Ok(Self::Eds(cla_name))
+            }
+            Some(xds_cluster::cluster::DiscoveryType::LogicalDns) => {
+                let (hostname, port) = logical_dns_name(cluster.load_assignment.as_ref())
+                    .with_field("load_assignment")?;
+                Ok(Self::LogicalDns { hostname, port })
+            }
+            Some(dt) => Err(ResourceError::invalid_with(format!(
+                "unsupported discovery type: {dt:?}"
+            )))
+            .with_field("cluster_discovery_type"),
+            None => Err(ResourceError::invalid("missing discovery type"))
+                .with_field("cluster_discovery_type"),
+        }
+    }
+}
+
+fn eds_service_name(cluster: &xds_cluster::Cluster) -> Result<ResourceName, ResourceError> {
+    let Some(eds_cluster_config) = &cluster.eds_cluster_config else {
+        return Err(ResourceError::invalid("missing EDS config"));
+    };
+    if eds_cluster_config.eds_config != Some(ads_config_source()) {
+        return Err(ResourceError::invalid("EDS cluster does not use ADS"));
+    }
+
+    Ok(if eds_cluster_config.service_name.is_empty() {
+        ResourceName::from(cluster.name.clone())
+    } else {
+        ResourceName::from(eds_cluster_config.service_name.clone())
+    })
+}
+
+fn logical_dns_name(
+    cla: Option<&xds_endpoint::ClusterLoadAssignment>,
+) -> Result<(Hostname, u16), ResourceError> {
+    let Some(cla) = cla else {
+        return Err(ResourceError::invalid(
+            "logical DNS cluster has no load assignment",
+        ));
+    };
+
+    let [endpoint] = &cla.endpoints[..] else {
+        return Err(ResourceError::invalid("must have exactly one endpoints"))
+            .with_field("endpoints");
+    };
+    let [lb_endpoint] = &endpoint.lb_endpoints[..] else {
+        return Err(ResourceError::invalid("must have exactly one lb endpoint"))
+            .with_fields("endpoints", "lb_endpoints");
+    };
+
+    let endpoint = match &lb_endpoint.host_identifier {
+        Some(xds_endpoint::lb_endpoint::HostIdentifier::Endpoint(endpoint)) => Ok(endpoint),
+        Some(xds_endpoint::lb_endpoint::HostIdentifier::EndpointName(_)) => Err(
+            ResourceError::invalid("host identifier may not be an endpoint name"),
+        ),
+        None => Err(ResourceError::invalid("missing endpoint identifier")),
+    };
+    let endpoint = endpoint
+        .with_field("host_identifier")
+        .with_fields("endpoints", "lb_endpoint")?;
+
+    let socket_addr = match &endpoint.address.as_ref().and_then(|a| a.address.as_ref()) {
+        Some(xds_core::address::Address::SocketAddress(socket_addr)) => Ok(socket_addr),
+        Some(_) => Err(ResourceError::invalid("address must be a socket address")),
+        None => Err(ResourceError::invalid("missing address")),
+    };
+    let socket_addr = socket_addr
+        .with_fields("host_identifier", "address")
+        .with_fields("endpoints", "lb_endpoint")?;
+
+    // FIXME: we should provide an error path here but things get so tedious and type-error-y
+    // that we should probably fix the error API first.
+    let hostname: Hostname = socket_addr
+        .address
+        .parse()
+        .map_err(|_| ResourceError::invalid("invalid hostname"))?;
+    let port = xds_port(socket_addr.port_specifier.as_ref())
+        .ok_or_else(|| ResourceError::invalid("invalid port"))?;
+
+    Ok((hostname, port))
+}
+
+impl LbPolicy {
+    pub(crate) fn from_xds(cluster: &xds_cluster::Cluster) -> Result<Self, ResourceError> {
+        use xds_cluster::cluster::ring_hash_lb_config;
+
+        match cluster.lb_policy() {
+            // for ROUND_ROBIN, ignore the slow_start_config entirely and return a brand new
+            // RoundRobin policy each time. validate that the config matches the enum field even
+            // though it's ignored.
+            xds_cluster::cluster::LbPolicy::RoundRobin => match cluster.lb_config.as_ref() {
+                Some(xds_cluster::cluster::LbConfig::RoundRobinLbConfig(_)) => {
+                    Ok(LbPolicy::RoundRobin)
+                }
+                None => Ok(LbPolicy::Unspecified),
+                _ => Err(
+                    ResourceError::invalid("RoundRobin lb_policy has a mismatched lb_config")
+                        .with_field("lb_config"),
+                ),
+            },
+            // for RING_HASH pull the config out if set or use default values to populate our
+            // config.
+            xds_cluster::cluster::LbPolicy::RingHash => {
+                let lb_config = match cluster.lb_config.as_ref() {
+                    Some(xds_cluster::cluster::LbConfig::RingHashLbConfig(config)) => config,
+                    None => &xds_cluster::cluster::RingHashLbConfig::default(),
+                    _ => {
+                        return Err(ResourceError::invalid(
+                            "RingHash lb_policy has a mismatched lb_config",
+                        )
+                        .with_field("lb_config"))
+                    }
+                };
+
+                // hash function must be XX_HASH to match gRPC
+                if lb_config.hash_function() != ring_hash_lb_config::HashFunction::XxHash {
+                    return Err(ResourceError::invalid_with(format!(
+                        "unsupported hash function: {:?}",
+                        lb_config.hash_function(),
+                    )))
+                    .with_fields("lb_config", "hash_function");
+                }
+
+                let min_ring_size = value_or_default!(lb_config.minimum_ring_size, 1024);
+                let min_ring_size = min_ring_size
+                    .try_into()
+                    .map_err(|_| ResourceError::invalid("integer overflow"))
+                    .with_fields("lb_config", ",minimum_ring_size")?;
+
+                Ok(LbPolicy::RingHash { min_ring_size })
+            }
+            _ => Err(ResourceError::invalid("unrecognized lb policy")).with_field("lb_policy"),
+        }
+    }
+}

--- a/crates/junction-core/src/xds/resources/endpoints.rs
+++ b/crates/junction-core/src/xds/resources/endpoints.rs
@@ -1,0 +1,167 @@
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::{collections::BTreeMap, net::IpAddr};
+
+use xds_api::pb::envoy::config::{core::v3 as xds_core, endpoint::v3 as xds_endpoint};
+
+use crate::hash::thread_local_xxhash;
+use crate::xds::resources::ErrorCtx;
+
+use super::{xds_port, Resource, ResourceError};
+
+#[derive(Clone, Debug)]
+pub(crate) struct LoadAssignment {
+    pub endpoints: Vec<EndpointGroup>,
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub(crate) struct EndpointGroup {
+    pub hash: u64,
+    #[allow(unused)]
+    pub priority: u32,
+    pub endpoints: BTreeMap<Locality, Vec<SocketAddr>>,
+}
+
+impl EndpointGroup {
+    pub(crate) fn new(priority: u32, endpoints: BTreeMap<Locality, Vec<SocketAddr>>) -> Self {
+        let hash = thread_local_xxhash::hash(&endpoints);
+        Self {
+            hash,
+            priority,
+            endpoints,
+        }
+    }
+
+    pub(crate) fn from_dns_addrs(addrs: impl IntoIterator<Item = SocketAddr>) -> Self {
+        let mut endpoints = BTreeMap::new();
+        let endpoint_addrs = addrs.into_iter().collect();
+        endpoints.insert(Locality::empty(), endpoint_addrs);
+        Self::new(0, endpoints)
+    }
+}
+
+// TODO: intern localities
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Locality {
+    pub region: String,
+    pub zone: String,
+}
+
+impl Locality {
+    pub(crate) fn empty() -> Self {
+        Locality {
+            region: "".to_string(),
+            zone: "".to_string(),
+        }
+    }
+
+    fn from_xds(locality: &Option<xds_core::Locality>) -> Option<Self> {
+        locality.as_ref().map(|locality| Self {
+            region: locality.region.clone(),
+            zone: locality.zone.clone(),
+        })
+    }
+}
+
+impl Resource for LoadAssignment {
+    type Xds = xds_endpoint::ClusterLoadAssignment;
+
+    fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError> {
+        // priority -> locality -> [addr]
+        let mut endpoints: BTreeMap<u32, BTreeMap<Locality, HashSet<SocketAddr>>> = BTreeMap::new();
+
+        for (endpoints_idx, locality_lb_endpoint) in xds.endpoints.iter().enumerate() {
+            let priority = locality_lb_endpoint.priority;
+
+            if let Some(locality) = Locality::from_xds(&locality_lb_endpoint.locality) {
+                let priority_endpoints = endpoints.entry(priority).or_default();
+                let locality_endpoints = priority_endpoints.entry(locality).or_default();
+
+                for (lb_idx, lb_endpoint) in locality_lb_endpoint.lb_endpoints.iter().enumerate() {
+                    // skip all endpoints that are not HEALTHY or UNKNOWN
+                    if !matches!(
+                        lb_endpoint.health_status(),
+                        xds_core::HealthStatus::Healthy | xds_core::HealthStatus::Unknown,
+                    ) {
+                        continue;
+                    }
+
+                    // parse the address and save it by locality/priority
+                    let socket_addr = xds_lb_endpoint_socket_addr(&lb_endpoint)
+                        .with_field_index("lb_endpoints", lb_idx)
+                        .with_field_index("endpoints", endpoints_idx)?;
+                    locality_endpoints.insert(socket_addr);
+                }
+            }
+        }
+
+        // convert the endpoints map into an EndpointGroup. the inner
+        // HashSet has to get converted to a Vec and the outer map becomes a
+        // Vec of EndpointGroups.
+        //
+        // EndpointGroups are ordered by priority because they're in an ordered map
+        let endpoints = endpoints.into_iter().map(|(priority, endpoints)| {
+            let endpoints = endpoints
+                .into_iter()
+                .map(|(locality, addrs)| (locality, addrs.into_iter().collect()))
+                .collect();
+            EndpointGroup::new(priority, endpoints)
+        });
+        let endpoints: Vec<_> = endpoints.collect();
+        assert!(
+            endpoints.is_sorted_by_key(|e| e.priority),
+            "EndpointGroups are ordered by priority: this is a bug in Junction",
+        );
+        Ok(Self { endpoints })
+    }
+
+    fn references(&self) -> Vec<(super::ResourceType, super::ResourceName)> {
+        Vec::new()
+    }
+}
+
+impl EndpointGroup {
+    pub(crate) fn len(&self) -> usize {
+        self.endpoints.values().map(|v| v.len()).sum()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &SocketAddr> {
+        self.endpoints.values().flatten()
+    }
+
+    pub(crate) fn nth(&self, n: usize) -> Option<&SocketAddr> {
+        let mut n = n;
+        for endpoints in self.endpoints.values() {
+            if n < endpoints.len() {
+                return Some(&endpoints[n]);
+            }
+            n -= endpoints.len();
+        }
+
+        None
+    }
+}
+
+fn xds_lb_endpoint_socket_addr(
+    endpoint: &xds_endpoint::LbEndpoint,
+) -> Result<SocketAddr, ResourceError> {
+    let endpoint = match &endpoint.host_identifier {
+        Some(xds_endpoint::lb_endpoint::HostIdentifier::Endpoint(ep)) => ep,
+        _ => return Err(ResourceError::invalid("missing endpoint data")),
+    };
+
+    let address = endpoint.address.as_ref().and_then(|a| a.address.as_ref());
+    match address {
+        Some(xds_core::address::Address::SocketAddress(a)) => {
+            let ip: IpAddr = a
+                .address
+                .parse()
+                .map_err(|_| ResourceError::invalid("invalid socket address"))?;
+            let port = xds_port(a.port_specifier.as_ref())
+                .ok_or_else(|| ResourceError::invalid("invalid port"))?;
+
+            Ok(SocketAddr::new(ip, port))
+        }
+        _ => Err(ResourceError::invalid("missing socket addr")),
+    }
+}

--- a/crates/junction-core/src/xds/resources/listeners.rs
+++ b/crates/junction-core/src/xds/resources/listeners.rs
@@ -1,0 +1,63 @@
+use super::{ErrorCtx, Resource, ResourceError, ResourceName, ResourceType, RouteConfiguration};
+
+use xds_api::pb::envoy::{
+    config::listener::v3 as xds_listener,
+    extensions::filters::network::http_connection_manager::v3 as xds_http,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ApiListener {
+    pub route_config: RouteConfig,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RouteConfig {
+    Rds(ResourceName),
+    Inline(RouteConfiguration),
+}
+
+impl Resource for ApiListener {
+    type Xds = xds_listener::Listener;
+
+    fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError> {
+        use xds_http::http_connection_manager::RouteSpecifier;
+
+        let conn_manager = http_connection_manager(&xds).with_field("api_listener")?;
+
+        let route_config = match &conn_manager.route_specifier {
+            Some(RouteSpecifier::Rds(rds)) => {
+                let name = ResourceName::from(rds.route_config_name.clone());
+                RouteConfig::Rds(name)
+            }
+            Some(RouteSpecifier::RouteConfig(route_config)) => {
+                let inline = RouteConfiguration::from_xds(route_config)
+                    .with_fields("api_listener", "route_specifier")?;
+                RouteConfig::Inline(inline)
+            }
+            _ => return Err(ResourceError::invalid("no routes configured")),
+        };
+
+        Ok(Self { route_config })
+    }
+
+    fn references(&self) -> Vec<(super::ResourceType, ResourceName)> {
+        match &self.route_config {
+            RouteConfig::Rds(name) => vec![(ResourceType::RouteConfiguration, name.clone())],
+            RouteConfig::Inline(route_config) => route_config.references(),
+        }
+    }
+}
+
+fn http_connection_manager(
+    listener: &xds_listener::Listener,
+) -> Result<xds_http::HttpConnectionManager, ResourceError> {
+    let api_listener = listener
+        .api_listener
+        .as_ref()
+        .and_then(|l| l.api_listener.as_ref())
+        .ok_or_else(|| ResourceError::invalid("missing api_listener"))?;
+
+    api_listener
+        .to_msg()
+        .map_err(|e| ResourceError::invalid_with(format!("invalid api_listener: {e}")))
+}

--- a/crates/junction-core/src/xds/resources/route_configs.rs
+++ b/crates/junction-core/src/xds/resources/route_configs.rs
@@ -1,0 +1,363 @@
+use super::{ErrorCtx, Resource, ResourceError, ResourceName, ResourceType};
+
+use junction_api::Hostname;
+use regex::Regex;
+use std::{collections::HashSet, str::FromStr};
+use xds_api::pb::envoy::config::route::v3::{self as xds_route};
+
+macro_rules! vec_from_xds {
+    ($xs:expr, $field:literal, $type:ty) => {{
+        $xs.iter()
+            .enumerate()
+            .map(|(i, x)| <$type>::from_xds(x).with_field_index($field, i))
+            .collect::<Result<Vec<_>, _>>()
+    }};
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RouteConfiguration {
+    pub vhosts: Vec<VirtualHost>,
+}
+
+impl Resource for RouteConfiguration {
+    type Xds = xds_route::RouteConfiguration;
+
+    fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError> {
+        let vhosts = vec_from_xds!(xds.virtual_hosts, "virtual_hosts", VirtualHost)?;
+        Ok(Self { vhosts })
+    }
+
+    fn references(&self) -> Vec<(super::ResourceType, ResourceName)> {
+        let mut clusters = HashSet::new();
+        for vhost in &self.vhosts {
+            for route in &vhost.routes {
+                match &route.action.cluster {
+                    ClusterSpecifier::Cluster(name) => {
+                        clusters.insert(name.clone());
+                    }
+                    ClusterSpecifier::Weighted(weights) => {
+                        for weight in weights {
+                            clusters.insert(weight.name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        clusters
+            .into_iter()
+            .map(|name| (ResourceType::Cluster, name))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VirtualHost {
+    pub domains: Vec<DomainMatcher>,
+    pub routes: Vec<Route>,
+}
+
+impl VirtualHost {
+    fn from_xds(xds: &xds_route::VirtualHost) -> Result<Self, ResourceError> {
+        // domains can't be empty and has to be a valid set of matchers.
+        if xds.domains.is_empty() {
+            return Err(ResourceError::invalid("empty domain list").with_field("domains"))?;
+        }
+        let mut domains = Vec::with_capacity(xds.domains.len());
+        for (i, domain) in xds.domains.iter().enumerate() {
+            domains.push(DomainMatcher::from_str(domain).with_field_index("domains", i)?);
+        }
+
+        // descend for routes
+        let routes = vec_from_xds!(xds.routes, "routes", Route)?;
+        Ok(Self { domains, routes })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Route {
+    pub matcher: Matcher,
+    pub action: Action,
+}
+
+impl Route {
+    fn from_xds(xds: &xds_route::Route) -> Result<Self, ResourceError> {
+        let matcher = xds
+            .r#match
+            .as_ref()
+            .ok_or_else(|| ResourceError::invalid("RouteMatch is required"))
+            .with_field("match")?;
+        let matcher = Matcher::from_xds(matcher).with_field("match")?;
+
+        let action = xds
+            .action
+            .as_ref()
+            .ok_or_else(|| ResourceError::invalid("missing route action"))
+            .with_field("action")?;
+        let action = Action::from_xds(action).with_field("action")?;
+
+        Ok(Self { matcher, action })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Action {
+    pub hash_policies: Vec<HashPolicy>,
+    pub retries: Retries,
+    pub timeouts: Timeouts,
+    pub cluster: ClusterSpecifier,
+}
+
+impl Action {
+    fn from_xds(xds: &xds_route::route::Action) -> Result<Self, ResourceError> {
+        match xds {
+            xds_route::route::Action::Route(action) => {
+                let cluster = match &action.cluster_specifier {
+                    Some(xds_route::route_action::ClusterSpecifier::Cluster(cluster)) => {
+                        ClusterSpecifier::Cluster(ResourceName::from(cluster.to_string()))
+                    }
+                    Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(_)) => todo!(),
+                    Some(_) => todo!(),
+                    None => todo!(),
+                };
+                let hash_policies = vec_from_xds!(action.hash_policy, "hash_policy", HashPolicy)?;
+
+                Ok(Self {
+                    hash_policies,
+                    cluster,
+                    retries: Retries {},   // FIXME
+                    timeouts: Timeouts {}, // FIXME
+                })
+            }
+            _ => return Err(ResourceError::invalid("unsupported action")),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ClusterSpecifier {
+    Cluster(ResourceName),
+    Weighted(Vec<ClusterWeight>),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClusterWeight {
+    pub name: ResourceName,
+    pub weight: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HashPolicy {
+    pub terminal: bool,
+    pub hasher: RequestHasher,
+}
+
+impl HashPolicy {
+    fn from_xds(xds: &xds_route::route_action::HashPolicy) -> Result<Self, ResourceError> {
+        let hasher = match &xds.policy_specifier {
+            Some(xds_route::route_action::hash_policy::PolicySpecifier::Header(xds)) => {
+                Ok(RequestHasher::Header {
+                    name: xds.header_name.clone(),
+                })
+            }
+            Some(xds_route::route_action::hash_policy::PolicySpecifier::QueryParameter(xds)) => {
+                Ok(RequestHasher::QueryParameter {
+                    name: xds.name.clone(),
+                })
+            }
+            Some(_) => Err(ResourceError::invalid("unsupported policy")),
+            None => Err(ResourceError::invalid("missing policiy specifier")),
+        };
+
+        let terminal = xds.terminal;
+        let hasher = hasher.with_field("policy_specifier")?;
+
+        Ok(Self { terminal, hasher })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RequestHasher {
+    Header { name: String },
+    QueryParameter { name: String },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Retries {}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Timeouts {}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Matcher {
+    pub path: PathMatcher,
+    pub method: Option<MethodMatcher>,
+    pub headers: Vec<HeaderMatcher>,
+    pub query: Vec<QueryMatcher>,
+}
+
+impl Matcher {
+    fn from_xds(xds: &xds_route::RouteMatch) -> Result<Self, ResourceError> {
+        let path = xds
+            .path_specifier
+            .as_ref()
+            .ok_or_else(|| ResourceError::invalid("missing path specifier"))
+            .and_then(|p| PathMatcher::from_xds(p))
+            .with_field("path_specifier")?;
+
+        Ok(Matcher {
+            path,
+            method: None,
+            headers: vec![],
+            query: vec![],
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum DomainMatcher {
+    Exact(Hostname),
+    Subdomain(Hostname),
+}
+
+impl DomainMatcher {
+    pub(crate) fn matches_hostname(&self, s: &str) -> bool {
+        match self {
+            Self::Subdomain(d) => {
+                let (subdomain, domain) = s.split_at(s.len() - d.len());
+                domain == &d[..] && subdomain.ends_with('.')
+            }
+            Self::Exact(e) => s == e.as_ref(),
+        }
+    }
+}
+
+impl FromStr for DomainMatcher {
+    type Err = ResourceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.strip_prefix("*.") {
+            Some(hostname) => Self::Subdomain(
+                Hostname::from_str(hostname)
+                    .map_err(|_| ResourceError::invalid("invalid hostname"))?,
+            ),
+            None => Self::Exact(
+                Hostname::from_str(s).map_err(|_| ResourceError::invalid("invalid hostname"))?,
+            ),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MethodMatcher {
+    method: http::Method,
+}
+
+impl MethodMatcher {
+    pub(crate) fn is_match(&self, method: &http::Method) -> bool {
+        self.method == method
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PathMatcher(StringMatcher);
+
+impl PathMatcher {
+    pub(crate) fn matches_path(&self, path: &str) -> bool {
+        self.0.matches(path)
+    }
+
+    fn from_xds(xds: &xds_route::route_match::PathSpecifier) -> Result<Self, ResourceError> {
+        let matcher = match &xds {
+            xds_route::route_match::PathSpecifier::Prefix(p) => {
+                StringMatcher::Prefix { value: p.clone() }
+            }
+            xds_route::route_match::PathSpecifier::Path(p) => {
+                StringMatcher::Exact { value: p.clone() }
+            }
+            xds_route::route_match::PathSpecifier::SafeRegex(p) => {
+                StringMatcher::RegularExpression {
+                    value: parse_xds_regex(p).with_field("safe_regex")?,
+                }
+            }
+            _ => return Err(ResourceError::invalid("unsupported match type")),
+        };
+        Ok(Self(matcher))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HeaderMatcher {
+    pub name: String,
+    invert: bool,
+    matcher: Option<StringMatcher>,
+}
+
+impl HeaderMatcher {
+    pub(crate) fn matches_value(&self, header_value: Option<&[u8]>) -> bool {
+        let matches = match &self.matcher {
+            Some(matcher) => {
+                // try to parse the header value as ascii, using the empty
+                // string as the incoming value if it's not present.
+                //
+                // https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6
+                let Some(header_value) = from_ascii(header_value.unwrap_or_default()) else {
+                    return false;
+                };
+                matcher.matches(header_value)
+            }
+            None => header_value.is_some(),
+        };
+        // if invert is true, we need to flip the conditional
+        matches && !self.invert
+    }
+}
+
+#[inline]
+fn from_ascii(bs: &[u8]) -> Option<&str> {
+    if !bs.is_ascii() {
+        return None;
+    }
+    Some(str::from_utf8(bs).expect("expected a valid ascii string"))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueryMatcher {
+    pub name: String,
+    matcher: Option<StringMatcher>,
+}
+
+impl QueryMatcher {
+    pub(crate) fn matches(&self, s: Option<&str>) -> bool {
+        match &self.matcher {
+            Some(matcher) => matcher.matches(s.unwrap_or_default()),
+            None => s.is_some(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum StringMatcher {
+    Prefix { value: String },
+    Suffix { value: String },
+    RegularExpression { value: Regex },
+    Exact { value: String },
+}
+
+impl StringMatcher {
+    fn matches(&self, s: &str) -> bool {
+        match self {
+            StringMatcher::Prefix { value } => s.starts_with(value),
+            StringMatcher::Suffix { value } => s.ends_with(value),
+            Self::RegularExpression { value } => value.is_match(s),
+            Self::Exact { value } => value == s,
+        }
+    }
+}
+
+fn parse_xds_regex(
+    p: &xds_api::pb::envoy::r#type::matcher::v3::RegexMatcher,
+) -> Result<Regex, ResourceError> {
+    Regex::from_str(&p.regex)
+        .map_err(|e| ResourceError::invalid_with(format!("invalid regex: {e}")))
+}

--- a/crates/junction-core/src/xds/test.rs
+++ b/crates/junction-core/src/xds/test.rs
@@ -2,10 +2,7 @@
 //!
 //! Use these macros as a shorthand for writing out full XDS resource structs.
 
-use std::str::FromStr;
-
-use crate::xds::ResourceType;
-use junction_api::backend::{Backend, BackendId, LbPolicy};
+use crate::xds::{resources::ads_config_source, ResourceType};
 use xds_api::pb::{
     envoy::{
         config::{
@@ -15,7 +12,9 @@ use xds_api::pb::{
             listener::v3 as xds_listener,
             route::v3::{self as xds_route, route_action::hash_policy::Header},
         },
-        service::discovery::v3::{DeltaDiscoveryRequest, DeltaDiscoveryResponse},
+        service::discovery::v3::{
+            self as xds_discovery, DeltaDiscoveryRequest, DeltaDiscoveryResponse,
+        },
     },
     google::{protobuf, rpc},
 };
@@ -25,15 +24,23 @@ use xds_api::pb::envoy::extensions::filters::{
 };
 
 macro_rules! listener {
-    ($name:expr, $route_name:expr$(,)*) => {{
-        crate::xds::test::api_listener_rds($name, $route_name)
+    ($name:expr, $route_name:expr$(,)*) => {
+        crate::xds::test::listener!($name, "v123", $route_name)
+    };
+    ($name:expr, $version:expr, $route_name:expr$(,)*) => {{
+        let listener = crate::xds::test::api_listener_rds($name, $route_name);
+        crate::xds::test::xds_resource($name.to_string(), $version.to_string(), listener)
     }};
-    ($name:expr, $route_name:expr => [$($vhost:expr),*$(,)*]$(,)?) => {{
-        crate::xds::test::api_listener_inline_routes($name, $route_name, vec![
+    ($name:expr, $route_name:expr => [$($vhost:expr),*$(,)*]$(,)?) =>  {
+        crate::xds::test::listener!($name, "v123", $route_name => [$($vhost,)*])
+    };
+    ($name:expr, $version:expr, $route_name:expr => [$($vhost:expr),*$(,)*]$(,)?) => {{
+        let listener = crate::xds::test::api_listener_inline_routes($name, $route_name, vec![
             $(
                 $vhost,
             )*
-        ])
+        ]);
+        crate::xds::test::xds_resource($name.to_string(), $version.to_string(), listener)
     }};
 }
 
@@ -48,47 +55,57 @@ macro_rules! vhost {
 pub(crate) use vhost;
 
 macro_rules! cluster {
-    ($cluster_name:expr) => {{
-        crate::xds::test::cluster_from_name($cluster_name, None)
+    (eds => $cluster_name:expr) => {
+        crate::xds::test::cluster!(eds => $cluster_name, "v123")
+    };
+    (eds => $cluster_name:expr, $version:expr) => {{
+        let cluster = crate::xds::test::eds_cluster($cluster_name, None);
+        crate::xds::test::xds_resource($cluster_name.to_string(), $version.to_string(), cluster)
     }};
-    (ring_hash $cluster_name:expr) => {{
-        crate::xds::test::cluster_from_name($cluster_name, Some(xds_cluster::cluster::LbPolicy::RingHash))
-    }};
-    (inline $cluster_name:expr => { $($region:expr => [$($addr:expr),*]),* }) => {{
-        let cla = crate::xds::test::cluster_load_assignment($cluster_name, vec![$(
-            crate::xds::test::locality_lb_endpoints(Some($region), None, vec![
-                $(
-                    crate::xds::test::lb_endpoint($addr, None, None),
-                )+
-            ]),
-        )*]);
-
-        crate::xds::test::cluster_inline($cluster_name, cla)
+    (logical_dns => $hostname:expr, $port:expr) => {
+        crate::xds::test::cluster!(logical_dns => $hostname, $port, "v123")
+    };
+    (logical_dns => $hostname:expr, $port:expr, $version:expr) => {{
+        let cluster_name = format!("{}:{}", $hostname, $port);
+        let cluster = crate::xds::test::logical_dns_cluster(&cluster_name, $hostname, $port, None);
+        crate::xds::test::xds_resource(cluster_name.to_string(), $version.to_string(), cluster)
     }};
 }
 
 pub(crate) use cluster;
 
 macro_rules! cla {
-    ($cluster_name:expr => { $($region:expr => [$($addr:expr),*]),* }) => {{
-        crate::xds::test::cluster_load_assignment($cluster_name, vec![$(
+    ($name:expr => { $($region:expr => [$($addr:expr),*]),* }) => {
+        crate::xds::test::cla!($name, "v123" => {
+            $(
+                $region => [$($addr),*]
+            ),*
+        })
+    };
+    ($name:expr, $version:expr => { $($region:expr => [$($addr:expr),*]),* }) => {{
+        let cla = crate::xds::test::cluster_load_assignment($name, vec![$(
             crate::xds::test::locality_lb_endpoints(Some($region), None, vec![
                 $(
                     crate::xds::test::lb_endpoint($addr, None, None),
                 )+
             ]),
-        )*])
+        )*]);
+        crate::xds::test::xds_resource($name.to_string(), $version.to_string(), cla)
     }};
 }
 pub(crate) use cla;
 
 macro_rules! route_config {
-    ($name:expr, $vhosts:expr) => {{
-        xds_api::pb::envoy::config::route::v3::RouteConfiguration {
+    ($name:expr, $vhosts:expr) => {
+        crate::xds::test::route_config!($name, "v123", $vhosts)
+    };
+    ($name:expr, $version:expr, $vhosts:expr) => {{
+        let rc = xds_api::pb::envoy::config::route::v3::RouteConfiguration {
             name: $name.to_string(),
             virtual_hosts: $vhosts.into_iter().collect(),
             ..Default::default()
-        }
+        };
+        crate::xds::test::xds_resource($name.to_string(), $version.to_string(), rc)
     }};
 }
 
@@ -192,8 +209,6 @@ macro_rules! req {
 
 pub(crate) use req;
 
-use super::ResourceVec;
-
 pub fn delta_discovery_request(
     rtype: ResourceType,
     response_nonce: &'static str,
@@ -227,6 +242,9 @@ pub fn delta_discovery_request(
 }
 
 macro_rules! resp {
+    (n = $nonce:expr, ty = $rtype:expr, remove = $remove:expr $(,)*) => {
+        crate::xds::test::empty_delta_discovery_response($nonce, None, $rtype, $remove)
+    };
     (n = $nonce:expr, add = $add:expr, remove = $remove:expr $(,)*) => {
         crate::xds::test::delta_discovery_response($nonce, None, $add, $remove)
     };
@@ -234,15 +252,36 @@ macro_rules! resp {
 
 pub(crate) use resp;
 
+pub fn empty_delta_discovery_response(
+    nonce: &'static str,
+    version: Option<&'static str>,
+    rtype: ResourceType,
+    removed_resources: Vec<&'static str>,
+) -> DeltaDiscoveryResponse {
+    let type_url = rtype.type_url().to_string();
+    let system_version_info = version.map(|s| s.to_string()).unwrap_or_default();
+    let removed_resources = removed_resources
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    DeltaDiscoveryResponse {
+        type_url,
+        system_version_info,
+        nonce: nonce.to_string(),
+        removed_resources,
+        ..Default::default()
+    }
+}
+
 pub fn delta_discovery_response(
     nonce: &'static str,
     version: Option<&'static str>,
-    resources: ResourceVec,
+    resources: Vec<xds_discovery::Resource>,
     removed_resources: Vec<&'static str>,
 ) -> DeltaDiscoveryResponse {
-    let type_url = resources.resource_type().type_url().to_string();
+    let type_url = resources.first().and_then(resource_type_url).unwrap();
     let system_version_info = version.map(|s| s.to_string()).unwrap_or_default();
-    let resources = resources.to_resources().unwrap();
     let removed_resources = removed_resources
         .into_iter()
         .map(|s| s.to_string())
@@ -254,6 +293,24 @@ pub fn delta_discovery_response(
         nonce: nonce.to_string(),
         resources,
         removed_resources,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn resource_type_url(resource: &xds_discovery::Resource) -> Option<String> {
+    resource.resource.as_ref().map(|r| r.type_url.clone())
+}
+
+pub fn xds_resource<T: prost::Name>(
+    name: String,
+    version: String,
+    xds: T,
+) -> xds_discovery::Resource {
+    xds_discovery::Resource {
+        name,
+        version,
+        resource: Some(protobuf::Any::from_msg(&xds).unwrap()),
         ..Default::default()
     }
 }
@@ -392,16 +449,65 @@ pub fn virtual_host(
     }
 }
 
-pub fn cluster_from_name(
+pub fn eds_cluster(
     name: &'static str,
     lb_policy: Option<xds_cluster::cluster::LbPolicy>,
 ) -> xds_cluster::Cluster {
-    let backend = Backend {
-        id: BackendId::from_str(name).unwrap(),
-        lb: LbPolicy::Unspecified,
-    };
+    use xds_cluster::cluster::ClusterDiscoveryType;
+    use xds_cluster::cluster::DiscoveryType;
+    use xds_cluster::cluster::EdsClusterConfig;
 
-    let mut cluster = backend.to_xds();
+    let cluster_discovery_type = Some(ClusterDiscoveryType::Type(DiscoveryType::Eds.into()));
+    let eds_cluster_config = Some(EdsClusterConfig {
+        eds_config: Some(ads_config_source()),
+        service_name: name.to_string(),
+    });
+    let mut cluster = xds_cluster::Cluster {
+        name: name.to_string(),
+        cluster_discovery_type,
+        eds_cluster_config,
+        ..Default::default()
+    };
+    if let Some(lb_policy) = lb_policy {
+        cluster.lb_policy = lb_policy.into();
+    }
+    cluster
+}
+
+pub fn logical_dns_cluster(
+    name: &str,
+    hostname: &str,
+    port: u16,
+    lb_policy: Option<xds_cluster::cluster::LbPolicy>,
+) -> xds_cluster::Cluster {
+    use xds_cluster::cluster::ClusterDiscoveryType;
+    use xds_cluster::cluster::DiscoveryType;
+
+    let cluster_discovery_type = Some(ClusterDiscoveryType::Type(DiscoveryType::LogicalDns.into()));
+    let host_identifier = Some(xds_endpoint::lb_endpoint::HostIdentifier::Endpoint(
+        xds_endpoint::Endpoint {
+            address: Some(to_xds_address(&hostname, port)),
+            ..Default::default()
+        },
+    ));
+    let endpoints = vec![xds_endpoint::LocalityLbEndpoints {
+        lb_endpoints: vec![xds_endpoint::LbEndpoint {
+            host_identifier,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }];
+    let load_assignment = Some(xds_endpoint::ClusterLoadAssignment {
+        endpoints,
+        ..Default::default()
+    });
+
+    let mut cluster = xds_cluster::Cluster {
+        name: name.to_string(),
+        cluster_discovery_type,
+        load_assignment,
+        ..Default::default()
+    };
     if let Some(lb_policy) = lb_policy {
         cluster.lb_policy = lb_policy.into();
     }
@@ -467,12 +573,16 @@ pub fn lb_endpoint(
     }
 }
 
-pub fn ads_config_source() -> xds_core::ConfigSource {
-    xds_core::ConfigSource {
-        config_source_specifier: Some(xds_core::config_source::ConfigSourceSpecifier::Ads(
-            xds_core::AggregatedConfigSource {},
+fn to_xds_address(hostname: &str, port: u16) -> xds_core::Address {
+    let socket_address = xds_core::SocketAddress {
+        address: hostname.to_string(),
+        port_specifier: Some(xds_core::socket_address::PortSpecifier::PortValue(
+            port as u32,
         )),
-        resource_api_version: xds_core::ApiVersion::V3 as i32,
         ..Default::default()
+    };
+
+    xds_core::Address {
+        address: Some(xds_core::address::Address::SocketAddress(socket_address)),
     }
 }


### PR DESCRIPTION
# What on earth?

After working on the Junction control plane, we think it makes sense to stop explicitly representing Junction resources in the client internals. This gives us more flexibility to change the higher level APIs without first porting that change into the client, which we have to do even if routing behavior doesn't change.

## Working on a Branch

This is a massive change, and nearly impossible to do gradually, so we're doing it on a branch. We're working inside-out on this change, going from the core XDS client and caches (this PR) to our public APIs and our Python and Node clients. For our first few PRs, we expect crates other than `junction-core` to be completely broken. As we get back to green on `junction-node` and `junction-python` we'll  open a PR to merge into main and then continue our work there.

## Interface changes

As part of this change, we expect to make some breaking changes to the public API. 

- `resolve_http` and `report_status` do not need any changes, but the data available on an `Endpoint` may change.
 
- The `resolve_route` and `resolve_endpoint` methods will be removed in favor of first-class events and XDS traces returned from `resolve_http`. In the short term, we plan to  remove `dump_routes` and `dump_backends` and stick with `dump_xds`. We definitely want to prioritize debugging, interactive and otherwise, as part of the client, but we may not end up with a reversible conversion from XDS back to Junction resources as part of our changes.
 
- We're still investigating the right way to handle static configuration and how it interacts with dynamic configuration and local caches. We're going to temporarily remove the ability to mix static and dynamic configuration so that examples and unit tests can still use a fixed set of resources.
 
## This PR

This PR starts inside-out and modifies our xDS `Cache` and `AdsClient` to use non-Junction xDS types. The core of this PR is the new `Resource` trait and `ApiListener`, `Cluster`, `RouteConfiguration` and `Endpoints` structs.

The Resource trait lets us generically convert from xDS and track downstream references to other resource types in the Cache.

```rust
pub(crate) trait Resource: Sized {
    type Xds: prost::Name + Default;

    fn from_any(any: &protobuf::Any) -> Result<Self, ResourceError> {
        let m: Self::Xds = any.to_msg()?;
        Self::from_xds(&m)
    }

    fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError>;
    fn references(&self) -> Vec<(ResourceType, ResourceName)>;
    fn dns_names(&self) -> Vec<&Hostname> {
        Vec::new()
    }
}
```

The new structs mirror xDS much more closely - we're no longer inverting and converting back to Junction, and we've completely removed the notion of special Load Balancer configuration Listeners and RouteConfigurations. They're written to be as close to a projection of the xDS Protobuf types as possible while still being easy to write endpoint resolution code with.

Endpoint resolution and type conversions in this PR are still incomplete. I wanted to get enough of them done that we could pass `Cache` tests and `AdsConnection` tests, but we'll need to finish fleshing things out to get `Client` routing tests passing again.