### PR TITLE
[xds] junction-core: dns overhaul

### DIFF
--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -1,10 +1,9 @@
 use crate::{
-    dns,
+    dns::{self, StdlibResolver},
     xds::{self, AdsClient, ResourceType},
     Endpoint, Error, Trace,
 };
 use futures::{stream::FuturesOrdered, StreamExt};
-use junction_api::Hostname;
 use rand::{distributions::WeightedError, seq::SliceRandom};
 use serde::Deserialize;
 use std::{
@@ -124,6 +123,9 @@ pub struct Client {
 
     // the ADS client used to fetch xDS config from the control plane
     ads: AdsClient,
+
+    // the DNS resolver used to fetch DNS endpoints when appropriate
+    dns: StdlibResolver,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -136,11 +138,11 @@ pub struct SearchConfig {
 
     // the list of suffixes searched during hostname lookup. only consulted if the number of
     // dots in a url's hostname is less than `ndots`.
-    pub search: Vec<Hostname>,
+    pub search: Vec<String>,
 }
 
 impl SearchConfig {
-    pub fn new(ndots: u8, search: Vec<Hostname>) -> Self {
+    pub fn new(ndots: u8, search: Vec<String>) -> Self {
         Self { ndots, search }
     }
 }
@@ -164,7 +166,8 @@ impl Client {
         node_id: String,
         cluster: String,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let ads = AdsClient::build(address, node_id, cluster).await?;
+        let dns = StdlibResolver::new_with(Duration::from_secs(5), Duration::from_millis(500), 2);
+        let ads = AdsClient::build(dns.clone(), address, node_id, cluster).await?;
 
         // load search-path config from the system.
         //
@@ -182,6 +185,7 @@ impl Client {
             resolve_timeout: Duration::from_secs(5),
             search_config,
             ads,
+            dns,
         };
 
         Ok(client)
@@ -253,6 +257,7 @@ impl Client {
         // select endpoints using the result of route resolution
         let selected = select_endpoint(
             &self.ads,
+            &self.dns,
             resolved.trace,
             RequestContext {
                 request_hash: resolved.request_hash,
@@ -309,6 +314,7 @@ impl Client {
         let deadline = Instant::now() + self.resolve_timeout;
         let next = select_endpoint(
             &self.ads,
+            &self.dns,
             endpoint.trace,
             RequestContext {
                 request_hash: endpoint.request_hash,
@@ -558,6 +564,7 @@ struct RequestContext<'a> {
 
 async fn select_endpoint(
     cache: &impl XdsCache,
+    dns: &StdlibResolver,
     mut trace: Trace,
     request: RequestContext<'_>,
     cluster_name: &xds::ResourceName,
@@ -605,8 +612,25 @@ async fn select_endpoint(
             }
         }
         xds::clusters::Endpoints::LogicalDns { hostname, port } => {
-            // get a handle to the DNS resolver here and call into it
-            todo!("support LOGICAL_DNS clusters")
+            let load_assignment = with_deadline!(
+                dns.get_endpoints_await(hostname, *port),
+                deadline,
+                "dns resolution",
+                trace
+            );
+            match load_assignment {
+                Some(load_assignment) => {
+                    trace.lookup_endpoints(hostname.clone());
+                    load_assignment
+                }
+                None => {
+                    return Err(Error::not_found(
+                        "dns".to_string(),
+                        hostname.to_string(),
+                        trace,
+                    ));
+                }
+            }
         }
     };
     let Some(endpoints) = load_assignment.endpoints.first() else {
@@ -815,7 +839,6 @@ fn search<'a>(search_config: &SearchConfig, url: &'a crate::Url) -> Vec<Cow<'a, 
 #[cfg(test)]
 mod test {
     use crate::Url;
-    use junction_api::Hostname;
     use std::str::FromStr;
 
     use pretty_assertions::assert_eq;
@@ -834,11 +857,10 @@ mod test {
     #[test]
     fn test_search() {
         let url = Url::from_str("https://tasty.potato.tomato:9876").unwrap();
-        let search_setup: Vec<Hostname> = vec![
-            Hostname::from_static("foo.bar.baz"),
-            Hostname::from_static("bar.baz"),
-            Hostname::from_static("baz"),
-        ];
+        let search_setup: Vec<_> = ["foo.bar.baz", "bar.baz", "baz"]
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
 
         // with ndots < dots, should just return the original url
         assert_eq!(

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -122,7 +122,8 @@ pub struct Client {
     // expanding the search over the set of possible authority matches.
     search_config: SearchConfig,
 
-    config: Arc<DynamicConfig>,
+    // the ADS client used to fetch xDS config from the control plane
+    ads: AdsClient,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -144,17 +145,6 @@ impl SearchConfig {
     }
 }
 
-struct DynamicConfig {
-    ads: AdsClient,
-
-    /// a the shared handle to the task that's actually running the client in
-    /// the background. should not drop until every active client drops.
-    ///
-    /// TODO: should this get bundled into AdsClient? shrug emoji?
-    #[allow(unused)]
-    task_handle: tokio::task::JoinHandle<()>,
-}
-
 // FIXME: Vec<Endpoints> is probably the wrong thing to return from all our
 // resolve methods. We probably need a struct that has something like a list
 // of primary endpoints to cycle through on retries, and a separate list of
@@ -174,22 +164,7 @@ impl Client {
         node_id: String,
         cluster: String,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let (ads, mut ads_task) = AdsClient::build(address, node_id, cluster).unwrap();
-
-        // try to start the ADS connection while blocking. if it fails, fail
-        // fast here instead of letting the client start.
-        //
-        // once it's started, hand off the task to the executor in the
-        // background.
-        ads_task.connect().await?;
-        let handle = tokio::spawn(async move {
-            match ads_task.run().await {
-                Ok(()) => (),
-                Err(e) => panic!(
-                    "junction-core: ads client exited with an unexpected error: {e}. this is a bug in Junction!"
-                ),
-            }
-        });
+        let ads = AdsClient::build(address, node_id, cluster).await?;
 
         // load search-path config from the system.
         //
@@ -203,14 +178,10 @@ impl Client {
         };
 
         // wrap it all up in a dynamic config and return
-        let config = Arc::new(DynamicConfig {
-            ads,
-            task_handle: handle,
-        });
         let client = Self {
             resolve_timeout: Duration::from_secs(5),
             search_config,
-            config,
+            ads,
         };
 
         Ok(client)
@@ -271,7 +242,7 @@ impl Client {
         let request = HttpRequest::from_parts(method, url, headers);
 
         let resolved = resolve_route(
-            &self.config.ads,
+            &self.ads,
             &self.search_config,
             Trace::new(),
             request.clone(),
@@ -281,7 +252,7 @@ impl Client {
 
         // select endpoints using the result of route resolution
         let selected = select_endpoint(
-            &self.config.ads,
+            &self.ads,
             resolved.trace,
             RequestContext {
                 request_hash: resolved.request_hash,
@@ -337,7 +308,7 @@ impl Client {
         // not necessarily pick the same endpoint.
         let deadline = Instant::now() + self.resolve_timeout;
         let next = select_endpoint(
-            &self.config.ads,
+            &self.ads,
             endpoint.trace,
             RequestContext {
                 request_hash: endpoint.request_hash,
@@ -397,7 +368,7 @@ impl Client {
     ///
     /// For static clients, this does nothing.
     pub async fn csds_server(self, port: u16) -> Result<(), tonic::transport::Error> {
-        self.config.ads.csds_server(port).await
+        self.ads.csds_server(port).await
     }
 
     /// Dump the client's current cache of xDS resources, as fetched from the
@@ -406,17 +377,14 @@ impl Client {
     /// This is a programmatic view of the same data that you can fetch over
     /// gRPC by starting a [Client::csds_server].
     pub fn dump_xds(&self) -> impl Iterator<Item = crate::XdsConfig> + '_ {
-        self.config.ads.iter_xds()
+        self.ads.iter_xds()
     }
 
     /// Dump xDS resources that failed to update. This is a view of the data
     /// returned by [Client::dump_xds] that only contains resources with
     /// errors.
     pub fn dump_xds_errors(&self) -> impl Iterator<Item = crate::XdsConfig> + '_ {
-        self.config
-            .ads
-            .iter_xds()
-            .filter(|x| x.last_error.is_some())
+        self.ads.iter_xds().filter(|x| x.last_error.is_some())
     }
 }
 

--- a/crates/junction-core/src/dns.rs
+++ b/crates/junction-core/src/dns.rs
@@ -23,11 +23,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use junction_api::Hostname;
 use rand::Rng;
 use tokio::sync::Notify;
 
-use crate::xds::endpoints::EndpointGroup;
+use crate::xds::{endpoints::EndpointGroup, LoadAssignment};
 
 /// An error that occurred while parsing a system DNS configuration.
 #[derive(Debug, thiserror::Error)]
@@ -50,7 +49,7 @@ pub(crate) enum ConfigError {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct SystemConfig {
     pub(crate) ndots: u8,
-    pub(crate) search: Vec<Hostname>,
+    pub(crate) search: Vec<String>,
 }
 
 /// Load a [SystemConfig] from the given path. You probaly want to read
@@ -107,8 +106,10 @@ fn parse_resolv_conf(path: impl AsRef<Path>, content: &[u8]) -> Result<SystemCon
                 }
             }
             [b"search", hostnames @ ..] => {
-                let hostnames: Result<Vec<_>, _> =
-                    hostnames.iter().map(|bs| Hostname::try_from(*bs)).collect();
+                let hostnames: Result<Vec<_>, _> = hostnames
+                    .iter()
+                    .map(|bs| String::from_utf8(bs.to_vec()))
+                    .collect();
 
                 match hostnames {
                     Ok(hostnames) => search = hostnames,
@@ -134,6 +135,54 @@ fn parse_as_str<T: std::str::FromStr>(bs: &[u8]) -> Result<T, ()> {
     let as_str = std::str::from_utf8(bs).map_err(|_| ())?;
     as_str.parse().map_err(|_| ())
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DnsAddr {
+    pub(crate) hostname: String,
+    pub(crate) port: u16,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct DnsUpdates {
+    pub(crate) add: BTreeSet<DnsAddr>,
+    pub(crate) remove: BTreeSet<DnsAddr>,
+    pub(crate) sync: bool,
+}
+
+#[cfg(test)]
+impl DnsUpdates {
+    pub(crate) fn is_noop(&self) -> bool {
+        self.add.is_empty() && self.remove.is_empty() && !self.sync
+    }
+}
+
+#[cfg(test)]
+macro_rules! dns_updates {
+    (add = [$(($add_h:literal, $add_p:literal)),* $(,)?], remove = [$(($remove_h:literal, $remove_p:literal)),* $(,)?] $(,)?) => {
+        crate::dns::DnsUpdates {
+            add: std::collections::BTreeSet::from_iter([
+                $(
+                    crate::dns::DnsAddr {
+                        hostname: $add_h.to_string(),
+                        port: $add_p,
+                    }
+                ),*
+            ]),
+            remove: std::collections::BTreeSet::from_iter([
+                $(
+                    crate::dns::DnsAddr {
+                        hostname: $remove_h.to_string(),
+                        port: $remove_p,
+                    }
+                ),*
+            ]),
+            ..Default::default()
+        }
+    };
+}
+
+#[cfg(test)]
+pub(crate) use dns_updates;
 
 /// A blocking resolver that uses the stdlib to resolve hostnames to addresses.
 ///
@@ -216,20 +265,16 @@ impl StdlibResolver {
         resolver
     }
 
-    pub(crate) fn get_endpoints(
-        &self,
-        hostname: &Hostname,
-        port: u16,
-    ) -> Option<Arc<EndpointGroup>> {
+    pub(crate) fn get_endpoints(&self, hostname: &str, port: u16) -> Option<Arc<LoadAssignment>> {
         let tasks = no_poison!(self.inner.tasks.lock());
         tasks.get_endpoints(hostname, port)
     }
 
     pub(crate) async fn get_endpoints_await(
         &self,
-        hostname: &Hostname,
+        hostname: &str,
         port: u16,
-    ) -> Option<Arc<EndpointGroup>> {
+    ) -> Option<Arc<LoadAssignment>> {
         // fast path: the endpoints are in the map.
         if let Some(endpoints) = self.get_endpoints(hostname, port) {
             return Some(endpoints);
@@ -270,29 +315,38 @@ impl StdlibResolver {
         }
     }
 
-    pub(crate) fn subscribe(&self, name: Hostname, port: u16) {
+    pub(crate) fn subscribe(&self, addr: DnsAddr) {
         let mut tasks = no_poison!(self.inner.tasks.lock());
 
         // on a new subscribtion, notify both the background workers and any
         // async tasks waiting on a get.
-        if tasks.pin(name, port) {
+        if tasks.add_name(addr.hostname, addr.port) {
             self.inner.cond.notify_all();
             self.inner.async_notify.notify_waiters();
         }
     }
 
-    pub(crate) fn unsubscribe(&self, name: &Hostname, port: u16) {
+    pub(crate) fn unsubscribe(&self, addr: DnsAddr) {
         let mut tasks = no_poison!(self.inner.tasks.lock());
-        tasks.remove(name, port);
+        tasks.remove_name(&addr.hostname, addr.port);
         self.inner.cond.notify_all();
     }
 
-    pub(crate) fn set_names(&self, new_names: impl IntoIterator<Item = (Hostname, u16)>) {
+    pub(crate) fn set_names(&self, new_names: impl IntoIterator<Item = DnsAddr>) {
         let new_names = new_names.into_iter();
 
         let mut tasks = no_poison!(self.inner.tasks.lock());
-        if tasks.update_all(new_names) {
+        if tasks.set_names(new_names) {
             self.inner.cond.notify_all();
+        }
+    }
+
+    pub(crate) fn update_names(&self, updates: DnsUpdates) {
+        for addr in updates.add {
+            self.subscribe(addr);
+        }
+        for addr in updates.remove {
+            self.unsubscribe(addr);
         }
     }
 
@@ -342,7 +396,7 @@ impl StdlibResolver {
         Arc::strong_count(&self.inner) <= self.inner.worker_count
     }
 
-    fn next_name(&self) -> Option<Hostname> {
+    fn next_name(&self) -> Option<String> {
         let mut tasks = no_poison!(self.inner.tasks.lock());
 
         loop {
@@ -353,7 +407,7 @@ impl StdlibResolver {
             // claim a name older than the cutoff
             let before = Instant::now() - self.inner.lookup_interval;
             if let Some(name) = tasks.next_name(before) {
-                return Some(name.clone());
+                return Some(name.to_string());
             }
 
             // if there's nothing to do, sleep until there is. add a little
@@ -378,7 +432,7 @@ impl StdlibResolver {
 
     fn insert_answer(
         &self,
-        name: Hostname,
+        name: String,
         resolved_at: Instant,
         answer: io::Result<Vec<SocketAddr>>,
     ) {
@@ -403,7 +457,7 @@ fn rng_jitter(max: Duration) -> Duration {
 }
 
 #[derive(Debug, Default)]
-struct ResolverState(BTreeMap<Hostname, NameInfo>);
+struct ResolverState(BTreeMap<String, NameInfo>);
 
 #[derive(Debug, Default)]
 struct NameInfo {
@@ -416,8 +470,7 @@ struct NameInfo {
 
 #[derive(Debug, Default)]
 struct PortInfo {
-    pinned: bool,
-    endpoint_group: Option<Arc<EndpointGroup>>,
+    load_assignment: Option<Arc<LoadAssignment>>,
 }
 
 impl PortInfo {
@@ -426,7 +479,9 @@ impl PortInfo {
             addr.set_port(port);
             addr
         });
-        self.endpoint_group = Some(Arc::new(EndpointGroup::from_dns_addrs(addrs)))
+        self.load_assignment = Some(Arc::new(LoadAssignment {
+            endpoints: vec![EndpointGroup::from_dns_addrs(addrs)],
+        }));
     }
 }
 
@@ -465,92 +520,7 @@ impl NameInfo {
 }
 
 impl ResolverState {
-    fn next_name(&mut self, before: Instant) -> Option<&Hostname> {
-        let mut min: Option<(_, &mut NameInfo)> = None;
-
-        for (name, state) in &mut self.0 {
-            if state.in_flight {
-                continue;
-            }
-
-            match state.resolved_at {
-                Some(t) => {
-                    if t <= before && min.as_ref().map_or(true, |(_, s)| s.resolved_before(t)) {
-                        min = Some((name, state))
-                    }
-                }
-                None => {
-                    state.in_flight = true;
-                    return Some(name);
-                }
-            }
-        }
-
-        min.map(|(name, state)| {
-            state.in_flight = true;
-            name
-        })
-    }
-
-    fn min_resolved_at(&self) -> Option<Instant> {
-        self.0.values().filter_map(|state| state.resolved_at).min()
-    }
-
-    fn get_endpoints(&self, hostname: &Hostname, port: u16) -> Option<Arc<EndpointGroup>> {
-        let name_info = self.0.get(hostname)?;
-        let port_info = name_info.ports.get(&port)?;
-        port_info.endpoint_group.clone()
-    }
-
-    fn insert_answer(
-        &mut self,
-        hostname: &Hostname,
-        resolved_at: Instant,
-        answer: io::Result<Vec<SocketAddr>>,
-    ) {
-        // only update if there's still state for this name.
-        //
-        // if there's no state for this name it's because the set of target
-        // names changed and we're not interested anymore.
-        if let Some(state) = self.0.get_mut(hostname) {
-            state.in_flight = false;
-            state.merge_answer(resolved_at, answer);
-        }
-    }
-
-    fn pin(&mut self, hostname: Hostname, port: u16) -> bool {
-        let (mut created, name_info) = match self.0.entry(hostname) {
-            btree_map::Entry::Vacant(entry) => (true, entry.insert(Default::default())),
-            btree_map::Entry::Occupied(entry) => (false, entry.into_mut()),
-        };
-
-        let (port_created, port_info) = match name_info.ports.entry(port) {
-            btree_map::Entry::Vacant(entry) => (true, entry.insert(Default::default())),
-            btree_map::Entry::Occupied(entry) => (false, entry.into_mut()),
-        };
-        created |= port_created;
-        port_info.pinned = true;
-
-        if let Some(addrs) = &name_info.last_addrs {
-            port_info.set_addrs(port, addrs);
-        }
-
-        created
-    }
-
-    fn remove(&mut self, hostname: &Hostname, port: u16) {
-        let mut remove = false;
-        if let Some(entry) = self.0.get_mut(hostname) {
-            entry.ports.remove(&port);
-            remove = entry.ports.is_empty();
-        };
-
-        if remove {
-            self.0.remove(hostname);
-        }
-    }
-
-    fn update_all(&mut self, new_names: impl IntoIterator<Item = (Hostname, u16)>) -> bool {
+    fn set_names(&mut self, new_names: impl IntoIterator<Item = DnsAddr>) -> bool {
         // build an index of name -> [port] for the union of all names in the
         // new set of names and the old set of names.
         //
@@ -561,23 +531,20 @@ impl ResolverState {
         for name in self.0.keys() {
             names.insert(name.clone(), Vec::new());
         }
-        for (name, port) in new_names {
-            names.entry(name).or_default().push(port);
+        for DnsAddr { hostname, port } in new_names {
+            names.entry(hostname).or_default().push(port);
         }
 
         // iterate through the names index, for every set of ports, modify the
         // name info so it only contains the listed ports or any existing pinned
-        // ports. the APIs for removing an entry we've already creatd here are not
+        // ports. the APIs for removing an entry we've already created here are not
         // good, so don't actually do removal in this step.
         let mut changed = false;
         for (name, new_ports) in &names {
             let name_info = self.0.entry(name.clone()).or_default();
 
             let mut to_remove = BTreeSet::new();
-            for (port, port_info) in &name_info.ports {
-                if port_info.pinned {
-                    continue;
-                }
+            for port in name_info.ports.keys() {
                 to_remove.insert(*port);
             }
 
@@ -601,6 +568,90 @@ impl ResolverState {
         changed
     }
 
+    fn add_name(&mut self, hostname: String, port: u16) -> bool {
+        let (mut created, name_info) = match self.0.entry(hostname) {
+            btree_map::Entry::Vacant(entry) => (true, entry.insert(Default::default())),
+            btree_map::Entry::Occupied(entry) => (false, entry.into_mut()),
+        };
+
+        let (port_created, port_info) = match name_info.ports.entry(port) {
+            btree_map::Entry::Vacant(entry) => (true, entry.insert(Default::default())),
+            btree_map::Entry::Occupied(entry) => (false, entry.into_mut()),
+        };
+        created |= port_created;
+
+        if let Some(addrs) = &name_info.last_addrs {
+            port_info.set_addrs(port, addrs);
+        }
+
+        created
+    }
+
+    fn remove_name(&mut self, hostname: &str, port: u16) {
+        let mut remove = false;
+        if let Some(entry) = self.0.get_mut(hostname) {
+            entry.ports.remove(&port);
+            remove = entry.ports.is_empty();
+        };
+
+        if remove {
+            self.0.remove(hostname);
+        }
+    }
+
+    fn next_name(&mut self, before: Instant) -> Option<&str> {
+        let mut min: Option<(_, &mut NameInfo)> = None;
+
+        for (name, state) in &mut self.0 {
+            if state.in_flight {
+                continue;
+            }
+
+            match state.resolved_at {
+                Some(t) => {
+                    if t <= before && min.as_ref().map_or(true, |(_, s)| s.resolved_before(t)) {
+                        min = Some((name, state))
+                    }
+                }
+                None => {
+                    state.in_flight = true;
+                    return Some(name);
+                }
+            }
+        }
+
+        min.map(|(name, state)| {
+            state.in_flight = true;
+            &name[..]
+        })
+    }
+
+    fn min_resolved_at(&self) -> Option<Instant> {
+        self.0.values().filter_map(|state| state.resolved_at).min()
+    }
+
+    fn get_endpoints(&self, hostname: &str, port: u16) -> Option<Arc<LoadAssignment>> {
+        let name_info = self.0.get(hostname)?;
+        let port_info = name_info.ports.get(&port)?;
+        port_info.load_assignment.clone()
+    }
+
+    fn insert_answer(
+        &mut self,
+        hostname: &str,
+        resolved_at: Instant,
+        answer: io::Result<Vec<SocketAddr>>,
+    ) {
+        // only update if there's still state for this name.
+        //
+        // if there's no state for this name it's because the set of target
+        // names changed and we're not interested anymore.
+        if let Some(state) = self.0.get_mut(hostname) {
+            state.in_flight = false;
+            state.merge_answer(resolved_at, answer);
+        }
+    }
+
     #[cfg(test)]
     fn names_and_ports(&self) -> Vec<(&str, Vec<u16>)> {
         self.0
@@ -621,7 +672,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_resolv_conf_macos() {
+    fn resolv_conf_macos() {
         let macos_resolv = b"
 #
 # macOS Notice
@@ -644,14 +695,14 @@ nameserver 123.456.789.123
         assert_eq!(
             SystemConfig {
                 ndots: 1,
-                search: vec![Hostname::from_static("localdomain")],
+                search: vec!["localdomain".to_string()],
             },
             parse_resolv_conf("/kube/etc/resolv.conf", macos_resolv).unwrap()
         );
     }
 
     #[test]
-    fn test_resolv_conf_kube() {
+    fn resolv_conf_kube() {
         let kube_resolv = b"
 nameserver 192.168.194.138
 ; another comment
@@ -670,7 +721,7 @@ options extra:hello ndots:5 not-valid
                     "cluster.local",
                 ]
                 .into_iter()
-                .map(Hostname::from_static)
+                .map(|s| s.to_string())
                 .collect()
             },
             parse_resolv_conf("/kube/etc/resolv.conf", kube_resolv).unwrap()
@@ -678,16 +729,33 @@ options extra:hello ndots:5 not-valid
     }
 
     #[test]
-    fn test_resolv_conf_invalid_search() {
-        let conf = b"
+    fn resolv_conf_invalid_hostname() {
+        // none of the DNS clients we can find do real hostname
+        // validation before making a query. systemd-resolvd is
+        // happy to set invalid characaters in a name, cares and
+        // GRPC don't do any ahead-of-time validation, etc.
+        let weird_conf = b"
 search default.svc$$$cluster.local svc.cluster.local cluster.local
 options ndots:5";
-        let err = parse_resolv_conf("bad", conf).unwrap_err();
-        assert!(matches!(err, ConfigError::Invalid { line: 1, .. }));
+
+        assert_eq!(
+            SystemConfig {
+                ndots: 5,
+                search: [
+                    "default.svc$$$cluster.local",
+                    "svc.cluster.local",
+                    "cluster.local",
+                ]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect()
+            },
+            parse_resolv_conf("/kube/etc/resolv.conf", weird_conf).unwrap()
+        );
     }
 
     #[test]
-    fn test_resolv_conf_invalid_ndots() {
+    fn resolv_conf_invalid_ndots() {
         let conf = b"
 search default.svc.cluster.local svc.cluster.local cluster.local
 options ndots:1 ndots:a-potato ndots:3";
@@ -696,64 +764,65 @@ options ndots:1 ndots:a-potato ndots:3";
     }
 
     #[inline]
-    fn update_all(
+    fn set_names(
         resolver: &mut ResolverState,
         names: impl IntoIterator<Item = (&'static str, u16)>,
     ) {
-        resolver.update_all(
-            names
-                .into_iter()
-                .map(|(name, port)| (Hostname::from_static(name), port)),
-        );
+        resolver.set_names(names.into_iter().map(|(name, port)| DnsAddr {
+            hostname: name.to_string(),
+            port,
+        }));
     }
 
     #[test]
-    fn test_answers() {
+    fn insert_answers_multiple_ports() {
         let mut resolver = ResolverState::default();
 
-        update_all(
+        set_names(
             &mut resolver,
             [("www.junctionlabs.io", 80), ("www.junctionlabs.io", 443)],
         );
 
         resolver.insert_answer(
-            &Hostname::from_static("www.junctionlabs.io"),
+            "www.junctionlabs.io",
             Instant::now(),
             // the port here shouldn't matter
             Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234)]),
         );
 
         assert_eq!(
-            resolver
-                .get_endpoints(&Hostname::from_static("www.junctionlabs.io"), 80)
-                .as_deref(),
-            Some(&EndpointGroup::from_dns_addrs(vec![SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
-                80,
-            )])),
+            resolver.get_endpoints("www.junctionlabs.io", 80).as_deref(),
+            Some(&LoadAssignment {
+                endpoints: vec![EndpointGroup::from_dns_addrs(vec![SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::LOCALHOST),
+                    80,
+                )])],
+            })
         );
         assert_eq!(
             resolver
-                .get_endpoints(&Hostname::from_static("www.junctionlabs.io"), 443)
+                .get_endpoints("www.junctionlabs.io", 443)
                 .as_deref(),
-            Some(&EndpointGroup::from_dns_addrs(vec![SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
-                443,
-            )])),
+            Some(&LoadAssignment {
+                endpoints: vec![EndpointGroup::from_dns_addrs(vec![SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::LOCALHOST),
+                    443,
+                )])]
+            }),
         );
         assert_eq!(
             resolver
-                .get_endpoints(&Hostname::from_static("www.junctionlabs.io"), 1234)
+                .get_endpoints("www.junctionlabs.io", 1234)
                 .as_deref(),
             None,
         );
     }
 
     #[test]
-    fn test_resolver_tasks_next() {
+    fn resolver_tasks_next() {
         let mut resolver = ResolverState::default();
 
-        update_all(
+        set_names(
             &mut resolver,
             [
                 ("doesnotexistihopereallybad.com", 80),
@@ -779,7 +848,7 @@ options ndots:1 ndots:a-potato ndots:3";
 
         // resolve one name.
         resolver.insert_answer(
-            &Hostname::from_static("www.junctionlabs.io"),
+            "www.junctionlabs.io",
             now,
             Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80)]),
         );
@@ -799,74 +868,35 @@ options ndots:1 ndots:a-potato ndots:3";
     }
 
     #[test]
-    fn test_pinned_name() {
+    fn add_name_new_port() {
         let mut resolver = ResolverState::default();
 
-        resolver.pin(Hostname::from_static("important.com"), 1234);
-
-        update_all(&mut resolver, [("www.example.com", 80)]);
-        assert_eq!(
-            resolver.names_and_ports(),
-            &[("important.com", vec![1234]), ("www.example.com", vec![80]),]
-        );
-
-        update_all(&mut resolver, [("www.newthing.com", 80)]);
-        assert_eq!(
-            resolver.names_and_ports(),
-            &[
-                ("important.com", vec![1234]),
-                ("www.newthing.com", vec![80]),
-            ]
-        );
-
-        update_all(&mut resolver, [("www.newthing.com", 443)]);
-        assert_eq!(
-            resolver.names_and_ports(),
-            &[
-                ("important.com", vec![1234]),
-                ("www.newthing.com", vec![443]),
-            ]
-        );
-
-        resolver.remove(&Hostname::from_static("important.com"), 1234);
-        update_all(&mut resolver, [("www.newthing.com", 443)]);
-        assert_eq!(
-            resolver.names_and_ports(),
-            &[("www.newthing.com", vec![443]),]
-        );
-    }
-
-    #[test]
-    fn test_pin_new_port() {
-        let mut resolver = ResolverState::default();
-
-        update_all(
+        set_names(
             &mut resolver,
             [("www.junctionlabs.io", 80), ("www.junctionlabs.io", 443)],
         );
 
         resolver.insert_answer(
-            &Hostname::from_static("www.junctionlabs.io"),
+            "www.junctionlabs.io",
             Instant::now(),
             // the port here shouldn't matter
             Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234)]),
         );
 
         assert!(
-            !resolver.pin(Hostname::from_static("www.junctionlabs.io"), 443),
+            !resolver.add_name("www.junctionlabs.io".to_string(), 443),
             "should not return true when the same port is inserted"
         );
         assert!(
-            resolver.pin(Hostname::from_static("www.junctionlabs.io"), 7777),
+            resolver.add_name("www.junctionlabs.io".to_string(), 7777),
             "should return true when a new port is inserted"
         );
 
-        let endpoints: Vec<_> = resolver
-            .get_endpoints(&Hostname::from_static("www.junctionlabs.io"), 7777)
-            .unwrap()
-            .iter()
-            .cloned()
-            .collect();
+        let load_assigment = resolver
+            .get_endpoints(&"www.junctionlabs.io", 7777)
+            .unwrap();
+        let endpoints = load_assigment.endpoints.first().unwrap();
+        let endpoints: Vec<_> = endpoints.iter().cloned().collect();
         assert_eq!(
             endpoints,
             vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7777,)]
@@ -874,10 +904,10 @@ options ndots:1 ndots:a-potato ndots:3";
     }
 
     #[test]
-    fn test_reset_drops_inflight() {
+    fn reset_drops_inflight() {
         let mut resolver = ResolverState::default();
 
-        update_all(&mut resolver, [("www.example.com", 8910)]);
+        set_names(&mut resolver, [("www.example.com", 8910)]);
 
         let now = Instant::now();
 
@@ -885,13 +915,13 @@ options ndots:1 ndots:a-potato ndots:3";
         assert!(resolver.next_name(now).is_some());
 
         // reset while the name is in-flight. should have one more name to take.
-        update_all(&mut resolver, [("www.junctionlabs.io", 8910)]);
+        set_names(&mut resolver, [("www.junctionlabs.io", 8910)]);
         assert!(resolver.next_name(now).is_some());
         assert!(resolver.next_name(now).is_none());
 
         // inserting the old answer shouldn't do anything
         resolver.insert_answer(
-            &Hostname::from_static("www.example.com"),
+            &"www.example.com",
             now,
             Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80)]),
         );

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -102,6 +102,10 @@ pub(super) struct AdsClient {
     subs: mpsc::Sender<SubscriptionUpdate>,
     cache: CacheReader,
     dns: StdlibResolver,
+
+    // a handle to the currently running task.
+    #[allow(unused)]
+    task_handle: Arc<tokio::task::JoinHandle<()>>,
 }
 
 impl AdsClient {
@@ -114,11 +118,11 @@ impl AdsClient {
     /// This method doesn't start the background work necessary to communicate with
     /// an ADS server. To do that, call the [run][AdsTask::run] method on the returned
     /// `AdsTask`.
-    pub(super) fn build(
+    pub(super) async fn build(
         address: impl Into<Bytes>,
         node_id: String,
         cluster: String,
-    ) -> Result<(AdsClient, AdsTask), tonic::transport::Error> {
+    ) -> Result<AdsClient, tonic::transport::Error> {
         // FIXME: make this configurable
         let endpoint = Endpoint::from_shared(address)?
             .connect_timeout(Duration::from_secs(5))
@@ -140,22 +144,40 @@ impl AdsClient {
 
         // FIXME: make this configurable
         let dns = StdlibResolver::new_with(Duration::from_secs(5), Duration::from_millis(500), 2);
+        let cache_reader = cache.reader();
 
-        let client = AdsClient {
-            subs: sub_tx,
-            cache: cache.reader(),
-            dns: dns.clone(),
-        };
-        let task = AdsTask {
+        // try to start the ADS connection while blocking. if it fails, fail
+        // fast here instead of letting the client start.
+        //
+        // once it's started, hand off the task to the executor in the
+        // background.
+        let mut task = AdsTask {
             endpoint,
             initial_channel: None,
             node_info,
             cache,
-            dns,
+            dns: dns.clone(),
             subs: sub_rx,
         };
+        task.connect().await?;
+        let task_handle = tokio::spawn({
+            async move {
+                match task.run().await {
+                    Ok(()) => (),
+                    Err(e) => panic!(
+                        "junction-core: ads client exited with an unexpected error: {e}. this is a bug in Junction!"
+                    ),
+                }
+            }
+        });
 
-        Ok((client, task))
+        // bundle up the client and return it
+        Ok(AdsClient {
+            subs: sub_tx,
+            cache: cache_reader,
+            dns,
+            task_handle: Arc::new(task_handle),
+        })
     }
 
     pub(super) fn csds_server(

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -33,11 +33,8 @@ use bytes::Bytes;
 use cache::{Cache, CacheReader};
 use enum_map::EnumMap;
 use futures::{FutureExt, TryStreamExt};
-use junction_api::Hostname;
 pub(crate) use resources::ResourceName;
-use std::{
-    borrow::Cow, collections::BTreeSet, future::Future, io::ErrorKind, sync::Arc, time::Duration,
-};
+use std::{borrow::Cow, future::Future, io::ErrorKind, sync::Arc, time::Duration};
 use tokio::sync::mpsc::{self, Receiver};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Endpoint, Streaming};
@@ -63,7 +60,10 @@ pub(crate) use resources::{
     ResourceType, RouteConfiguration,
 };
 
-use crate::{client::XdsCache, dns::StdlibResolver};
+use crate::{
+    client::XdsCache,
+    dns::{DnsUpdates, StdlibResolver},
+};
 
 mod csds;
 
@@ -101,7 +101,6 @@ enum SubscriptionUpdate {
 pub(super) struct AdsClient {
     subs: mpsc::Sender<SubscriptionUpdate>,
     cache: CacheReader,
-    dns: StdlibResolver,
 
     // a handle to the currently running task.
     #[allow(unused)]
@@ -119,6 +118,7 @@ impl AdsClient {
     /// an ADS server. To do that, call the [run][AdsTask::run] method on the returned
     /// `AdsTask`.
     pub(super) async fn build(
+        dns: StdlibResolver,
         address: impl Into<Bytes>,
         node_id: String,
         cluster: String,
@@ -143,7 +143,6 @@ impl AdsClient {
         let cache = Cache::default();
 
         // FIXME: make this configurable
-        let dns = StdlibResolver::new_with(Duration::from_secs(5), Duration::from_millis(500), 2);
         let cache_reader = cache.reader();
 
         // try to start the ADS connection while blocking. if it fails, fail
@@ -156,7 +155,7 @@ impl AdsClient {
             initial_channel: None,
             node_info,
             cache,
-            dns: dns.clone(),
+            dns,
             subs: sub_rx,
         };
         task.connect().await?;
@@ -175,7 +174,6 @@ impl AdsClient {
         Ok(AdsClient {
             subs: sub_tx,
             cache: cache_reader,
-            dns,
             task_handle: Arc::new(task_handle),
         })
     }
@@ -345,7 +343,7 @@ impl AdsTask {
         // set DNS names
         //
         // FIXME: lol, lmao, etc
-        let dns_names = self.cache.dns_names().map(|h| (h, 80));
+        let dns_names = self.cache.dns_names();
         self.dns.set_names(dns_names);
 
         // set up the xDS connection and start sending messages
@@ -373,7 +371,7 @@ impl AdsTask {
                     return Err(ConnectionError::AdsDisconnected);
                 }
             }
-            update_dns(&self.dns, dns_updates.add, dns_updates.remove);
+            self.dns.update_names(dns_updates);
         }
     }
 
@@ -474,18 +472,6 @@ async fn handle_update_batch(
     }
 
     Ok(false)
-}
-
-#[inline]
-fn update_dns(dns: &StdlibResolver, add: BTreeSet<Hostname>, remove: BTreeSet<Hostname>) {
-    for name in add {
-        // FIXME: lol, lmao, etc
-        dns.subscribe(name, 80);
-    }
-    for name in remove {
-        // FIXME: lol, lmao, etc
-        dns.unsubscribe(&name, 80);
-    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -686,26 +672,14 @@ impl<'a> AdsConnection<'a> {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-struct DnsUpdates {
-    add: BTreeSet<Hostname>,
-    remove: BTreeSet<Hostname>,
-    sync: bool,
-}
-
-#[cfg(test)]
-impl DnsUpdates {
-    fn is_noop(&self) -> bool {
-        self.add.is_empty() && self.remove.is_empty() && !self.sync
-    }
-}
-
 #[cfg(test)]
 mod test_ads_conn {
     use cache::Cache;
     use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
     use xds_api::pb::envoy::service::discovery::v3 as xds_discovery;
+
+    use crate::dns::dns_updates;
 
     use super::test as xds_test;
     use super::*;
@@ -1339,9 +1313,9 @@ mod test_ads_conn {
         // dns changes, we got a dns cluster
         assert_eq!(
             dns,
-            DnsUpdates {
-                add: BTreeSet::from_iter([Hostname::from_static("cooler.example.org")]),
-                ..Default::default()
+            dns_updates! {
+                add = [("cooler.example.org", 2345)],
+                remove = [],
             }
         );
         // should generate ACKs

--- a/crates/junction-core/src/xds/cache.rs
+++ b/crates/junction-core/src/xds/cache.rs
@@ -88,7 +88,6 @@ use std::{
 
 use dashmap::DashMap;
 use enum_map::EnumMap;
-use junction_api::Hostname;
 use petgraph::{
     graph::{DiGraph, NodeIndex},
     visit::{EdgeRef, Visitable},
@@ -97,6 +96,8 @@ use petgraph::{
 use tokio::sync::Notify;
 use xds_api::pb::envoy::service::discovery::v3 as xds_discovery;
 use xds_api::pb::google::protobuf;
+
+use crate::dns::DnsAddr;
 
 use super::{
     resources::{
@@ -502,17 +503,17 @@ impl Subscriptions {
 /// `collect` is called.
 #[derive(Clone, Debug, Default)]
 struct DnsNames {
-    names: HashMap<Hostname, usize>,
+    names: HashMap<DnsAddr, usize>,
     changes: DnsUpdates,
 }
 
 impl DnsNames {
     /// Add a name to the set.
     /// present.
-    fn add_name(&mut self, name: Hostname) {
+    fn add_name(&mut self, addr: DnsAddr) {
         use std::collections::hash_map::Entry;
 
-        match self.names.entry(name) {
+        match self.names.entry(addr) {
             Entry::Occupied(mut entry) => {
                 *entry.get_mut() += 1;
             }
@@ -529,15 +530,15 @@ impl DnsNames {
     }
 
     /// Remove a name from the tracked set.
-    fn remove_name(&mut self, name: &Hostname) {
-        let Some(val) = self.names.get_mut(name) else {
+    fn remove_name(&mut self, addr: DnsAddr) {
+        let Some(val) = self.names.get_mut(&addr) else {
             return;
         };
 
         if *val == 1 {
-            self.names.remove(name);
-            self.changes.add.remove(name);
-            self.changes.remove.insert(name.clone());
+            self.names.remove(&addr);
+            self.changes.add.remove(&addr);
+            self.changes.remove.insert(addr);
         } else {
             *val -= 1;
         }
@@ -609,11 +610,18 @@ impl Cache {
         self.subs.explicit(rtype).map(|s| s.clone()).collect()
     }
 
-    pub(crate) fn dns_names(&self) -> impl Iterator<Item = Hostname> + '_ {
-        self.data
-            .clusters
-            .iter()
-            .filter_map(|e| e.data.as_ref().and_then(|c| c.dns_name().cloned()))
+    pub(crate) fn dns_names(&self) -> Vec<DnsAddr> {
+        let mut names = Vec::new();
+
+        for entry in self.data.clusters.iter() {
+            let Some(cluster) = &entry.data else {
+                continue;
+            };
+            for dns_name in cluster.dns_names() {
+                names.push(dns_name)
+            }
+        }
+        names
     }
 
     /// Return the list of resources the cache has a registered subscription for
@@ -677,7 +685,7 @@ impl Cache {
             if let Some((_, entry)) = self.data.clusters.remove(cluster_name) {
                 if let Some(cluster) = entry.data {
                     for dns_name in cluster.dns_names() {
-                        self.dns.remove_name(dns_name);
+                        self.dns.remove_name(dns_name.clone());
                     }
                 }
             }
@@ -799,7 +807,7 @@ where
         // like basically the same thing. just accept the Vec::new call and call
         // it a day.
         for dns_name in resource.dns_names() {
-            dns.add_name(dns_name.clone())
+            dns.add_name(dns_name)
         }
 
         // clear any pending changes for this resource - it's no longer pending
@@ -863,7 +871,7 @@ mod test {
     use xds_api::pb::envoy::config::listener::v3 as xds_listener;
 
     use super::*;
-    use crate::xds::test as xds_test;
+    use crate::{dns::dns_updates, xds::test as xds_test};
 
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
@@ -1112,10 +1120,10 @@ mod test {
         );
         assert_eq!(
             dns,
-            DnsUpdates {
-                add: BTreeSet::from_iter([Hostname::from_static("cluster.example")]),
-                ..Default::default()
-            },
+            dns_updates! {
+                add = [("cluster.example", 7890)],
+                remove = [],
+            }
         );
 
         // subscriptions should be empty but current versions should match
@@ -1508,12 +1516,9 @@ mod test {
         let (resources, dns) = cache.collect();
         assert_eq!(
             dns,
-            DnsUpdates {
-                add: BTreeSet::new(),
-                remove: [Hostname::from_static("cluster.example")]
-                    .into_iter()
-                    .collect(),
-                sync: false,
+            dns_updates! {
+                add = [],
+                remove = [("cluster.example", 8008)],
             }
         );
 
@@ -1657,12 +1662,9 @@ mod test {
         let (resources, dns) = cache.collect();
         assert_eq!(
             dns,
-            DnsUpdates {
-                add: BTreeSet::new(),
-                remove: [Hostname::from_static("cluster.example")]
-                    .into_iter()
-                    .collect(),
-                sync: false,
+            dns_updates! {
+                add = [],
+                remove = [("cluster.example", 8008)],
             }
         );
         assert_eq!(

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -4,7 +4,6 @@ pub(crate) mod listeners;
 pub(crate) mod route_configs;
 pub(crate) use clusters::Cluster;
 pub(crate) use endpoints::LoadAssignment;
-use junction_api::Hostname;
 pub(crate) use listeners::ApiListener;
 pub(crate) use route_configs::RouteConfiguration;
 
@@ -26,6 +25,8 @@ macro_rules! value_or_default {
 }
 pub(crate) use value_or_default;
 
+use crate::dns::DnsAddr;
+
 // FIXME: validate that the all the EDS config sources use ADS instead of just assuming it everywhere.
 
 /// An xDS resource that can be handled, decoded, and cached.
@@ -43,7 +44,7 @@ pub(crate) trait Resource: Sized {
 
     fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError>;
     fn references(&self) -> Vec<(ResourceType, ResourceName)>;
-    fn dns_names(&self) -> Vec<&Hostname> {
+    fn dns_names(&self) -> Vec<DnsAddr> {
         Vec::new()
     }
 }

--- a/crates/junction-core/src/xds/resources/clusters.rs
+++ b/crates/junction-core/src/xds/resources/clusters.rs
@@ -1,10 +1,12 @@
-use crate::xds::{
-    load_balancer::LoadBalancer,
-    resources::{value_or_default, ErrorCtx},
+use crate::{
+    dns::DnsAddr,
+    xds::{
+        load_balancer::LoadBalancer,
+        resources::{value_or_default, ErrorCtx},
+    },
 };
 
 use super::{ads_config_source, xds_port, ResourceError, ResourceName, ResourceType};
-use junction_api::Hostname;
 use xds_api::pb::envoy::config::{
     cluster::v3 as xds_cluster, core::v3 as xds_core, endpoint::v3 as xds_endpoint,
 };
@@ -29,17 +31,8 @@ pub(crate) struct Cluster {
 #[derive(Clone, Debug)]
 pub(crate) enum Endpoints {
     Eds(ResourceName),
-    LogicalDns { hostname: Hostname, port: u16 },
+    LogicalDns { hostname: String, port: u16 },
     // TODO: Aggregate clusters
-}
-
-impl Cluster {
-    pub(crate) fn dns_name(&self) -> Option<&Hostname> {
-        match &self.endpoints {
-            Endpoints::LogicalDns { hostname, .. } => Some(hostname),
-            _ => None,
-        }
-    }
 }
 
 impl super::Resource for Cluster {
@@ -63,9 +56,12 @@ impl super::Resource for Cluster {
         }
     }
 
-    fn dns_names(&self) -> Vec<&Hostname> {
+    fn dns_names(&self) -> Vec<DnsAddr> {
         match &self.endpoints {
-            Endpoints::LogicalDns { hostname, .. } => vec![hostname],
+            Endpoints::LogicalDns { hostname, port } => vec![DnsAddr {
+                hostname: hostname.clone(),
+                port: *port,
+            }],
             _ => vec![],
         }
     }
@@ -115,9 +111,10 @@ fn eds_service_name(cluster: &xds_cluster::Cluster) -> Result<ResourceName, Reso
     })
 }
 
+// TODO: allow this to take a hostname/port? Figure out how and when GRPC does DNS resolution
 fn logical_dns_name(
     cla: Option<&xds_endpoint::ClusterLoadAssignment>,
-) -> Result<(Hostname, u16), ResourceError> {
+) -> Result<(String, u16), ResourceError> {
     let Some(cla) = cla else {
         return Err(ResourceError::invalid(
             "logical DNS cluster has no load assignment",
@@ -155,10 +152,7 @@ fn logical_dns_name(
 
     // FIXME: we should provide an error path here but things get so tedious and type-error-y
     // that we should probably fix the error API first.
-    let hostname: Hostname = socket_addr
-        .address
-        .parse()
-        .map_err(|_| ResourceError::invalid("invalid hostname"))?;
+    let hostname = socket_addr.address.clone();
     let port = xds_port(socket_addr.port_specifier.as_ref())
         .ok_or_else(|| ResourceError::invalid("invalid port"))?;
 

--- a/crates/junction-core/src/xds/resources/endpoints.rs
+++ b/crates/junction-core/src/xds/resources/endpoints.rs
@@ -9,7 +9,7 @@ use crate::xds::resources::ErrorCtx;
 
 use super::{xds_port, Resource, ResourceError};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct LoadAssignment {
     pub endpoints: Vec<EndpointGroup>,
 }


### PR DESCRIPTION
This PR slightly changes our approach to DNS and gets Logical DNS clusters working again.

### Client changes

48b6c940c97a459f5c417ede041b3fa700962ce3 totally deletes the concept of `DynamicConfig` from the client, and there's now just an ADS client directly included. The client was already made up of cheaply cloneable (Arc'd) fields, so putting it behind another layer of Arc was doing almost nothing - the `AdsTask` future is now bundled with the ADS client itself, like that long-standing comment suggested doing.

### DNS Changes

That minor cleanup got done to get ready for moving the DNS resolver back to the top-level of the client, and using it directly in endpoint selection, rather than hiding it as part of the ADS client.

This PR also removes `Hostname` from junction_api in favor of a `DnsAddr` type that's just a fancy `(name, port)` pair. In looking at GRPC and some other DNS clients (like systemd) it seems like almost no one does validation of configuration and lets their resolver handle bad names - we should definitely do server validation, but I've stopped doing any of it here.

`DnsAddr` now gets used in the cache to track DNS names for a cluster, and the client now trusts that the cache will accurately report DNS changes. This PR also totally gets rid of the concept of pinning names in the internal resolver, since it was confusing and only useful for static config overlay, which we don't expect to be bringing back. 