### PR TITLE
junction-core: allow parsing endpoint groups with missing Locality

### DIFF
--- a/crates/junction-core/src/xds/resources/endpoints.rs
+++ b/crates/junction-core/src/xds/resources/endpoints.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::{collections::BTreeMap, net::IpAddr};
 
@@ -55,11 +54,14 @@ impl Locality {
         }
     }
 
-    fn from_xds(locality: &Option<xds_core::Locality>) -> Option<Self> {
-        locality.as_ref().map(|locality| Self {
-            region: locality.region.clone(),
-            zone: locality.zone.clone(),
-        })
+    fn from_xds(locality: &Option<xds_core::Locality>) -> Self {
+        locality
+            .as_ref()
+            .map(|locality| Self {
+                region: locality.region.clone(),
+                zone: locality.zone.clone(),
+            })
+            .unwrap_or_else(Self::empty)
     }
 }
 
@@ -68,30 +70,34 @@ impl Resource for LoadAssignment {
 
     fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError> {
         // priority -> locality -> [addr]
-        let mut endpoints: BTreeMap<u32, BTreeMap<Locality, HashSet<SocketAddr>>> = BTreeMap::new();
+        //
+        // NOTE: this completely trusts the control plane not to send us
+        // duplicate addresses or to reorder addresses in a meaningless way. if
+        // endpoints are reordered, the hash of the EndpointGroup will not stay
+        // stable and load balancing may be affected.
+        let mut endpoints: BTreeMap<u32, BTreeMap<Locality, Vec<SocketAddr>>> = BTreeMap::new();
 
         for (endpoints_idx, locality_lb_endpoint) in xds.endpoints.iter().enumerate() {
             let priority = locality_lb_endpoint.priority;
 
-            if let Some(locality) = Locality::from_xds(&locality_lb_endpoint.locality) {
-                let priority_endpoints = endpoints.entry(priority).or_default();
-                let locality_endpoints = priority_endpoints.entry(locality).or_default();
+            let locality = Locality::from_xds(&locality_lb_endpoint.locality);
+            let priority_endpoints = endpoints.entry(priority).or_default();
+            let locality_endpoints = priority_endpoints.entry(locality).or_default();
 
-                for (lb_idx, lb_endpoint) in locality_lb_endpoint.lb_endpoints.iter().enumerate() {
-                    // skip all endpoints that are not HEALTHY or UNKNOWN
-                    if !matches!(
-                        lb_endpoint.health_status(),
-                        xds_core::HealthStatus::Healthy | xds_core::HealthStatus::Unknown,
-                    ) {
-                        continue;
-                    }
-
-                    // parse the address and save it by locality/priority
-                    let socket_addr = xds_lb_endpoint_socket_addr(&lb_endpoint)
-                        .with_field_index("lb_endpoints", lb_idx)
-                        .with_field_index("endpoints", endpoints_idx)?;
-                    locality_endpoints.insert(socket_addr);
+            for (lb_idx, lb_endpoint) in locality_lb_endpoint.lb_endpoints.iter().enumerate() {
+                // skip all endpoints that are not HEALTHY or UNKNOWN
+                if !matches!(
+                    lb_endpoint.health_status(),
+                    xds_core::HealthStatus::Healthy | xds_core::HealthStatus::Unknown,
+                ) {
+                    continue;
                 }
+
+                // parse the address and save it by locality/priority
+                let socket_addr = xds_lb_endpoint_socket_addr(&lb_endpoint)
+                    .with_field_index("lb_endpoints", lb_idx)
+                    .with_field_index("endpoints", endpoints_idx)?;
+                locality_endpoints.push(socket_addr);
             }
         }
 
@@ -163,5 +169,82 @@ fn xds_lb_endpoint_socket_addr(
             Ok(SocketAddr::new(ip, port))
         }
         _ => Err(ResourceError::invalid("missing socket addr")),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn hash_huh() {
+        assert_eq!(
+            thread_local_xxhash::hash(&[1, 2, 3]),
+            thread_local_xxhash::hash(&[1, 2, 3]),
+        )
+    }
+
+    #[test]
+    fn load_assignment_from_xds() {
+        let endpoint = |addr: SocketAddr| {
+            xds_endpoint::lb_endpoint::HostIdentifier::Endpoint(xds_endpoint::Endpoint {
+                address: Some(xds_core::Address {
+                    address: Some(xds_core::address::Address::SocketAddress(
+                        xds_core::SocketAddress {
+                            address: addr.ip().to_string(),
+                            port_specifier: Some(
+                                xds_core::socket_address::PortSpecifier::PortValue(
+                                    addr.port() as u32
+                                ),
+                            ),
+                            ..Default::default()
+                        },
+                    )),
+                }),
+                ..Default::default()
+            })
+        };
+
+        let load_assignment = xds_endpoint::ClusterLoadAssignment {
+            cluster_name: "whatever.com:8008".to_string(),
+            endpoints: vec![xds_endpoint::LocalityLbEndpoints {
+                lb_endpoints: vec![
+                    xds_endpoint::LbEndpoint {
+                        host_identifier: Some(endpoint("192.168.194.79:8008".parse().unwrap())),
+                        ..Default::default()
+                    },
+                    xds_endpoint::LbEndpoint {
+                        host_identifier: Some(endpoint("192.168.194.80:8008".parse().unwrap())),
+                        ..Default::default()
+                    },
+                    xds_endpoint::LbEndpoint {
+                        host_identifier: Some(endpoint("192.168.194.81:8008".parse().unwrap())),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            LoadAssignment::from_xds(&load_assignment).unwrap(),
+            LoadAssignment {
+                endpoints: vec![EndpointGroup {
+                    hash: 13400130612657829157,
+                    priority: 0,
+                    endpoints: BTreeMap::from_iter([(
+                        Locality::empty(),
+                        vec![
+                            "192.168.194.79:8008".parse().unwrap(),
+                            "192.168.194.80:8008".parse().unwrap(),
+                            "192.168.194.81:8008".parse().unwrap(),
+                        ]
+                    )]),
+                }],
+            }
+        )
     }
 }


### PR DESCRIPTION
A quick fix that allows treating a `None` locality in xDS as the empty locality. This isn't allowed by GRPC, but makes our lives easier in the short term while we get back to a functioning client on `main`.