### PR TITLE
junction-python: update to the new API

### DIFF
--- a/junction-python/junction/__init__.py
+++ b/junction-python/junction/__init__.py
@@ -1,11 +1,9 @@
-import typing
-
 from junction.junction import (
     _version,
     _build,
     Junction,
     Endpoint,
-    RetryPolicy,
+    Retries,
     default_client,
     check_route,
     dump_kube_backend,
@@ -19,36 +17,10 @@ __version__ = _version
 __build__ = _build
 
 
-def _default_client(
-    static_routes: typing.Optional[typing.List[config.Route]],
-    static_backends: typing.Optional[typing.List[config.Backend]],
-) -> Junction:
-    """
-    Return a Junction client with default Routes and Backends.
-
-    Uses the passed defaults to create a new client with default Routes
-    and Backends.
-    """
-    client_kwargs = {}
-    if static_routes:
-        # This check is just in case the user does something dumb as otherwise
-        # the error on the return line is pretty ambiguous
-        if not isinstance(static_routes, typing.List):
-            raise ValueError("static_routes must be a list of routes")
-        client_kwargs["static_routes"] = static_routes
-    if static_backends:
-        # This check is just in case the user does something dumb as otherwise
-        # the error on the return line is pretty ambiguous
-        if not isinstance(static_backends, typing.List):
-            raise ValueError("static_backends must be a list of backends")
-        client_kwargs["static_backends"] = static_backends
-    return default_client(**client_kwargs)
-
-
 __all__ = (
     Junction,
     Endpoint,
-    RetryPolicy,
+    Retries,
     config,
     urllib3,
     requests,

--- a/junction-python/junction/requests.py
+++ b/junction-python/junction/requests.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Mapping, Union, Optional
+from typing import Mapping, Union, Optional
 
 import requests
 
@@ -205,8 +205,6 @@ class Session(requests.Session):
 
     def __init__(
         self,
-        static_routes: Optional[List["junction.config.Route"]] = None,
-        static_backends: Optional[List["junction.config.Backend"]] = None,
         junction_client: Optional[junction.Junction] = None,
     ) -> None:
         super().__init__()
@@ -214,9 +212,7 @@ class Session(requests.Session):
         if junction_client:
             self.junction = junction_client
         else:
-            self.junction = junction._default_client(
-                static_routes=static_routes, static_backends=static_backends
-            )
+            self.junction = junction.default_client()
 
         self.mount("https://", HTTPAdapter(junction_client=self.junction))
         self.mount("http://", HTTPAdapter(junction_client=self.junction))

--- a/junction-python/junction/urllib3.py
+++ b/junction-python/junction/urllib3.py
@@ -12,7 +12,7 @@ from urllib3.exceptions import (
 
 import junction
 
-from junction import Endpoint, RetryPolicy
+from junction import Endpoint, Retries
 
 # When integrating with urllib3, it makes the most sense to provide a drop-in
 # replacement for PoolManager - HTTPConnectionPool and friends are pools of
@@ -43,7 +43,7 @@ def _is_redirect_err(e: MaxRetryError) -> bool:
 
 
 def _configure_retries(
-    retries: typing.Optional[urllib3.Retry], policy: RetryPolicy
+    retries: typing.Optional[urllib3.Retry], policy: Retries
 ) -> typing.Tuple[urllib3.Retry, typing.Union[int, bool]]:
     """
     Merge Junction retries with callsite specific urilib3.Retry objects.
@@ -91,8 +91,6 @@ class PoolManager(urllib3.PoolManager):
         num_pools: int = 10,
         headers: typing.Optional[typing.Mapping[str, str]] = None,
         # junction
-        static_routes: typing.Optional[typing.List["junction.config.Route"]] = None,
-        static_backends: typing.Optional[typing.List["junction.config.Backend"]] = None,
         junction_client: typing.Optional[junction.Junction] = None,
         # kwargs
         **kwargs: typing.Any,
@@ -100,9 +98,7 @@ class PoolManager(urllib3.PoolManager):
         if junction_client:
             self.junction = junction_client
         else:
-            self.junction = junction._default_client(
-                static_routes=static_routes, static_backends=static_backends
-            )
+            self.junction = junction.default_client()
 
         super().__init__(num_pools, headers, **kwargs)
 
@@ -145,19 +141,19 @@ class PoolManager(urllib3.PoolManager):
         )
 
         deadline = None
-        if endpoint.timeout_policy and endpoint.timeout_policy.request != 0:
-            deadline = time.time() + endpoint.timeout_policy.request
+        if endpoint.timeout_policy and endpoint.timeout_policy.total != 0:
+            deadline = time.time() + endpoint.timeout_policy.total
 
         while True:
             # we don't clobber a method specific timeout even when there is a
-            # backend_request value.
+            # attempt value.
             if (
                 endpoint.timeout_policy
-                and endpoint.timeout_policy.backend_request != 0
+                and endpoint.timeout_policy.attempt != 0
                 and kwargs.get("timeout", None) is None
             ):
                 kwargs["timeout"] = urllib3.Timeout(
-                    total=endpoint.timeout_policy.backend_request
+                    total=endpoint.timeout_policy.attempt
                 )
 
             # we do clobber a method specific timeout when there is a deadline

--- a/junction-python/samples/smoke-test/client.py
+++ b/junction-python/samples/smoke-test/client.py
@@ -41,33 +41,28 @@ class SessionFactory:
         self.delete_resources = []
         self.delete_patches = []
 
-        if self.args.use_gateway_api:
-            if routes:
-                manifests = [
-                    junction.dump_kube_route(route=route, namespace="default")
-                    for route in routes
-                ]
-                self._kubectl_apply(*manifests)
-                self.delete_resources = manifests
-            if backends:
-                manifests = [
-                    junction.dump_kube_backend(backend) for backend in backends
-                ]
-                self._kubectl_patch(*manifests)
-                for manifest in manifests:
-                    spec = yaml.safe_load(manifest)
-                    for key in spec["metadata"]["annotations"].keys():
-                        spec["metadata"]["annotations"][key] = None
-                    self.delete_patches.append(yaml.dump(spec))
+        if routes:
+            manifests = [
+                junction.dump_kube_route(route=route, namespace="default")
+                for route in routes
+            ]
+            self._kubectl_apply(*manifests)
+            self.delete_resources = manifests
+        if backends:
+            manifests = [
+                junction.dump_kube_backend(backend) for backend in backends
+            ]
+            self._kubectl_patch(*manifests)
+            for manifest in manifests:
+                spec = yaml.safe_load(manifest)
+                for key in spec["metadata"]["annotations"].keys():
+                    spec["metadata"]["annotations"][key] = None
+                self.delete_patches.append(yaml.dump(spec))
 
-            # unfortunately, kube/ezbake do not propagate changes instantly
-            # so we need to wait for them to be ready
-            sleep(2)
-            self.session = junction.requests.Session()
-        else:
-            self.session = junction.requests.Session(
-                static_routes=routes, static_backends=backends
-            )
+        # unfortunately, kube/ezbake do not propagate changes instantly
+        # so we need to wait for them to be ready
+        sleep(2)
+        self.session = junction.requests.Session()
 
     def __enter__(self):
         return self.session
@@ -193,7 +188,7 @@ def retry_test(args):
 
 
 def path_match_test(args):
-    print_header("Header Match - 50% of /feature-1/index sent to a different backend")
+    print_header("Path Match - 50% of /feature-1/index sent to a different backend")
 
     service: junction.config.Service = {
         "type": "kube",
@@ -360,7 +355,7 @@ def urllib3_test(args):
         "name": "jct-simple-app",
         "namespace": "default",
     }
-    default_routes: List[junction.config.Route] = [
+    routes: List[junction.config.Route] = [
         {
             "id": "smoke-test-urllib3",
             "hostnames": ["jct-simple-app.default.svc.cluster.local"],
@@ -374,18 +369,19 @@ def urllib3_test(args):
             ],
         }
     ]
-    http = JunctionPoolManger(static_routes=default_routes)
 
-    results = []
-    for sleep_ms in [0, 100]:
-        counters = defaultdict(int)
-        try:
-            http.urlopen("GET", f"{args.base_url}/?sleep_ms={sleep_ms}")
-            counters["success"] += 1
-        except urllib3.exceptions.MaxRetryError:
-            counters["exception"] += 1
-        print(f"With server sleep time '{sleep_ms}'ms call result counts are - ")
-        results.append(print_counters(counters))
+    with SessionFactory(args, routes=routes) as _session:
+        http = JunctionPoolManger()
+        results = []
+        for sleep_ms in [0, 100]:
+            counters = defaultdict(int)
+            try:
+                http.urlopen("GET", f"{args.base_url}/?sleep_ms={sleep_ms}")
+                counters["success"] += 1
+            except urllib3.exceptions.MaxRetryError:
+                counters["exception"] += 1
+            print(f"With server sleep time '{sleep_ms}'ms call result counts are - ")
+            results.append(print_counters(counters))
 
     # now show an override of timeout on the method call still works
     for sleep_ms in [0, 100]:

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -1,7 +1,4 @@
-use junction_api::{
-    backend::{Backend, BackendId},
-    http::Route,
-};
+use junction_api::{backend::Backend, http::Route};
 use junction_core::{HttpResult, ResourceVersion};
 use once_cell::sync::Lazy;
 use pyo3::{
@@ -13,11 +10,7 @@ use pyo3::{
     wrap_pyfunction, Bound, Py, PyAny, PyResult, Python,
 };
 use serde::Serialize;
-use std::{
-    net::IpAddr,
-    str::FromStr,
-    time::{Duration, Instant},
-};
+use std::{net::IpAddr, str::FromStr};
 use tracing_subscriber::EnvFilter;
 use xds_api::pb::google::protobuf;
 
@@ -32,7 +25,7 @@ fn junction(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("_build", BUILD)?;
     m.add_class::<Junction>()?;
     m.add_class::<Endpoint>()?;
-    m.add_class::<RetryPolicy>()?;
+    m.add_class::<Retries>()?;
     m.add_class::<SearchConfig>()?;
     m.add_function(wrap_pyfunction!(default_client, m)?)?;
     m.add_function(wrap_pyfunction!(check_route, m)?)?;
@@ -121,12 +114,12 @@ impl Endpoint {
     }
 
     #[getter]
-    fn retry_policy(&self) -> Option<RetryPolicy> {
+    fn retry_policy(&self) -> Option<Retries> {
         self.inner.retry().clone().map(|r| r.into())
     }
 
     #[getter]
-    fn timeout_policy(&self) -> Option<TimeoutPolicy> {
+    fn timeout_policy(&self) -> Option<Timeouts> {
         self.inner.timeouts().clone().map(|t| t.into())
     }
 
@@ -148,19 +141,25 @@ impl From<junction_core::Endpoint> for Endpoint {
 /// A policy that describes how a client should retry requests.
 #[derive(Clone, Debug)]
 #[pyclass]
-pub struct RetryPolicy {
+pub struct Retries {
+    /// The HTTP error codes that retries should be applied to.
     #[pyo3(get)]
     codes: Vec<u16>,
 
+    /// The total number of attempts to make when retrying this request. If
+    /// unset, the client should only ever make a single request.
     #[pyo3(get)]
     attempts: u32,
 
+    /// The initial amount of time to back off between requests during a series
+    /// of retries. Backoff may scale up to `max_backoff` between requests at
+    /// the client's discretion
     #[pyo3(get)]
     backoff: f64,
 }
 
 #[pymethods]
-impl RetryPolicy {
+impl Retries {
     #[new]
     fn new(codes: Option<Vec<u16>>, attempts: Option<u32>, backoff: Option<f64>) -> Self {
         Self {
@@ -172,16 +171,16 @@ impl RetryPolicy {
 
     fn __repr__(&self) -> String {
         format!(
-            "RetryPolicy({attempts}, {min})",
-            //FIXME: add codes
+            "Retries({codes:#?}, {attempts}, {backoff})",
+            codes = self.codes,
             attempts = self.attempts,
-            min = self.backoff,
+            backoff = self.backoff,
         )
     }
 }
 
-impl From<junction_api::http::RouteRetry> for RetryPolicy {
-    fn from(value: junction_api::http::RouteRetry) -> Self {
+impl From<junction_core::Retries> for Retries {
+    fn from(value: junction_core::Retries) -> Self {
         Self {
             codes: value.codes,
             attempts: value.attempts.unwrap_or(1),
@@ -193,33 +192,30 @@ impl From<junction_api::http::RouteRetry> for RetryPolicy {
 /// A policy that describes how a client should do timeouts.
 #[derive(Clone, Debug)]
 #[pyclass]
-pub struct TimeoutPolicy {
+pub struct Timeouts {
     #[pyo3(get)]
-    backend_request: f64,
+    attempt: f64,
 
     #[pyo3(get)]
-    request: f64,
+    total: f64,
 }
 
 #[pymethods]
-impl TimeoutPolicy {
+impl Timeouts {
     fn __repr__(&self) -> String {
         format!(
-            "TimeoutPolicy({backend_request}, {request})",
-            backend_request = self.backend_request,
-            request = self.request,
+            "Timeouts({attempt}, {total})",
+            attempt = self.attempt,
+            total = self.total,
         )
     }
 }
 
-impl From<junction_api::http::RouteTimeouts> for TimeoutPolicy {
-    fn from(value: junction_api::http::RouteTimeouts) -> Self {
+impl From<junction_core::Timeouts> for Timeouts {
+    fn from(value: junction_core::Timeouts) -> Self {
         Self {
-            backend_request: value
-                .backend_request
-                .map(|x| x.as_secs_f64())
-                .unwrap_or(0.0),
-            request: value.request.map(|x| x.as_secs_f64()).unwrap_or(0.0),
+            attempt: value.attempt.map(|x| x.as_secs_f64()).unwrap_or(0.0),
+            total: value.total.map(|x| x.as_secs_f64()).unwrap_or(0.0),
         }
     }
 }
@@ -274,13 +270,12 @@ impl From<junction_core::SearchConfig> for SearchConfig {
 #[pyfunction]
 #[pyo3(signature = (routes, url, *, method=None, headers=None, search_config=None))]
 fn check_route(
-    py: Python<'_>,
     routes: Bound<'_, PyAny>,
     url: &str,
     method: Option<&str>,
     headers: Option<&Bound<PyMapping>>,
     search_config: Option<Bound<'_, PyAny>>,
-) -> PyResult<(Py<PyAny>, usize, Py<PyAny>)> {
+) -> PyResult<String> {
     let url: junction_core::Url = url
         .parse()
         .map_err(|e| PyValueError::new_err(format!("{e}")))?;
@@ -291,14 +286,11 @@ fn check_route(
         .transpose()?;
 
     let routes: Vec<Route> = pythonize::depythonize_bound(routes)?;
-    let resolved =
-        junction_core::check_route(routes, &method, &url, &headers, search_config.as_ref())
+    let cluster_name =
+        junction_core::check_route(routes, search_config.as_ref(), &method, &url, &headers)
             .map_err(|e| PyRuntimeError::new_err(format!("failed to resolve: {e}")))?;
 
-    let route = pythonize::pythonize(py, &resolved.route)?;
-    let backend = pythonize::pythonize(py, &resolved.backend)?;
-
-    Ok((route, resolved.rule, backend))
+    Ok(cluster_name)
 }
 
 /// Dump a Route as Kubernetes YAML.
@@ -358,7 +350,8 @@ fn new_client(
     cluster_name: String,
 ) -> PyResult<junction_core::Client> {
     runtime::block_and_check_signals(async {
-        junction_core::Client::build(ads_address, node_name, cluster_name)
+        junction_core::Client::builder(node_name, cluster_name)
+            .build(ads_address)
             .await
             .map_err(|e| match e.source() {
                 Some(cause) => format!("ads connection failed: {e}: {cause}"),
@@ -374,29 +367,11 @@ fn new_client(
 /// setting the JUNCTION_ADS_SERVER, JUNCTION_NODE, and JUNCTION_CLUSTER
 /// environment variables.
 #[pyfunction]
-#[pyo3(signature = (*, static_routes=None, static_backends=None))]
-fn default_client(
-    static_routes: Option<Bound<'_, PyAny>>,
-    static_backends: Option<Bound<'_, PyAny>>,
-) -> PyResult<Junction> {
-    let mut core = match DEFAULT_CLIENT.as_ref() {
-        Ok(default_client) => default_client.clone(),
-        Err(e) => return Err(PyRuntimeError::new_err(e)),
-    };
-
-    let routes = static_routes
-        .map(|routes| pythonize::depythonize_bound(routes))
-        .transpose()?;
-
-    let backends = static_backends
-        .map(|backends| pythonize::depythonize_bound(backends))
-        .transpose()?;
-
-    if routes.is_some() || backends.is_some() {
-        let routes = routes.unwrap_or_default();
-        let backends = backends.unwrap_or_default();
-        core = core.with_static_config(routes, backends);
-    }
+fn default_client() -> PyResult<Junction> {
+    let core = DEFAULT_CLIENT
+        .as_ref()
+        .map_err(|e| PyRuntimeError::new_err(e))?
+        .clone();
 
     Ok(Junction { core })
 }
@@ -408,15 +383,11 @@ impl Junction {
     #[new]
     #[pyo3(signature = (
         *,
-        static_routes=None,
-        static_backends=None,
         ads_server=None,
         node=None,
         cluster=None,
     ))]
     fn new(
-        static_routes: Option<Bound<'_, PyAny>>,
-        static_backends: Option<Bound<'_, PyAny>>,
         ads_server: Option<String>,
         node: Option<String>,
         cluster: Option<String>,
@@ -427,67 +398,9 @@ impl Junction {
         )?;
         let node = env::node_info(node);
         let cluster = env::cluster_name(cluster);
-        let mut core = new_client(ads, node, cluster).map_err(PyRuntimeError::new_err)?;
 
-        let routes = static_routes
-            .map(|routes| pythonize::depythonize_bound(routes))
-            .transpose()?;
-        let backends = static_backends
-            .map(|backends| pythonize::depythonize_bound(backends))
-            .transpose()?;
-        if routes.is_some() || backends.is_some() {
-            let routes = routes.unwrap_or_default();
-            let backends = backends.unwrap_or_default();
-            core = core.with_static_config(routes, backends);
-        }
-
+        let core = new_client(ads, node, cluster).map_err(PyRuntimeError::new_err)?;
         Ok(Junction { core })
-    }
-
-    /// Perform the route resolution half of resolve_http, returning the
-    /// matched route, the index of the matching rule, and the backend that
-    /// was selected. Use it as a lower level method to debug route resolution,
-    /// or to look up Routes without making a full request.
-    ///
-    /// If `dynamic=False` is passed as a kwarg, the resolution happens without
-    /// fetching any new routing data over the network.
-    #[pyo3(signature = (url, *, method=None, headers=None, timeout=None))]
-    fn resolve_route(
-        &self,
-        py: Python<'_>,
-        url: &str,
-        method: Option<&str>,
-        headers: Option<&Bound<PyMapping>>,
-        timeout: Option<u64>,
-    ) -> PyResult<(Py<PyAny>, usize, Py<PyAny>)> {
-        let method = method_from_py(method)?;
-        let url =
-            junction_core::Url::from_str(url).map_err(|e| PyValueError::new_err(format!("{e}")))?;
-        let headers = headers_from_py(headers)?;
-
-        let deadline = timeout.map(|d| Instant::now() + Duration::from_secs(d));
-
-        let request = junction_core::HttpRequest::from_parts(&method, &url, &headers)
-            .map_err(|e| PyValueError::new_err(e.to_string()))?;
-        let resolved =
-            runtime::block_and_check_signals(self.core.resolve_route(request, deadline))?;
-
-        let route = pythonize::pythonize(py, &resolved.route)?;
-        let backend = pythonize::pythonize(py, &resolved.backend)?;
-        Ok((route, resolved.rule, backend))
-    }
-
-    /// Return the list of addresses currently in cache for a backend. These
-    /// endpoints are a snapshot of what is currently in cache.
-    #[pyo3(signature = (backend))]
-    fn get_endpoints(&self, backend: Bound<'_, PyAny>) -> PyResult<Vec<(IpAddr, u16)>> {
-        let backend: BackendId = pythonize::depythonize_bound(backend)?;
-        let endpoint_iter = match self.core.dump_endpoints(&backend) {
-            Some(iter) => iter,
-            None => return Ok(Vec::new()),
-        };
-
-        Ok(endpoint_iter.addrs().map(|a| (a.ip(), a.port())).collect())
     }
 
     /// Resolve an endpoint based on an HTTP method, url, and headers.
@@ -553,43 +466,15 @@ impl Junction {
         Ok(())
     }
 
-    /// Dump the client's current route config.
-    ///
-    /// This is the same merged view of dynamic config and static config that
-    /// the client uses to make routing decisions.
-    fn dump_routes(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
-        let mut values = vec![];
-
-        for route in self.core.dump_routes() {
-            values.push(pythonize::pythonize(py, &route)?);
-        }
-
-        Ok(values)
-    }
-
-    /// Dump the client's backend config.
-    ///
-    /// This is the same merged view of dynamic config and static config that
-    /// the client uses to make load balancing decisions.
-    fn dump_backends(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
-        let mut values = vec![];
-
-        for backend in self.core.dump_backends() {
-            values.push(pythonize::pythonize(py, &backend.config)?);
-        }
-
-        Ok(values)
-    }
-
     /// Dump the client's current xDS config as a pbjson dict.
     ///
     /// The xDS config will contain the latest values for all resources and any
     /// errors encountered while trying to fetch updated versions.
-    #[pyo3(signature = (not_found=false))]
-    fn dump_xds(&self, py: Python<'_>, not_found: bool) -> PyResult<Vec<Py<PyAny>>> {
+    #[pyo3(signature = ())]
+    fn dump_xds(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
         let mut values = vec![];
 
-        for config in self.core.dump_xds(not_found) {
+        for config in self.core.dump_xds() {
             let config: XdsConfig = config.into();
             let as_py = pythonize::pythonize(py, &config)?;
             values.push(as_py);

--- a/junction-python/tests/test_routes.py
+++ b/junction-python/tests/test_routes.py
@@ -23,7 +23,7 @@ def test_check_basic_route_url_port(nginx):
         "rules": [{"backends": [nginx]}],
     }
 
-    (_, _, matched_backend) = junction.check_route(
+    matched_backend = junction.check_route(
         [route],
         "http://nginx.default.svc.cluster.local",
     )
@@ -44,7 +44,7 @@ def test_check_basic_route_url_port_with_ndots(nginx):
         "rules": [{"backends": [nginx]}],
     }
 
-    (_, _, matched_backend) = junction.check_route(
+    matched_backend = junction.check_route(
         [route], "http://nginx.default", search_config=search_config
     )
 

--- a/junction-python/tests/test_urllib3.py
+++ b/junction-python/tests/test_urllib3.py
@@ -1,7 +1,7 @@
 from urllib3 import Retry
 
 from junction.urllib3 import _configure_retries
-from junction import RetryPolicy
+from junction import Retries
 
 
 def retry_equals(r1: Retry, r2: Retry):
@@ -11,7 +11,7 @@ def retry_equals(r1: Retry, r2: Retry):
 def test_retry_policy_only():
     expected = Retry(total=1, status_forcelist=[501, 503], backoff_factor=0.5)
     (actual, redirect_retries) = _configure_retries(
-        retries=None, policy=RetryPolicy(codes=[501, 503], attempts=2, backoff=0.5)
+        retries=None, policy=Retries(codes=[501, 503], attempts=2, backoff=0.5)
     )
 
     assert retry_equals(expected, actual)
@@ -31,7 +31,7 @@ def test_retries_only():
 
 def test_merge_retries_and_policy():
     expected = Retry(total=123, redirect=789, connect=123)
-    policy = RetryPolicy(codes=[501, 503], attempts=2, backoff=0.5)
+    policy = Retries(codes=[501, 503], attempts=2, backoff=0.5)
 
     (actual, redirect_retries) = _configure_retries(
         retries=expected,
@@ -44,7 +44,7 @@ def test_merge_retries_and_policy():
 
 def test_merge_default_retries_and_policy():
     default_retry = Retry.from_int(0)
-    policy = RetryPolicy(codes=[501, 503], attempts=2, backoff=0.5)
+    policy = Retries(codes=[501, 503], attempts=2, backoff=0.5)
 
     (actual, redirect_retries) = _configure_retries(
         retries=default_retry,


### PR DESCRIPTION
Updates `junction-python` to the new API just enough code to pass the smoke test.

> NOTE: this is stacked on top of #196 and #194 and won't merge until they're ready.

#### Unit tests

Our pytests are written against the Junction API, and expect to get a structured `Backend` back from `check_route`. I haven't gone ahead and made that happen in `junction_python` because I'm not sure it's the right thing to do. Eyeballing it, `check_route` is returning the right clusters, but they're string names instead of `Backend` dicts.

#### The smoke test

The big missing thing here is that we don't pass the `ring_hash_test` smoke test - the control plane (`ezbake` and the new one) doesn't actually include Hash Policies in existing listeners, so the client only ever does RingHash load balancing with a random value. We'll have to go back and fix that server side soon.