### PR TITLE
[xds] juncton-core: client error trace apis

### DIFF
--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -1,12 +1,11 @@
 use crate::{
     dns,
-    error::Trace,
-    xds::{self, AdsClient},
-    Endpoint, Error,
+    xds::{self, AdsClient, ResourceType},
+    Endpoint, Error, Trace,
 };
 use futures::{stream::FuturesOrdered, StreamExt};
 use junction_api::Hostname;
-use rand::{distributions::WeightedError, rngs::StdRng, seq::SliceRandom};
+use rand::{distributions::WeightedError, seq::SliceRandom};
 use serde::Deserialize;
 use std::{
     borrow::Cow,
@@ -291,11 +290,15 @@ impl Client {
         let cluster = with_deadline!(
             self.config.ads.get_cluster(&resolved.cluster),
             Some(deadline),
-            "timed out fetching backend",
+            "fetching backend",
             resolved.trace,
         );
         let Some(cluster) = cluster else {
-            return Err(Error::no_backend(todo!(), resolved.trace));
+            return Err(Error::not_found(
+                ResourceType::Cluster.type_url().to_string(),
+                resolved.cluster.to_string(),
+                resolved.trace,
+            ));
         };
 
         // select endpoints using the result of route resolution
@@ -362,11 +365,15 @@ impl Client {
         let cluster = with_deadline!(
             self.config.ads.get_cluster(&endpoint.cluster_name),
             Some(deadline),
-            "timed out fetching backend",
+            "fetching cluster",
             endpoint.trace,
         );
         let Some(cluster) = cluster else {
-            return Err(Error::no_backend(todo!(), endpoint.trace));
+            return Err(Error::not_found(
+                ResourceType::Cluster.type_url().to_string(),
+                endpoint.cluster_name.to_string(),
+                endpoint.trace,
+            ));
         };
 
         let next = select_endpoint(
@@ -524,9 +531,8 @@ pub(crate) async fn resolve_route(
         });
     }
 
-    let msg = "timed out fetching route";
     let listener = loop {
-        match with_deadline!(futures_ordered.next(), deadline, msg, trace) {
+        match with_deadline!(futures_ordered.next(), deadline, "fetching listener", trace) {
             Some(Some(found)) => break found,
             Some(None) => {
                 continue;
@@ -543,12 +549,17 @@ pub(crate) async fn resolve_route(
     // immdediately try to fetch the route
     let route_config = match &listener.route_config {
         xds::listeners::RouteConfig::Rds(name) => {
-            let msg = "timed out fetching route";
-            match with_deadline!(cache.get_route_config(&name), deadline, msg, trace) {
+            match with_deadline!(
+                cache.get_route_config(&name),
+                deadline,
+                "fetching route",
+                trace
+            ) {
                 Some(route) => RouteConfigRef::Route(route),
                 None => {
-                    return Err(Error::no_route_matched(
-                        request.url.authority().to_string(),
+                    return Err(Error::not_found(
+                        ResourceType::Listener.type_url().to_string(),
+                        name.to_string(),
                         trace,
                     ))
                 }
@@ -562,12 +573,28 @@ pub(crate) async fn resolve_route(
     // need to match headers/url params/method and so on.
     let action = match find_match(route_config.as_ref(), request.clone()) {
         Some(route) => route,
-        None => return Err(Error::no_rule_matched(todo!(), trace)),
+        None => {
+            return Err(Error::no_route_matched(
+                request.url.authority().to_string(),
+                trace,
+            ))
+        }
     };
 
     // pick a target at random from the list, respecting weights. if there are
     // no backends listed we should blackhole here.
-    let cluster = crate::rand::with_thread_rng(|rng| pick_cluster(rng, &action.cluster))?;
+    let cluster = match &action.cluster {
+        xds::route_configs::ClusterSpecifier::Cluster(name) => name,
+        xds::route_configs::ClusterSpecifier::Weighted(clusters) => {
+            match crate::rand::with_thread_rng(|rng| clusters.choose_weighted(rng, |c| c.weight)) {
+                Ok(cluster) => &cluster.name,
+                Err(WeightedError::NoItem) => {
+                    return Err(Error::unavailable(trace, "route has no backends"));
+                }
+                Err(_) => return Err(Error::unavailable(trace, "route has invalid weights")),
+            }
+        }
+    };
 
     // if there's nothign in the request that matches this hash policy, fall
     // back to essentially random with sticky sessions. this is what envoy
@@ -603,22 +630,31 @@ async fn select_endpoint(
 ) -> crate::Result<SelectedEndpoint> {
     // lookup endpoints for a cluster
     let load_assignment = match &cluster.endpoints {
-        xds::clusters::Endpoints::Eds(name) => with_deadline!(
-            cache.get_load_assignment(&name),
-            deadline,
-            "timed out fetching endpoints",
-            trace
-        ),
+        xds::clusters::Endpoints::Eds(name) => {
+            let load_assignment = with_deadline!(
+                cache.get_load_assignment(&name),
+                deadline,
+                "fetching endpoints",
+                trace
+            );
+            match load_assignment {
+                Some(load_assignment) => load_assignment,
+                None => {
+                    return Err(Error::not_found(
+                        ResourceType::ClusterLoadAssignment.type_url().to_string(),
+                        name.to_string(),
+                        trace,
+                    ));
+                }
+            }
+        }
         xds::clusters::Endpoints::LogicalDns { hostname, port } => {
             // get a handle to the DNS resolver here and call into it
             todo!("support LOGICAL_DNS clusters")
         }
     };
-    let Some(load_assignment) = load_assignment else {
-        return Err(Error::no_reachable_endpoints(todo!(), trace));
-    };
     let Some(endpoints) = load_assignment.endpoints.first() else {
-        return Err(Error::no_reachable_endpoints(todo!(), trace));
+        return Err(Error::unavailable(trace, "no available endpoints"));
     };
 
     // load balance.
@@ -631,7 +667,7 @@ async fn select_endpoint(
         request.previous_addrs,
     );
     let Some(addr) = addr else {
-        return Err(Error::no_reachable_endpoints(todo!(), trace));
+        return Err(Error::unavailable(trace, "no available endpoints"));
     };
 
     Ok(SelectedEndpoint { addr: *addr, trace })
@@ -716,25 +752,6 @@ fn is_query_match(query_matches: &[xds::route_configs::QueryMatcher], url: &crat
         let query_val = query.get(&Cow::Borrowed(q.name.as_str()));
         q.matches(query_val.as_ref().map(|cow| cow.as_ref()))
     })
-}
-
-fn pick_cluster<'a>(
-    rng: &mut StdRng,
-    action: &'a xds::route_configs::ClusterSpecifier,
-) -> Result<&'a xds::ResourceName, Error> {
-    match action {
-        xds::route_configs::ClusterSpecifier::Cluster(name) => Ok(name),
-        xds::route_configs::ClusterSpecifier::Weighted(clusters) => {
-            match clusters.choose_weighted(rng, |c| c.weight) {
-                Ok(cluster) => Ok(&cluster.name),
-                Err(WeightedError::NoItem) => {
-                    // TODO: should this just return a special endpoint that 500s?
-                    return Err(todo!());
-                }
-                Err(_) => return Err(todo!()),
-            }
-        }
-    }
 }
 
 /// Hash an outgoing request based on a set of hash policies.

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -270,47 +270,24 @@ impl Client {
 
         let request = HttpRequest::from_parts(method, url, headers);
 
-        let trace = Trace::new();
         let resolved = resolve_route(
             &self.config.ads,
             &self.search_config,
-            trace,
+            Trace::new(),
             request.clone(),
             Some(deadline),
         )
         .await?;
-
-        // fetch the cluster for this request and compute the request hash. both
-        // cluster selection and endpoint hashing should be done at this point,
-        // even if the request gets retried.
-        //
-        // this happens here so that in THEORY we can switch out the hash
-        // function. in practice, there's no reason to do it here since there
-        // is exactly one hash function we support at the moment.
-        let cluster = with_deadline!(
-            self.config.ads.get_cluster(&resolved.cluster),
-            Some(deadline),
-            "fetching backend",
-            resolved.trace,
-        );
-        let Some(cluster) = cluster else {
-            return Err(Error::not_found(
-                ResourceType::Cluster.type_url().to_string(),
-                resolved.cluster.to_string(),
-                resolved.trace,
-            ));
-        };
 
         // select endpoints using the result of route resolution
         let selected = select_endpoint(
             &self.config.ads,
             resolved.trace,
             RequestContext {
-                request,
                 request_hash: resolved.request_hash,
                 previous_addrs: &[],
             },
-            cluster,
+            &resolved.cluster,
             Some(deadline),
         )
         .await?;
@@ -357,43 +334,25 @@ impl Client {
         // used in the initial request, and the same request hash, but should
         // not necessarily pick the same endpoint.
         let deadline = Instant::now() + self.resolve_timeout;
-        let context = RequestContext {
-            request: HttpRequest::from_parts(&endpoint.method, &endpoint.url, &endpoint.headers),
-            request_hash: endpoint.request_hash,
-            previous_addrs: &endpoint.previous_addrs,
-        };
-        let cluster = with_deadline!(
-            self.config.ads.get_cluster(&endpoint.cluster_name),
-            Some(deadline),
-            "fetching cluster",
-            endpoint.trace,
-        );
-        let Some(cluster) = cluster else {
-            return Err(Error::not_found(
-                ResourceType::Cluster.type_url().to_string(),
-                endpoint.cluster_name.to_string(),
-                endpoint.trace,
-            ));
-        };
-
         let next = select_endpoint(
             &self.config.ads,
             endpoint.trace,
-            context,
-            cluster,
+            RequestContext {
+                request_hash: endpoint.request_hash,
+                previous_addrs: &endpoint.previous_addrs,
+            },
+            &endpoint.cluster_name,
             Some(deadline),
         )
         .await?;
-        let address = next.addr;
-        let trace = next.trace;
 
         // track address history
         let mut previous_addrs = endpoint.previous_addrs;
         previous_addrs.push(endpoint.address);
 
         Ok(Endpoint {
-            address,
-            trace,
+            address: next.addr,
+            trace: next.trace,
             previous_addrs,
             ..endpoint
         })
@@ -503,7 +462,7 @@ pub(crate) struct ResolvedRoute {
 pub(crate) async fn resolve_route(
     cache: &impl XdsCache,
     search_config: &SearchConfig,
-    trace: Trace,
+    mut trace: Trace,
     request: HttpRequest<'_>,
     deadline: Option<Instant>,
 ) -> crate::Result<ResolvedRoute> {
@@ -527,11 +486,11 @@ pub(crate) async fn resolve_route(
             cache
                 .subscribe(xds::ResourceType::Listener, name.clone())
                 .await;
-            cache.get_listener(&name).await
+            cache.get_listener(&name).await.map(|l| (name, l))
         });
     }
 
-    let listener = loop {
+    let (listener_name, listener) = loop {
         match with_deadline!(futures_ordered.next(), deadline, "fetching listener", trace) {
             Some(Some(found)) => break found,
             Some(None) => {
@@ -545,6 +504,7 @@ pub(crate) async fn resolve_route(
             }
         }
     };
+    trace.lookup_listener(listener_name.to_string());
 
     // immdediately try to fetch the route
     let route_config = match &listener.route_config {
@@ -555,10 +515,13 @@ pub(crate) async fn resolve_route(
                 "fetching route",
                 trace
             ) {
-                Some(route) => RouteConfigRef::Route(route),
+                Some(route) => {
+                    trace.lookup_route(name.to_string());
+                    RouteConfigRef::Route(route)
+                }
                 None => {
                     return Err(Error::not_found(
-                        ResourceType::Listener.type_url().to_string(),
+                        ResourceType::RouteConfiguration.type_url().to_string(),
                         name.to_string(),
                         trace,
                     ))
@@ -572,7 +535,7 @@ pub(crate) async fn resolve_route(
     // request. the hostname and port of the request have already matched but we
     // need to match headers/url params/method and so on.
     let action = match find_match(route_config.as_ref(), request.clone()) {
-        Some(route) => route,
+        Some(action) => action,
         None => {
             return Err(Error::no_route_matched(
                 request.url.authority().to_string(),
@@ -580,6 +543,7 @@ pub(crate) async fn resolve_route(
             ))
         }
     };
+    trace.matched_route();
 
     // pick a target at random from the list, respecting weights. if there are
     // no backends listed we should blackhole here.
@@ -595,6 +559,7 @@ pub(crate) async fn resolve_route(
             }
         }
     };
+    trace.select_cluster();
 
     // if there's nothign in the request that matches this hash policy, fall
     // back to essentially random with sticky sessions. this is what envoy
@@ -604,6 +569,7 @@ pub(crate) async fn resolve_route(
     // https://github.com/envoyproxy/envoy/blob/73fe00fc139fd5053f4c4a5d66569cc254449896/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc#L157-L164
     let request_hash =
         hash_request(request.clone(), &action.hash_policies).unwrap_or_else(crate::rand::random);
+    trace.hash_request(request_hash);
 
     Ok(ResolvedRoute {
         trace,
@@ -616,7 +582,6 @@ pub(crate) async fn resolve_route(
 
 #[derive(Debug, Clone)]
 struct RequestContext<'a> {
-    request: HttpRequest<'a>,
     request_hash: u64,
     previous_addrs: &'a [SocketAddr],
 }
@@ -625,9 +590,27 @@ async fn select_endpoint(
     cache: &impl XdsCache,
     mut trace: Trace,
     request: RequestContext<'_>,
-    cluster: Arc<xds::Cluster>,
+    cluster_name: &xds::ResourceName,
     deadline: Option<Instant>,
 ) -> crate::Result<SelectedEndpoint> {
+    trace.start_endpoint_selection();
+
+    // lookup cluster
+    let cluster = with_deadline!(
+        cache.get_cluster(&cluster_name),
+        deadline,
+        "fetching cluster",
+        trace,
+    );
+    let Some(cluster) = cluster else {
+        return Err(Error::not_found(
+            ResourceType::Cluster.type_url().to_string(),
+            cluster_name.to_string(),
+            trace,
+        ));
+    };
+    trace.lookup_cluster(cluster_name.to_string());
+
     // lookup endpoints for a cluster
     let load_assignment = match &cluster.endpoints {
         xds::clusters::Endpoints::Eds(name) => {
@@ -638,7 +621,10 @@ async fn select_endpoint(
                 trace
             );
             match load_assignment {
-                Some(load_assignment) => load_assignment,
+                Some(load_assignment) => {
+                    trace.lookup_endpoints(name.to_string());
+                    load_assignment
+                }
                 None => {
                     return Err(Error::not_found(
                         ResourceType::ClusterLoadAssignment.type_url().to_string(),

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -298,22 +298,13 @@ impl Client {
             return Err(Error::no_backend(todo!(), resolved.trace));
         };
 
-        // if there's nothign in the request that matches this hash policy, fall
-        // back to essentially random with sticky sessions. this is what envoy
-        // does with the rationale that this is better than failing the request
-        // if the config is bad.
-        //
-        // https://github.com/envoyproxy/envoy/blob/73fe00fc139fd5053f4c4a5d66569cc254449896/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc#L157-L164
-        let request_hash = hash_request(request.clone(), &resolved.hash_policy)
-            .unwrap_or_else(crate::rand::random);
-
         // select endpoints using the result of route resolution
         let selected = select_endpoint(
             &self.config.ads,
             resolved.trace,
             RequestContext {
                 request,
-                request_hash,
+                request_hash: resolved.request_hash,
                 previous_addrs: &[],
             },
             cluster,
@@ -328,11 +319,11 @@ impl Client {
             method: method.clone(),
             url: url.clone(),
             headers: headers.clone(),
-            request_hash,
-            address,
+            request_hash: resolved.request_hash,
             cluster_name: resolved.cluster,
-            trace,
+            address,
             previous_addrs: vec![],
+            trace,
         })
     }
 
@@ -496,7 +487,7 @@ impl AsRef<xds::RouteConfiguration> for RouteConfigRef {
 
 pub(crate) struct ResolvedRoute {
     cluster: xds::ResourceName,
-    hash_policy: Vec<xds::route_configs::HashPolicy>,
+    request_hash: u64,
     retries: xds::route_configs::Retries,
     timeouts: xds::route_configs::Timeouts,
     trace: Trace,
@@ -577,10 +568,20 @@ pub(crate) async fn resolve_route(
     // pick a target at random from the list, respecting weights. if there are
     // no backends listed we should blackhole here.
     let cluster = crate::rand::with_thread_rng(|rng| pick_cluster(rng, &action.cluster))?;
+
+    // if there's nothign in the request that matches this hash policy, fall
+    // back to essentially random with sticky sessions. this is what envoy
+    // does with the rationale that this is better than failing the request
+    // if the config is bad.
+    //
+    // https://github.com/envoyproxy/envoy/blob/73fe00fc139fd5053f4c4a5d66569cc254449896/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc#L157-L164
+    let request_hash =
+        hash_request(request.clone(), &action.hash_policies).unwrap_or_else(crate::rand::random);
+
     Ok(ResolvedRoute {
         trace,
         cluster: cluster.clone(),
-        hash_policy: action.hash_policies.clone(),
+        request_hash,
         retries: action.retries.clone(),
         timeouts: action.timeouts.clone(),
     })

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use crate::{error::Trace, xds, HttpRequest, HttpResult};
+use crate::{xds, HttpRequest, HttpResult, Trace};
 
 // TODO: move to Client? all these fields can be private then.
 // TODO: this is way more than just a resolved endpoint, it's the whole request

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -17,8 +17,9 @@ pub struct Endpoint {
     // matched route info
     // TODO: do we need the matched route here???? is it enough to have the name and
     // version? is it enough to have it in the trace?
-    pub(crate) address: SocketAddr,
     pub(crate) cluster_name: xds::ResourceName,
+    pub(crate) address: SocketAddr,
+    pub(crate) previous_addrs: Vec<SocketAddr>,
 
     // FIXME: figure out what the type is here and expose it
     // pub(crate) timeouts: Option<RouteTimeouts>,
@@ -26,7 +27,6 @@ pub struct Endpoint {
 
     // debugging data
     pub(crate) trace: Trace,
-    pub(crate) previous_addrs: Vec<SocketAddr>,
 }
 
 impl Endpoint {

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -1,151 +1,6 @@
-use std::{borrow::Cow, net::SocketAddr, time::Instant};
+use std::borrow::Cow;
 
-use junction_api::{backend::BackendId, http::Route, Name};
-use smol_str::{SmolStr, ToSmolStr};
-
-#[derive(Clone, Debug)]
-pub(crate) struct Trace {
-    start: Instant,
-    phase: TracePhase,
-    events: Vec<TraceEvent>,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct TraceEvent {
-    pub(crate) phase: TracePhase,
-    pub(crate) kind: TraceEventKind,
-    pub(crate) at: Instant,
-    pub(crate) kv: Vec<TraceData>,
-}
-
-type TraceData = (&'static str, SmolStr);
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum TracePhase {
-    RouteResolution,
-    EndpointSelection(u8),
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum TraceEventKind {
-    RouteLookup,
-    RouteRuleMatched,
-    BackendSelected,
-    BackendLookup,
-    EndpointsLookup,
-    SelectAddr,
-}
-
-impl Trace {
-    pub(crate) fn new() -> Self {
-        Trace {
-            start: Instant::now(),
-            phase: TracePhase::RouteResolution,
-            events: Vec::new(),
-        }
-    }
-
-    pub(crate) fn events(&self) -> impl Iterator<Item = &TraceEvent> {
-        self.events.iter()
-    }
-
-    pub(crate) fn start(&self) -> Instant {
-        self.start
-    }
-
-    pub(crate) fn lookup_route(&mut self, route: &Route) {
-        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
-
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::RouteLookup,
-            phase: TracePhase::RouteResolution,
-            at: Instant::now(),
-            kv: vec![("route", route.id.to_smolstr())],
-        })
-    }
-
-    pub(crate) fn matched_rule(&mut self, rule: usize, rule_name: Option<&Name>) {
-        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
-
-        let kv = match rule_name {
-            Some(name) => vec![("rule-name", name.to_smolstr())],
-            None => vec![("rule-idx", rule.to_smolstr())],
-        };
-
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::RouteRuleMatched,
-            phase: TracePhase::RouteResolution,
-            at: Instant::now(),
-            kv,
-        })
-    }
-
-    pub(crate) fn select_backend(&mut self, backend: &BackendId) {
-        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
-
-        self.events.push(TraceEvent {
-            phase: self.phase,
-            kind: TraceEventKind::BackendSelected,
-            at: Instant::now(),
-            kv: vec![("name", backend.to_smolstr())],
-        });
-    }
-
-    pub(crate) fn start_endpoint_selection(&mut self) {
-        let next_phase = match self.phase {
-            TracePhase::RouteResolution => TracePhase::EndpointSelection(0),
-            TracePhase::EndpointSelection(n) => TracePhase::EndpointSelection(n + 1),
-        };
-        self.phase = next_phase;
-    }
-
-    pub(crate) fn lookup_backend(&mut self, backend: &BackendId) {
-        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
-
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::BackendLookup,
-            phase: self.phase,
-            at: Instant::now(),
-            kv: vec![("backend-id", backend.to_smolstr())],
-        })
-    }
-
-    pub(crate) fn lookup_endpoints(&mut self, backend: &BackendId) {
-        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
-
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::EndpointsLookup,
-            phase: self.phase,
-            at: Instant::now(),
-            kv: vec![("backend-id", backend.to_smolstr())],
-        })
-    }
-
-    pub(crate) fn load_balance(
-        &mut self,
-        lb_name: &'static str,
-        addr: Option<&SocketAddr>,
-        extra: Vec<TraceData>,
-    ) {
-        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
-
-        let mut kv = Vec::with_capacity(extra.len() + 2);
-        kv.push(("type", lb_name.to_smolstr()));
-        kv.push((
-            "addr",
-            addr.map(|a| a.to_smolstr())
-                .unwrap_or_else(|| "-".to_smolstr()),
-        ));
-        kv.extend(extra);
-
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::SelectAddr,
-            phase: self.phase,
-            at: Instant::now(),
-            kv,
-        });
-    }
-}
+use crate::Trace;
 
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -172,25 +27,11 @@ impl Error {
     /// Temporary errors may occur because of a network timeout or because of
     /// lag fetching a configuration from a Junction server.
     pub fn is_temporary(&self) -> bool {
-        matches!(*self.inner, ErrorImpl::NoReachableEndpoints { .. })
+        matches!(*self.inner, ErrorImpl::TimedOut { .. })
     }
 }
 
 impl Error {
-    // timeouts
-
-    pub(crate) fn timed_out(message: &'static str, trace: Trace) -> Self {
-        let inner = ErrorImpl::TimedOut(Cow::from(message));
-        Self {
-            trace: Some(trace),
-            inner: Box::new(inner),
-        }
-    }
-
-    // url problems
-    //
-    // TODO: should this be a separate type? thye don't need a Trace or anything
-
     pub(crate) fn into_invalid_url(message: String) -> Self {
         let inner = ErrorImpl::InvalidUrl(Cow::Owned(message));
         Self {
@@ -207,7 +48,13 @@ impl Error {
         }
     }
 
-    // route problems
+    pub(crate) fn timed_out(message: &'static str, trace: Trace) -> Self {
+        let inner = ErrorImpl::TimedOut(Cow::from(message));
+        Self {
+            trace: Some(trace),
+            inner: Box::new(inner),
+        }
+    }
 
     pub(crate) fn no_route_matched(authority: String, trace: Trace) -> Self {
         Self {
@@ -216,66 +63,41 @@ impl Error {
         }
     }
 
-    pub(crate) fn no_rule_matched(route: Name, trace: Trace) -> Self {
+    pub(crate) fn not_found(resource_type: String, resource_name: String, trace: Trace) -> Self {
         Self {
             trace: Some(trace),
-            inner: Box::new(ErrorImpl::NoRuleMatched { route }),
+            inner: Box::new(ErrorImpl::NotFound {
+                resource_type,
+                resource_name,
+            }),
         }
     }
 
-    pub(crate) fn invalid_route(
-        message: &'static str,
-        id: Name,
-        rule: usize,
-        trace: Trace,
-    ) -> Self {
+    pub(crate) fn unavailable(trace: Trace, msg: &'static str) -> Self {
         Self {
             trace: Some(trace),
-            inner: Box::new(ErrorImpl::InvalidRoute { id, message, rule }),
-        }
-    }
-
-    // backend problems
-
-    pub(crate) fn no_backend(backend: BackendId, trace: Trace) -> Self {
-        Self {
-            trace: Some(trace),
-            inner: Box::new(ErrorImpl::NoBackend { backend }),
-        }
-    }
-
-    pub(crate) fn no_reachable_endpoints(backend: BackendId, trace: Trace) -> Self {
-        Self {
-            trace: Some(trace),
-            inner: Box::new(ErrorImpl::NoReachableEndpoints { backend }),
+            inner: Box::new(ErrorImpl::Unavailable(Cow::Borrowed(msg))),
         }
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 enum ErrorImpl {
-    #[error("timed out: {0}")]
-    TimedOut(Cow<'static, str>),
-
     #[error("invalid url: {0}")]
     InvalidUrl(Cow<'static, str>),
 
-    #[error("invalid route configuration")]
-    InvalidRoute {
-        message: &'static str,
-        id: Name,
-        rule: usize,
-    },
+    #[error("timed out {0}")]
+    TimedOut(Cow<'static, str>),
 
     #[error("no route matched: '{authority}'")]
     NoRouteMatched { authority: String },
 
-    #[error("{route}: no rules matched the request")]
-    NoRuleMatched { route: Name },
+    #[error("xds {resource_type} not found: {resource_name}")]
+    NotFound {
+        resource_type: String,
+        resource_name: String,
+    },
 
-    #[error("{backend}: backend not found")]
-    NoBackend { backend: BackendId },
-
-    #[error("{backend}: no reachable endpoints")]
-    NoReachableEndpoints { backend: BackendId },
+    #[error("unavailable")]
+    Unavailable(Cow<'static, str>),
 }

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! * [Getting Started](https://docs.junctionlabs.io/getting-started/rust)
 
 mod error;
+mod trace;
 mod url;
 pub use crate::error::{Error, Result};
 pub use crate::url::Url;
@@ -18,9 +19,9 @@ mod dns;
 mod xds;
 
 pub use client::{Client, HttpRequest, HttpResult, SearchConfig, SelectedEndpoint};
-use error::Trace;
 use futures::FutureExt;
 use junction_api::Name;
+use trace::Trace;
 pub use xds::{ResourceVersion, XdsConfig};
 
 use junction_api::backend::BackendId;

--- a/crates/junction-core/src/trace.rs
+++ b/crates/junction-core/src/trace.rs
@@ -1,0 +1,148 @@
+use std::{net::SocketAddr, time::Instant};
+
+use junction_api::{backend::BackendId, http::Route, Name};
+use smol_str::{SmolStr, ToSmolStr};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Trace {
+    start: Instant,
+    phase: TracePhase,
+    events: Vec<TraceEvent>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TraceEvent {
+    pub(crate) phase: TracePhase,
+    pub(crate) kind: TraceEventKind,
+    pub(crate) at: Instant,
+    pub(crate) kv: Vec<TraceData>,
+}
+
+type TraceData = (&'static str, SmolStr);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TracePhase {
+    RouteResolution,
+    EndpointSelection(u8),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TraceEventKind {
+    RouteLookup,
+    RouteRuleMatched,
+    BackendSelected,
+    BackendLookup,
+    EndpointsLookup,
+    SelectAddr,
+}
+
+impl Trace {
+    pub(crate) fn new() -> Self {
+        Trace {
+            start: Instant::now(),
+            phase: TracePhase::RouteResolution,
+            events: Vec::new(),
+        }
+    }
+
+    pub(crate) fn events(&self) -> impl Iterator<Item = &TraceEvent> {
+        self.events.iter()
+    }
+
+    pub(crate) fn start(&self) -> Instant {
+        self.start
+    }
+
+    pub(crate) fn lookup_route(&mut self, route: &Route) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::RouteLookup,
+            phase: TracePhase::RouteResolution,
+            at: Instant::now(),
+            kv: vec![("route", route.id.to_smolstr())],
+        })
+    }
+
+    pub(crate) fn matched_rule(&mut self, rule: usize, rule_name: Option<&Name>) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        let kv = match rule_name {
+            Some(name) => vec![("rule-name", name.to_smolstr())],
+            None => vec![("rule-idx", rule.to_smolstr())],
+        };
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::RouteRuleMatched,
+            phase: TracePhase::RouteResolution,
+            at: Instant::now(),
+            kv,
+        })
+    }
+
+    pub(crate) fn select_backend(&mut self, backend: &BackendId) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        self.events.push(TraceEvent {
+            phase: self.phase,
+            kind: TraceEventKind::BackendSelected,
+            at: Instant::now(),
+            kv: vec![("name", backend.to_smolstr())],
+        });
+    }
+
+    pub(crate) fn start_endpoint_selection(&mut self) {
+        let next_phase = match self.phase {
+            TracePhase::RouteResolution => TracePhase::EndpointSelection(0),
+            TracePhase::EndpointSelection(n) => TracePhase::EndpointSelection(n + 1),
+        };
+        self.phase = next_phase;
+    }
+
+    pub(crate) fn lookup_backend(&mut self, backend: &BackendId) {
+        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::BackendLookup,
+            phase: self.phase,
+            at: Instant::now(),
+            kv: vec![("backend-id", backend.to_smolstr())],
+        })
+    }
+
+    pub(crate) fn lookup_endpoints(&mut self, backend: &BackendId) {
+        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::EndpointsLookup,
+            phase: self.phase,
+            at: Instant::now(),
+            kv: vec![("backend-id", backend.to_smolstr())],
+        })
+    }
+
+    pub(crate) fn load_balance(
+        &mut self,
+        lb_name: &'static str,
+        addr: Option<&SocketAddr>,
+        extra: Vec<TraceData>,
+    ) {
+        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
+
+        let mut kv = Vec::with_capacity(extra.len() + 2);
+        kv.push(("type", lb_name.to_smolstr()));
+        kv.push((
+            "addr",
+            addr.map(|a| a.to_smolstr())
+                .unwrap_or_else(|| "-".to_smolstr()),
+        ));
+        kv.extend(extra);
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::SelectAddr,
+            phase: self.phase,
+            at: Instant::now(),
+            kv,
+        });
+    }
+}

--- a/crates/junction-core/src/trace.rs
+++ b/crates/junction-core/src/trace.rs
@@ -1,6 +1,5 @@
 use std::{net::SocketAddr, time::Instant};
 
-use junction_api::{backend::BackendId, http::Route, Name};
 use smol_str::{SmolStr, ToSmolStr};
 
 #[derive(Clone, Debug)]
@@ -26,14 +25,18 @@ pub(crate) enum TracePhase {
     EndpointSelection(u8),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum TraceEventKind {
-    RouteLookup,
-    RouteRuleMatched,
-    BackendSelected,
-    BackendLookup,
-    EndpointsLookup,
-    SelectAddr,
+    // RouteResolution
+    LookupListener,
+    LookupRoute,
+    MatchRoute,
+    SelectCluster,
+    HashRequest,
+    // EndpointSelection
+    LookupCluster,
+    LookupEndpoints,
+    LoadBalance,
 }
 
 impl Trace {
@@ -53,43 +56,64 @@ impl Trace {
         self.start
     }
 
-    pub(crate) fn lookup_route(&mut self, route: &Route) {
+    // Route Resolution builders
+
+    pub(crate) fn lookup_listener(&mut self, listener: String) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
         self.events.push(TraceEvent {
-            kind: TraceEventKind::RouteLookup,
+            kind: TraceEventKind::LookupListener,
             phase: TracePhase::RouteResolution,
             at: Instant::now(),
-            kv: vec![("route", route.id.to_smolstr())],
+            kv: vec![("listener", listener.to_smolstr())],
         })
     }
 
-    pub(crate) fn matched_rule(&mut self, rule: usize, rule_name: Option<&Name>) {
+    pub(crate) fn lookup_route(&mut self, route: String) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
-        let kv = match rule_name {
-            Some(name) => vec![("rule-name", name.to_smolstr())],
-            None => vec![("rule-idx", rule.to_smolstr())],
-        };
-
         self.events.push(TraceEvent {
-            kind: TraceEventKind::RouteRuleMatched,
+            kind: TraceEventKind::LookupRoute,
             phase: TracePhase::RouteResolution,
             at: Instant::now(),
-            kv,
+            kv: vec![("route", route.to_smolstr())],
         })
     }
 
-    pub(crate) fn select_backend(&mut self, backend: &BackendId) {
+    pub(crate) fn matched_route(&mut self) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        self.events.push(TraceEvent {
+            kind: TraceEventKind::MatchRoute,
+            phase: TracePhase::RouteResolution,
+            at: Instant::now(),
+            kv: vec![],
+        })
+    }
+
+    pub(crate) fn select_cluster(&mut self) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
         self.events.push(TraceEvent {
             phase: self.phase,
-            kind: TraceEventKind::BackendSelected,
+            kind: TraceEventKind::SelectCluster,
             at: Instant::now(),
-            kv: vec![("name", backend.to_smolstr())],
+            kv: vec![],
         });
     }
+
+    pub(crate) fn hash_request(&mut self, request_hash: u64) {
+        debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
+
+        self.events.push(TraceEvent {
+            phase: self.phase,
+            kind: TraceEventKind::HashRequest,
+            at: Instant::now(),
+            kv: vec![("request-hash", request_hash.to_smolstr())],
+        });
+    }
+
+    // Endpoint Selection builders
 
     pub(crate) fn start_endpoint_selection(&mut self) {
         let next_phase = match self.phase {
@@ -99,26 +123,22 @@ impl Trace {
         self.phase = next_phase;
     }
 
-    pub(crate) fn lookup_backend(&mut self, backend: &BackendId) {
-        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
-
+    pub(crate) fn lookup_cluster(&mut self, cluster: String) {
         self.events.push(TraceEvent {
-            kind: TraceEventKind::BackendLookup,
             phase: self.phase,
+            kind: TraceEventKind::LookupCluster,
             at: Instant::now(),
-            kv: vec![("backend-id", backend.to_smolstr())],
-        })
+            kv: vec![("cluster", cluster.to_smolstr())],
+        });
     }
 
-    pub(crate) fn lookup_endpoints(&mut self, backend: &BackendId) {
-        debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
-
+    pub(crate) fn lookup_endpoints(&mut self, endpoints: String) {
         self.events.push(TraceEvent {
-            kind: TraceEventKind::EndpointsLookup,
             phase: self.phase,
+            kind: TraceEventKind::LookupEndpoints,
             at: Instant::now(),
-            kv: vec![("backend-id", backend.to_smolstr())],
-        })
+            kv: vec![("endpoints", endpoints.to_smolstr())],
+        });
     }
 
     pub(crate) fn load_balance(
@@ -139,7 +159,7 @@ impl Trace {
         kv.extend(extra);
 
         self.events.push(TraceEvent {
-            kind: TraceEventKind::SelectAddr,
+            kind: TraceEventKind::LoadBalance,
             phase: self.phase,
             at: Instant::now(),
             kv,

--- a/crates/junction-core/src/xds/load_balancer.rs
+++ b/crates/junction-core/src/xds/load_balancer.rs
@@ -1,7 +1,7 @@
 use crate::{
-    error::Trace,
     hash::thread_local_xxhash,
     xds::{clusters::LbPolicy, endpoints::EndpointGroup},
+    Trace,
 };
 use smol_str::ToSmolStr;
 use std::{

--- a/crates/junction-core/src/xds/load_balancer.rs
+++ b/crates/junction-core/src/xds/load_balancer.rs
@@ -75,7 +75,7 @@ impl RoundRobinLb {
         let idx = self.idx.fetch_add(1, Ordering::SeqCst) % endpoint_group.len();
         let addr = endpoint_group.nth(idx);
 
-        trace.load_balance("ROUND_ROBIN", addr, Vec::new());
+        trace.load_balance("RoundRobin", addr, Vec::new());
 
         addr
     }
@@ -120,7 +120,7 @@ impl RingHashLb {
         let endpoint_idx = self.with_ring(endpoints, |r| r.pick(request_hash))?;
         let addr = endpoints.nth(endpoint_idx);
 
-        trace.load_balance("RING_HASH", addr, vec![("hash", request_hash.to_smolstr())]);
+        trace.load_balance("RingHash", addr, vec![("hash", request_hash.to_smolstr())]);
 
         addr
     }


### PR DESCRIPTION
Overhauls the client's `Error` and `Trace` APIs to work with xDS routing. We're going to have to figure out exactly what's useful here, but this should give a complete trace of xDS lookups in the client with timings.

This PR also moves request hashing back into `select_endpoints` - I had moved it out while figuring out exactly where it was right to do it, but we just ended up with duplicated code in `resolve_route` and `select_endpoints`.