### PR TITLE
[xds] add an example, update junction-node to the new API

### DIFF
--- a/crates/junction-core/examples/resolve.rs
+++ b/crates/junction-core/examples/resolve.rs
@@ -1,0 +1,30 @@
+use http::Method;
+use junction_core::Client;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let server_addr =
+        std::env::var("JUNCTION_ADS_SERVER").unwrap_or("http://127.0.0.1:8008".to_string());
+
+    let client = Client::builder("node".to_string(), "cluster".to_string())
+        .build(server_addr)
+        .await
+        .unwrap();
+
+    let endpoint = client
+        .resolve_http(
+            &Method::GET,
+            &"http://httpbin.org".parse().unwrap(),
+            &http::HeaderMap::new(),
+        )
+        .await
+        .unwrap();
+
+    eprintln!("addr={}", endpoint.addr());
+    endpoint.print_trace();
+}

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -620,7 +620,7 @@ async fn select_endpoint(
             );
             match load_assignment {
                 Some(load_assignment) => {
-                    trace.lookup_endpoints(hostname.clone());
+                    trace.lookup_dns(hostname.clone());
                     load_assignment
                 }
                 None => {

--- a/crates/junction-core/src/trace.rs
+++ b/crates/junction-core/src/trace.rs
@@ -36,6 +36,7 @@ pub(crate) enum TraceEventKind {
     // EndpointSelection
     LookupCluster,
     LookupEndpoints,
+    LookupDns,
     LoadBalance,
 }
 
@@ -138,6 +139,15 @@ impl Trace {
             kind: TraceEventKind::LookupEndpoints,
             at: Instant::now(),
             kv: vec![("endpoints", endpoints.to_smolstr())],
+        });
+    }
+
+    pub(crate) fn lookup_dns(&mut self, hostname: String) {
+        self.events.push(TraceEvent {
+            phase: self.phase,
+            kind: TraceEventKind::LookupDns,
+            at: Instant::now(),
+            kv: vec![("hostname", hostname.to_smolstr())],
         });
     }
 

--- a/junction-node/package-lock.json
+++ b/junction-node/package-lock.json
@@ -345,6 +345,71 @@
         "@shikijs/vscode-textmate": "^10.0.1"
       }
     },
+    "node_modules/@junction-labs/client-darwin-arm64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-arm64/-/client-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-ZqW+0QVx9Lpnjo4mQ4LY4EjpOKbeXaF5h/QBzhtu1uQVVmGnUhnmpX+4/k0dVbzTtrYgw4CPpb+RriBXwTBt0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@junction-labs/client-darwin-x64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-x64/-/client-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-kczyGG7DxCi3Tl0CL/G1Nm7ax+dBqrYJbDjtEShl6/tCticyzc9UVdiPNruwmSpokZVaAI/2zkZ8WJ6eKApaPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@junction-labs/client-linux-arm64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-arm64-gnu/-/client-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-vNwSEif6FLhF0/K8lj2sMkcwvebMnZIn2LpM4HRpAE3wCaUyjGfWgrWoLHhIdZNQP45pJG16PvJsVU3efxfPPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@junction-labs/client-linux-x64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-x64-gnu/-/client-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-X63QHaylPGaZ7Q7eEq0gFjKLm+K4B2O9y8hO8G7LmeZv3EVMpnYOAX82oJ49yX95WBLkGO05KnR8sP8Q+eijYA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@junction-labs/client-win32-x64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-win32-x64-msvc/-/client-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-lHsX6xkwpIj0QLdCLx+ReqAAL/yoIRfnnHQmIsNbqdDbWpqt3yydB7OYaaPoI/Of/sJiBEpmfiTcxfQNdSVSzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@neon-rs/cli": {
       "version": "0.1.82",
       "resolved": "https://registry.npmjs.org/@neon-rs/cli/-/cli-0.1.82.tgz",

--- a/junction-node/src/lib.rs
+++ b/junction-node/src/lib.rs
@@ -93,7 +93,8 @@ fn new_client(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let cluster_id = arg_value!(cx, JsString, 3);
 
     let build_client = async move {
-        junction_core::Client::build(ads_server, node_id, cluster_id)
+        junction_core::Client::builder(node_id, cluster_id)
+            .build(ads_server)
             .await
             .map_err(|e| e.to_string())
     };
@@ -239,7 +240,7 @@ fn js_endpoint<'a>(
 
 fn js_retry<'a>(
     cx: &mut impl Context<'a>,
-    retry: &junction_api::http::RouteRetry,
+    retry: &junction_core::Retries,
 ) -> JsResult<'a, JsObject> {
     let obj = cx.empty_object();
 
@@ -267,21 +268,21 @@ fn js_retry<'a>(
 
 fn js_timeouts<'a>(
     cx: &mut impl Context<'a>,
-    timeouts: &junction_api::http::RouteTimeouts,
+    timeouts: &junction_core::Timeouts,
 ) -> JsResult<'a, JsObject> {
     let obj = cx.empty_object();
 
-    let request: Handle<JsValue> = match &timeouts.request {
+    let request: Handle<JsValue> = match &timeouts.total {
         Some(request) => js_duration_ms(cx, request)?.upcast(),
         None => cx.undefined().upcast(),
     };
-    obj.set(cx, "request", request)?;
+    obj.set(cx, "total", request)?;
 
-    let backend_request: Handle<JsValue> = match &timeouts.backend_request {
+    let backend_request: Handle<JsValue> = match &timeouts.attempt {
         Some(backend_request) => js_duration_ms(cx, backend_request)?.upcast(),
         None => cx.undefined().upcast(),
     };
-    obj.set(cx, "backendRequest", backend_request)?;
+    obj.set(cx, "attempt", backend_request)?;
 
     Ok(obj)
 }


### PR DESCRIPTION
> NOTE: This PR is stacked on top of #193 and #196 and will be rebased appropriately.

1ae03278b574c4cb24a57c04061c228e017293b9 adds a simple example that expects a DNS service named `httpbin` to exist, and an extra trace event for DNS resolution to distinguish it from endpoint lookups.

77aeca1cb3df257b3f1b9b860279cda9421b5d98 updates `junction-node` to the new APIs so it compiles. There's a package-lock.json change bundled in here that I think we're missing on main as well. 