### PR TITLE
[xds] junction-core: add types and conversions for Retries and Timeouts

### DIFF
--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -303,6 +303,8 @@ impl Client {
             cluster_name: resolved.cluster,
             address,
             previous_addrs: vec![],
+            retries: resolved.retries.map(|r| r.into()),
+            timeouts: resolved.timeouts.map(|t| t.into()),
             trace,
         })
     }
@@ -454,8 +456,8 @@ impl AsRef<xds::RouteConfiguration> for RouteConfigRef {
 pub(crate) struct ResolvedRoute {
     cluster: xds::ResourceName,
     request_hash: u64,
-    retries: xds::route_configs::Retries,
-    timeouts: xds::route_configs::Timeouts,
+    retries: Option<xds::route_configs::Retries>,
+    timeouts: Option<xds::route_configs::Timeouts>,
     trace: Trace,
 }
 
@@ -845,7 +847,7 @@ fn search<'a>(search_config: &SearchConfig, url: &'a crate::Url) -> Vec<Cow<'a, 
 #[cfg(test)]
 mod test {
     use crate::Url;
-    use junction_api::{http::BackendRef, Hostname, Name, Regex, Service};
+    use junction_api::Hostname;
     use std::str::FromStr;
 
     use pretty_assertions::assert_eq;

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -1,6 +1,54 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
-use crate::{xds, HttpRequest, HttpResult, Trace};
+use crate::{xds, HttpResult, Trace};
+
+#[derive(Debug, Clone)]
+pub struct Retries {
+    /// The HTTP error codes that retries should be applied to.
+    pub codes: Vec<u16>,
+
+    /// The total number of attempts to make when retrying this request. If
+    /// unset, the client should only ever make a single request.
+    pub attempts: Option<u32>,
+
+    /// The initial amount of time to back off between requests during a series
+    /// of retries. Backoff may scale up to `max_backoff` between requests at
+    /// the client's discretion
+    pub backoff: Option<Duration>,
+
+    /// The maximum amount of time to back off between requests.
+    pub max_backoff: Option<Duration>,
+}
+
+impl From<xds::route_configs::Retries> for Retries {
+    fn from(value: xds::route_configs::Retries) -> Self {
+        Self {
+            codes: value.codes,
+            attempts: value.attempts,
+            backoff: value.backoff,
+            max_backoff: value.max_backoff,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Timeouts {
+    /// The total timeout for this request and all of its retries.
+    pub total: Option<Duration>,
+
+    /// The timeout for each individual request attempt. The value of this
+    /// timeout should be less than or equal to the total timeout of the request.
+    pub attempt: Option<Duration>,
+}
+
+impl From<xds::route_configs::Timeouts> for Timeouts {
+    fn from(value: xds::route_configs::Timeouts) -> Self {
+        Self {
+            total: value.total,
+            attempt: value.attempt,
+        }
+    }
+}
 
 // TODO: move to Client? all these fields can be private then.
 // TODO: this is way more than just a resolved endpoint, it's the whole request
@@ -20,6 +68,8 @@ pub struct Endpoint {
     pub(crate) cluster_name: xds::ResourceName,
     pub(crate) address: SocketAddr,
     pub(crate) previous_addrs: Vec<SocketAddr>,
+    pub(crate) retries: Option<Retries>,
+    pub(crate) timeouts: Option<Timeouts>,
 
     // FIXME: figure out what the type is here and expose it
     // pub(crate) timeouts: Option<RouteTimeouts>,
@@ -46,34 +96,33 @@ impl Endpoint {
         self.address
     }
 
-    // pub fn timeouts(&self) -> &Option<RouteTimeouts> {
-    //     &self.timeouts
-    // }
+    pub fn timeouts(&self) -> &Option<Timeouts> {
+        &self.timeouts
+    }
 
-    // pub fn retry(&self) -> &Option<RouteRetry> {
-    //     &self.retry
-    // }
+    pub fn retry(&self) -> &Option<Retries> {
+        &self.retries
+    }
 
     pub(crate) fn should_retry(&self, result: HttpResult) -> bool {
-        todo!()
-        // let Some(retry) = &self.retry else {
-        //     return false;
-        // };
-        // let Some(allowed) = &retry.attempts else {
-        //     return false;
-        // };
-        // let allowed = *allowed as usize;
+        let Some(retry) = &self.retries else {
+            return false;
+        };
+        let Some(allowed) = &retry.attempts else {
+            return false;
+        };
+        let allowed = *allowed as usize;
 
-        // match result {
-        //     HttpResult::StatusError(code) if !retry.codes.contains(&code.as_u16()) => return false,
-        //     _ => (),
-        // }
+        match result {
+            HttpResult::StatusError(code) if !retry.codes.contains(&code.as_u16()) => return false,
+            _ => (),
+        }
 
-        // // total number of attempts taken is history + 1 because we include the
-        // // the current addr as an attempt.
-        // let attempts = self.previous_addrs.len() + 1;
+        // total number of attempts taken is history + 1 because we include the
+        // the current addr as an attempt.
+        let attempts = self.previous_addrs.len() + 1;
 
-        // attempts < allowed
+        attempts < allowed
     }
 
     // FIXME: lol
@@ -103,84 +152,85 @@ impl Endpoint {
 
 #[cfg(test)]
 mod test {
-    // use std::net::Ipv4Addr;
+    use http::StatusCode;
+    use std::net::Ipv4Addr;
 
-    // use http::StatusCode;
-    // use junction_api::{Duration, Service};
+    use crate::{xds::ResourceName, Url};
 
-    // use crate::Url;
+    use super::*;
 
-    // use super::*;
+    #[test]
+    fn test_endpoint_should_retry_no_policy() {
+        let mut endpoint = new_endpoint();
+        endpoint.retries = None;
 
-    // #[test]
-    // fn test_endpoint_should_retry_no_policy() {
-    //     let mut endpoint = new_endpoint();
-    //     endpoint.retry = None;
+        assert!(!endpoint.should_retry(HttpResult::StatusFailed));
+        assert!(!endpoint.should_retry(HttpResult::StatusError(
+            http::StatusCode::SERVICE_UNAVAILABLE
+        )));
+    }
 
-    //     assert!(!endpoint.should_retry(HttpResult::StatusFailed));
-    //     assert!(!endpoint.should_retry(HttpResult::StatusError(
-    //         http::StatusCode::SERVICE_UNAVAILABLE
-    //     )));
-    // }
+    #[test]
+    fn test_endpoint_should_retry_with_policy() {
+        let mut endpoint = new_endpoint();
+        endpoint.retries = Some(Retries {
+            codes: vec![StatusCode::BAD_REQUEST.as_u16()],
+            attempts: Some(3),
+            backoff: Some(Duration::from_secs(2)),
+            max_backoff: Some(Duration::from_secs(5)),
+        });
 
-    // #[test]
-    // fn test_endpoint_should_retry_with_policy() {
-    //     let mut endpoint = new_endpoint();
-    //     endpoint.retry = Some(RouteRetry {
-    //         codes: vec![StatusCode::BAD_REQUEST.as_u16()],
-    //         attempts: Some(3),
-    //         backoff: Some(Duration::from_secs(2)),
-    //     });
+        assert!(endpoint.should_retry(HttpResult::StatusFailed));
+        assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
+        assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
+    }
 
-    //     assert!(endpoint.should_retry(HttpResult::StatusFailed));
-    //     assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
-    //     assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
-    // }
+    #[test]
+    fn test_endpoint_should_retry_with_history() {
+        let mut endpoint = new_endpoint();
+        endpoint.retries = Some(Retries {
+            codes: vec![StatusCode::BAD_REQUEST.as_u16()],
+            attempts: Some(3),
+            backoff: Some(Duration::from_secs(2)),
+            max_backoff: Some(Duration::from_secs(5)),
+        });
 
-    // #[test]
-    // fn test_endpoint_should_retry_with_history() {
-    //     let mut endpoint = new_endpoint();
-    //     endpoint.retry = Some(RouteRetry {
-    //         codes: vec![StatusCode::BAD_REQUEST.as_u16()],
-    //         attempts: Some(3),
-    //         backoff: Some(Duration::from_secs(2)),
-    //     });
+        // first endpoint was the first attempt
+        assert!(endpoint.should_retry(HttpResult::StatusFailed));
+        assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
+        assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
 
-    //     // first endpoint was the first attempt
-    //     assert!(endpoint.should_retry(HttpResult::StatusFailed));
-    //     assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
-    //     assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::SERVICE_UNAVAILABLE)));
+        // add on ip to history - this is the second attempt
+        endpoint
+            .previous_addrs
+            .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
+        assert!(endpoint.should_retry(HttpResult::StatusFailed),);
+        assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)),);
 
-    //     // add on ip to history - this is the second attempt
-    //     endpoint
-    //         .previous_addrs
-    //         .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
-    //     assert!(endpoint.should_retry(HttpResult::StatusFailed),);
-    //     assert!(endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)),);
+        // two ips in history and one current ip, three attempts have been made, shouldn't retry again
+        endpoint
+            .previous_addrs
+            .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
+        assert!(!endpoint.should_retry(HttpResult::StatusFailed));
+        assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
+    }
 
-    //     // two ips in history and one current ip, three attempts have been made, shouldn't retry again
-    //     endpoint
-    //         .previous_addrs
-    //         .push(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443));
-    //     assert!(!endpoint.should_retry(HttpResult::StatusFailed));
-    //     assert!(!endpoint.should_retry(HttpResult::StatusError(StatusCode::BAD_REQUEST)));
-    // }
+    fn new_endpoint() -> Endpoint {
+        let url: Url = "http://example.com".parse().unwrap();
+        let cluster_name = ResourceName::from("example.com:443");
+        let address = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443);
 
-    // fn new_endpoint() -> Endpoint {
-    //     let url: Url = "http://example.com".parse().unwrap();
-    //     let backend = Service::dns(url.hostname()).unwrap().as_backend_id(443);
-    //     let address = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 443);
-
-    //     Endpoint {
-    //         method: http::Method::GET,
-    //         url,
-    //         headers: Default::default(),
-    //         backend,
-    //         address,
-    //         timeouts: None,
-    //         retry: None,
-    //         trace: Trace::new(),
-    //         previous_addrs: vec![],
-    //     }
-    // }
+        Endpoint {
+            method: http::Method::GET,
+            url,
+            headers: Default::default(),
+            cluster_name,
+            address,
+            request_hash: 1234,
+            timeouts: None,
+            retries: None,
+            trace: Trace::new(),
+            previous_addrs: vec![],
+        }
+    }
 }

--- a/crates/junction-core/src/xds/resources/route_configs.rs
+++ b/crates/junction-core/src/xds/resources/route_configs.rs
@@ -2,7 +2,7 @@ use super::{ErrorCtx, Resource, ResourceError, ResourceName, ResourceType};
 
 use junction_api::Hostname;
 use regex::Regex;
-use std::{collections::HashSet, str::FromStr};
+use std::{collections::HashSet, str::FromStr, time::Duration};
 use xds_api::pb::envoy::config::route::v3::{self as xds_route};
 
 macro_rules! vec_from_xds {
@@ -103,8 +103,8 @@ impl Route {
 #[derive(Debug, Clone)]
 pub(crate) struct Action {
     pub hash_policies: Vec<HashPolicy>,
-    pub retries: Retries,
-    pub timeouts: Timeouts,
+    pub retries: Option<Retries>,
+    pub timeouts: Option<Timeouts>,
     pub cluster: ClusterSpecifier,
 }
 
@@ -121,12 +121,14 @@ impl Action {
                     None => todo!(),
                 };
                 let hash_policies = vec_from_xds!(action.hash_policy, "hash_policy", HashPolicy)?;
+                let retries = Retries::from_xds(&action)?;
+                let timeouts = Timeouts::from_xds(&action)?;
 
                 Ok(Self {
                     hash_policies,
                     cluster,
-                    retries: Retries {},   // FIXME
-                    timeouts: Timeouts {}, // FIXME
+                    retries,
+                    timeouts,
                 })
             }
             _ => return Err(ResourceError::invalid("unsupported action")),
@@ -182,11 +184,90 @@ pub(crate) enum RequestHasher {
     QueryParameter { name: String },
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct Retries {}
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Retries {
+    pub(crate) codes: Vec<u16>,
+    pub(crate) attempts: Option<u32>,
+    pub(crate) backoff: Option<Duration>,
+    pub(crate) max_backoff: Option<Duration>,
+}
+
+impl Retries {
+    fn from_xds(xds: &xds_route::RouteAction) -> Result<Option<Self>, ResourceError> {
+        let Some(xds_retry) = xds.retry_policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let codes: Vec<_> = xds_retry
+            .retriable_status_codes
+            .iter()
+            .map(|code| *code as u16)
+            .collect();
+
+        let attempts = xds_retry.num_retries.map(|v| u32::from(v) + 1);
+        let (backoff, max_backoff) = match &xds_retry.retry_back_off {
+            Some(back_off) => {
+                let backoff = back_off
+                    .base_interval
+                    .map(Duration::try_from)
+                    .transpose()
+                    .map_err(|_| ResourceError::invalid("invalid duration"))
+                    .with_fields("retry_policy", "retry_back_off")?;
+
+                let max_backoff = back_off
+                    .max_interval
+                    .map(Duration::try_from)
+                    .transpose()
+                    .map_err(|_| ResourceError::invalid("invalid duration"))
+                    .with_fields("retry_policy", "max_interval")?;
+
+                (backoff, max_backoff)
+            }
+            None => (None, None),
+        };
+
+        let retries = match (&codes, attempts, backoff, max_backoff) {
+            (v, None, None, None) if v.is_empty() => None,
+            _ => Some(Self {
+                codes,
+                attempts,
+                backoff,
+                max_backoff,
+            }),
+        };
+        Ok(retries)
+    }
+}
 
 #[derive(Debug, Clone)]
-pub(crate) struct Timeouts {}
+pub(crate) struct Timeouts {
+    pub(crate) total: Option<Duration>,
+    pub(crate) attempt: Option<Duration>,
+}
+
+impl Timeouts {
+    fn from_xds(xds: &xds_route::RouteAction) -> Result<Option<Self>, ResourceError> {
+        let total = xds
+            .timeout
+            .map(Duration::try_from)
+            .transpose()
+            .map_err(|_| ResourceError::invalid("invalid duration"))
+            .with_field("timeout")?;
+
+        let attempt = xds
+            .retry_policy
+            .as_ref()
+            .and_then(|retry_policy| retry_policy.per_try_timeout.map(Duration::try_from))
+            .transpose()
+            .map_err(|_| ResourceError::invalid("invalid duration"))
+            .with_fields("retry_policy", "per_try_timeout")?;
+
+        match (total, attempt) {
+            (None, None) => Ok(None),
+            (total, attempt) => Ok(Some(Self { total, attempt })),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct Matcher {


### PR DESCRIPTION
Adds `Retry` and `Timeout` types to `junction-core` that mirror the XDS types. They're almost identical to our existing `junction-api` types, but we no longer have the dependency.

`junction_core` and `junction_core::xds::route_configs` have their own versions of these types so that going forward we can change the xDS representation without messing with our external API in the future.