### PR TITLE
junction-core: some final cleanup before Python and Node

### DIFF
--- a/crates/junction-core/src/xds/cache.rs
+++ b/crates/junction-core/src/xds/cache.rs
@@ -245,14 +245,20 @@ impl<T> ResourceMap<T> {
         }
     }
 
-    fn insert_ok(&self, name: ResourceName, version: ResourceVersion, resource: T) {
+    fn insert_ok(
+        &self,
+        name: ResourceName,
+        version: ResourceVersion,
+        resource: T,
+        raw_msg: protobuf::Any,
+    ) {
         self.map.insert(
             name,
             ResourceData {
                 version: Some(version),
                 last_error: None,
                 data: Some(Arc::new(resource)),
-                raw_msg: None,
+                raw_msg: Some(raw_msg),
             },
         );
         self.changed.notify_waiters();
@@ -813,7 +819,7 @@ where
         // clear any pending changes for this resource - it's no longer pending
         subs.clear_changes(rtype, &name);
         // actually insert the thing
-        data.insert_ok(name, version, resource);
+        data.insert_ok(name, version, resource, any);
     }
 
     errors
@@ -847,21 +853,33 @@ impl_get!(get_load_assignment(load_assignments)=>LoadAssignment);
 
 impl CacheReader {
     pub(super) fn iter_xds(&self) -> impl Iterator<Item = XdsConfig> + '_ {
-        self.data.listeners.iter().map(|entry| {
-            let name = entry.key().to_string();
-            let type_url = ResourceType::Listener.type_url().to_string();
-            let version = entry.version.clone();
-            let xds = entry.raw_msg.clone();
-            let last_error = entry.last_error.clone().map(|(v, e)| (v, e.to_string()));
+        macro_rules! data_iter {
+            ($field:ident, $rtype:expr) => {
+                self.data.$field.iter().map(|entry| {
+                    let name = entry.key().to_string();
+                    let type_url = $rtype.type_url().to_string();
+                    let version = entry.version.clone();
+                    let xds = entry.raw_msg.clone();
+                    let last_error = entry.last_error.clone().map(|(v, e)| (v, e.to_string()));
 
-            XdsConfig {
-                name,
-                type_url,
-                version,
-                xds,
-                last_error,
-            }
-        })
+                    XdsConfig {
+                        name,
+                        type_url,
+                        version,
+                        xds,
+                        last_error,
+                    }
+                })
+            };
+        }
+
+        data_iter!(listeners, ResourceType::Listener)
+            .chain(data_iter!(route_configs, ResourceType::RouteConfiguration))
+            .chain(data_iter!(clusters, ResourceType::Cluster))
+            .chain(data_iter!(
+                load_assignments,
+                ResourceType::ClusterLoadAssignment
+            ))
     }
 }
 
@@ -946,7 +964,7 @@ where
 {
     // actually insert the thing
     let resource = T::from_any(&any)?;
-    data.insert_ok(name, version.clone(), resource);
+    data.insert_ok(name, version.clone(), resource, any);
     Ok(())
 }
 

--- a/crates/junction-core/src/xds/resources/endpoints.rs
+++ b/crates/junction-core/src/xds/resources/endpoints.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::{collections::BTreeMap, net::IpAddr};
 
@@ -55,11 +54,14 @@ impl Locality {
         }
     }
 
-    fn from_xds(locality: &Option<xds_core::Locality>) -> Option<Self> {
-        locality.as_ref().map(|locality| Self {
-            region: locality.region.clone(),
-            zone: locality.zone.clone(),
-        })
+    fn from_xds(locality: &Option<xds_core::Locality>) -> Self {
+        locality
+            .as_ref()
+            .map(|locality| Self {
+                region: locality.region.clone(),
+                zone: locality.zone.clone(),
+            })
+            .unwrap_or_else(Self::empty)
     }
 }
 
