### PR TITLE
[xds] junction-core: actually await subscriptions

### DIFF
--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -192,7 +192,7 @@ impl AdsClient {
 
 impl XdsCache for AdsClient {
     async fn subscribe(&self, rtype: self::ResourceType, name: self::ResourceName) {
-        let _ = self.subs.send(SubscriptionUpdate::Add(rtype, name));
+        let _ = self.subs.send(SubscriptionUpdate::Add(rtype, name)).await;
     }
 
     async fn get_listener(&self, name: &self::ResourceName) -> Option<Arc<self::ApiListener>> {


### PR DESCRIPTION
Fixes a small (but very important) bug that kept resolution from actually happening. In theory this should have been caught by `#[must_use]` on the `Future`, but I'm ignoring the result anyway so it got dropped. This only affects the xDS 0.4 branch, we did this correctly before.

Submitting this as a separate PR just to get it landed quick.