@@ -68,30 +70,34 @@ impl Resource for LoadAssignment {
 
     fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError> {
         // priority -> locality -> [addr]
-        let mut endpoints: BTreeMap<u32, BTreeMap<Locality, HashSet<SocketAddr>>> = BTreeMap::new();
+        //
+        // NOTE: this completely trusts the control plane not to send us
+        // duplicate addresses or to reorder addresses in a meaningless way. if
+        // endpoints are reordered, the hash of the EndpointGroup will not stay
+        // stable and load balancing may be affected.
+        let mut endpoints: BTreeMap<u32, BTreeMap<Locality, Vec<SocketAddr>>> = BTreeMap::new();
 
         for (endpoints_idx, locality_lb_endpoint) in xds.endpoints.iter().enumerate() {
             let priority = locality_lb_endpoint.priority;
 
-            if let Some(locality) = Locality::from_xds(&locality_lb_endpoint.locality) {
-                let priority_endpoints = endpoints.entry(priority).or_default();
-                let locality_endpoints = priority_endpoints.entry(locality).or_default();
+            let locality = Locality::from_xds(&locality_lb_endpoint.locality);
+            let priority_endpoints = endpoints.entry(priority).or_default();
+            let locality_endpoints = priority_endpoints.entry(locality).or_default();
 
-                for (lb_idx, lb_endpoint) in locality_lb_endpoint.lb_endpoints.iter().enumerate() {
-                    // skip all endpoints that are not HEALTHY or UNKNOWN
-                    if !matches!(
-                        lb_endpoint.health_status(),
-                        xds_core::HealthStatus::Healthy | xds_core::HealthStatus::Unknown,
-                    ) {
-                        continue;
-                    }
-
-                    // parse the address and save it by locality/priority
-                    let socket_addr = xds_lb_endpoint_socket_addr(&lb_endpoint)
-                        .with_field_index("lb_endpoints", lb_idx)
-                        .with_field_index("endpoints", endpoints_idx)?;
-                    locality_endpoints.insert(socket_addr);
+            for (lb_idx, lb_endpoint) in locality_lb_endpoint.lb_endpoints.iter().enumerate() {
+                // skip all endpoints that are not HEALTHY or UNKNOWN
+                if !matches!(
+                    lb_endpoint.health_status(),
+                    xds_core::HealthStatus::Healthy | xds_core::HealthStatus::Unknown,
+                ) {
+                    continue;
                 }
+
+                // parse the address and save it by locality/priority
+                let socket_addr = xds_lb_endpoint_socket_addr(&lb_endpoint)
+                    .with_field_index("lb_endpoints", lb_idx)
+                    .with_field_index("endpoints", endpoints_idx)?;
+                locality_endpoints.push(socket_addr);
             }
         }
 
@@ -163,5 +169,82 @@ fn xds_lb_endpoint_socket_addr(
             Ok(SocketAddr::new(ip, port))
         }
         _ => Err(ResourceError::invalid("missing socket addr")),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn hash_huh() {
+        assert_eq!(
+            thread_local_xxhash::hash(&[1, 2, 3]),
+            thread_local_xxhash::hash(&[1, 2, 3]),
+        )
+    }
+
+    #[test]
+    fn load_assignment_from_xds() {
+        let endpoint = |addr: SocketAddr| {
+            xds_endpoint::lb_endpoint::HostIdentifier::Endpoint(xds_endpoint::Endpoint {
+                address: Some(xds_core::Address {
+                    address: Some(xds_core::address::Address::SocketAddress(
+                        xds_core::SocketAddress {
+                            address: addr.ip().to_string(),
+                            port_specifier: Some(
+                                xds_core::socket_address::PortSpecifier::PortValue(
+                                    addr.port() as u32
+                                ),
+                            ),
+                            ..Default::default()
+                        },
+                    )),
+                }),
+                ..Default::default()
+            })
+        };
+
+        let load_assignment = xds_endpoint::ClusterLoadAssignment {
+            cluster_name: "whatever.com:8008".to_string(),
+            endpoints: vec![xds_endpoint::LocalityLbEndpoints {
+                lb_endpoints: vec![
+                    xds_endpoint::LbEndpoint {
+                        host_identifier: Some(endpoint("192.168.194.79:8008".parse().unwrap())),
+                        ..Default::default()
+                    },
+                    xds_endpoint::LbEndpoint {
+                        host_identifier: Some(endpoint("192.168.194.80:8008".parse().unwrap())),
+                        ..Default::default()
+                    },
+                    xds_endpoint::LbEndpoint {
+                        host_identifier: Some(endpoint("192.168.194.81:8008".parse().unwrap())),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            LoadAssignment::from_xds(&load_assignment).unwrap(),
+            LoadAssignment {
+                endpoints: vec![EndpointGroup {
+                    hash: 13400130612657829157,
+                    priority: 0,
+                    endpoints: BTreeMap::from_iter([(
+                        Locality::empty(),
+                        vec![
+                            "192.168.194.79:8008".parse().unwrap(),
+                            "192.168.194.80:8008".parse().unwrap(),
+                            "192.168.194.81:8008".parse().unwrap(),
+                        ]
+                    )]),
+                }],
+            }
+        )
     }
 }

--- a/crates/junction-core/src/xds/resources/route_configs.rs
+++ b/crates/junction-core/src/xds/resources/route_configs.rs
@@ -115,10 +115,37 @@ impl Action {
                     Some(xds_route::route_action::ClusterSpecifier::Cluster(cluster)) => {
                         ClusterSpecifier::Cluster(ResourceName::from(cluster.to_string()))
                     }
-                    Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(_)) => todo!(),
-                    Some(_) => todo!(),
-                    None => todo!(),
+                    Some(xds_route::route_action::ClusterSpecifier::WeightedClusters(clusters)) => {
+                        if clusters.clusters.is_empty() {
+                            return Err(ResourceError::invalid("no clusters specified"))
+                                .with_fields("cluster_specifier", "clusters");
+                        }
+
+                        let mut weights = Vec::with_capacity(clusters.clusters.len());
+                        for (i, cluster) in clusters.clusters.iter().enumerate() {
+                            if cluster.name.is_empty() {
+                                return Err(ResourceError::invalid("empty cluster"))
+                                    .with_field("name")
+                                    .with_field_index("clusters", i);
+                            }
+                            let Some(weight) = &cluster.weight else {
+                                return Err(ResourceError::invalid("missing weight"))
+                                    .with_field("weight")
+                                    .with_field_index("clusters", i);
+                            };
+
+                            weights.push(ClusterWeight {
+                                name: ResourceName::from(cluster.name.clone()),
+                                weight: weight.value,
+                            })
+                        }
+
+                        ClusterSpecifier::Weighted(weights)
+                    }
+                    Some(_) => return Err(ResourceError::invalid("unsupported cluster specifier")),
+                    None => return Err(ResourceError::invalid("missing cluster specifier")),
                 };
+
                 let hash_policies = vec_from_xds!(action.hash_policy, "hash_policy", HashPolicy)?;
                 let retries = Retries::from_xds(&action)?;
                 let timeouts = Timeouts::from_xds(&action)?;


### PR DESCRIPTION
A few quick fixes before the Node and Python PRs are ready to go:

### 071c9ef7198c571a7152af41784ddf49ea13e8c0

Allows parsing an xDS ClusterLoadAssignment with a missing/null Locality. This is an error according to GRPC, but we're treating this just like the empty Locality. We don't validate Locality yet the same way that they do, and this lets us pass some of our existing smoke tests without control plane changes.

### 0c4a664261d564596ef86b9e6cffba5cdc324e16

`dump_xds` was only dumping listeners and not including the actual protobuf. Oops.

### ae2a9b677b4d6a1a97d376ed54ce11e1fb23eb6e

Finishes RouteConfiguration parsing so that we can actually handle weighted clusters and don't panic. This is also necessary for passing our existing smoke tests, but like Locality parsing is still missing some real specification and testing.