### PR TITLE
[xds] junction-core: add an actual Trace API

### DIFF
--- a/crates/junction-core/examples/resolve.rs
+++ b/crates/junction-core/examples/resolve.rs
@@ -1,5 +1,7 @@
+use std::time::{Duration, SystemTime};
+
 use http::Method;
-use junction_core::Client;
+use junction_core::{Client, Endpoint};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -16,15 +18,39 @@ async fn main() {
         .await
         .unwrap();
 
-    let endpoint = client
-        .resolve_http(
-            &Method::GET,
-            &"http://httpbin.org".parse().unwrap(),
-            &http::HeaderMap::new(),
-        )
-        .await
-        .unwrap();
+    for _ in 0..10 {
+        let endpoint = client
+            .resolve_http(
+                &Method::GET,
+                &"http://nginx.default.svc.cluster.local".parse().unwrap(),
+                &http::HeaderMap::new(),
+            )
+            .await
+            .unwrap();
 
+        print_trace(&endpoint);
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+fn print_trace(endpoint: &Endpoint) {
     eprintln!("addr={}", endpoint.addr());
-    endpoint.print_trace();
+    let trace = endpoint.trace();
+    let mut last_time = trace.start();
+    for event in trace.events() {
+        let event_time = event.time();
+        let since_start = elapsed_f64(event_time, trace.start());
+        let since_last = elapsed_f64(event_time, last_time);
+        last_time = event_time;
+
+        eprintln!(
+            "  at={since_start:.06} since_last={since_last:.06} kind={kind}",
+            kind = event.kind(),
+        )
+    }
+}
+
+#[inline]
+fn elapsed_f64(t: SystemTime, start: SystemTime) -> f64 {
+    t.duration_since(start).unwrap_or_default().as_secs_f64()
 }

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -1,7 +1,8 @@
 use crate::{
     dns::{self, StdlibResolver},
+    trace::Trace,
     xds::{self, AdsClient, ResourceType, XdsCache},
-    Endpoint, Error, Trace,
+    Endpoint, Error,
 };
 use futures::{stream::FuturesOrdered, StreamExt};
 use rand::{distributions::WeightedError, seq::SliceRandom};
@@ -634,7 +635,7 @@ async fn select_endpoint(
         }
     };
     let Some(endpoints) = load_assignment.endpoints.first() else {
-        return Err(Error::unavailable(trace, "no available endpoints"));
+        return Err(Error::unavailable(trace, "no available endpoint groups"));
     };
 
     // load balance.
@@ -647,7 +648,7 @@ async fn select_endpoint(
         request.previous_addrs,
     );
     let Some(addr) = addr else {
-        return Err(Error::unavailable(trace, "no available endpoints"));
+        return Err(Error::unavailable(trace, "no available end points"));
     };
 
     Ok(SelectedEndpoint { addr: *addr, trace })

--- a/crates/junction-core/src/endpoints.rs
+++ b/crates/junction-core/src/endpoints.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, time::Duration};
 
-use crate::{xds, HttpResult, Trace};
+use crate::{trace::Trace, xds, HttpResult};
 
 #[derive(Debug, Clone)]
 pub struct Retries {
@@ -104,6 +104,10 @@ impl Endpoint {
         &self.retries
     }
 
+    pub fn trace(&self) -> &Trace {
+        &self.trace
+    }
+
     pub(crate) fn should_retry(&self, result: HttpResult) -> bool {
         let Some(retry) = &self.retries else {
             return false;
@@ -123,30 +127,6 @@ impl Endpoint {
         let attempts = self.previous_addrs.len() + 1;
 
         attempts < allowed
-    }
-
-    // FIXME: lol
-    pub fn print_trace(&self) {
-        let start = self.trace.start();
-        let mut phase = None;
-
-        for event in self.trace.events() {
-            if phase != Some(event.phase) {
-                eprintln!("{:?}", event.phase);
-                phase = Some(event.phase);
-            }
-
-            let elapsed = event.at.duration_since(start).as_secs_f64();
-            eprint!("  {elapsed:.06}: {name:>16?}", name = event.kind);
-            if !event.kv.is_empty() {
-                eprint!(":");
-
-                for (k, v) in &event.kv {
-                    eprint!("  {k}={v}")
-                }
-            }
-            eprintln!();
-        }
     }
 }
 

--- a/crates/junction-core/src/error.rs
+++ b/crates/junction-core/src/error.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::Trace;
+use crate::trace::Trace;
 
 /// A `Result` alias where the `Err` case is `junction_core::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -28,6 +28,10 @@ impl Error {
     /// lag fetching a configuration from a Junction server.
     pub fn is_temporary(&self) -> bool {
         matches!(*self.inner, ErrorImpl::TimedOut { .. })
+    }
+
+    pub fn trace(&self) -> Option<&Trace> {
+        self.trace.as_ref()
     }
 }
 

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -2,26 +2,24 @@
 //!
 //! * [Getting Started](https://docs.junctionlabs.io/getting-started/rust)
 
+mod client;
+mod dns;
+mod endpoints;
 mod error;
-mod trace;
 mod url;
-pub use crate::error::{Error, Result};
-pub use crate::url::Url;
+mod xds;
 
 pub(crate) mod hash;
 pub(crate) mod rand;
 
-mod endpoints;
-pub use endpoints::{Endpoint, Retries, Timeouts};
-
-mod client;
-mod dns;
-mod xds;
-
+pub mod trace;
+pub use crate::error::{Error, Result};
+pub use crate::url::Url;
 pub use client::{Client, HttpRequest, HttpResult, SearchConfig, SelectedEndpoint};
-use futures::FutureExt;
-use trace::Trace;
+pub use endpoints::{Endpoint, Retries, Timeouts};
 pub use xds::{IntoXds, ResourceVersion, XdsConfig};
+
+use futures::FutureExt;
 
 /// Check route resolution.
 ///
@@ -45,11 +43,12 @@ pub fn check_route<T: IntoXds>(
     // resolve_routes is async but we know that with StaticConfig, fetching
     // config should NEVER block. now-or-never just calls Poll with a noop
     // waker and unwraps the result ASAP.
-    let resolved = client::resolve_route(&client, &search_config, Trace::new(), request, None)
-        .now_or_never()
-        .expect(
-            "check_route yielded unexpectedly. this is a bug in Junction, please file an issue",
-        )?;
+    let resolved =
+        client::resolve_route(&client, &search_config, trace::Trace::new(), request, None)
+            .now_or_never()
+            .expect(
+                "check_route yielded unexpectedly. this is a bug in Junction, please file an issue",
+            )?;
 
     Ok(resolved.cluster.to_string())
 }

--- a/crates/junction-core/src/trace.rs
+++ b/crates/junction-core/src/trace.rs
@@ -1,32 +1,38 @@
-use std::{net::SocketAddr, time::Instant};
+//! A structured resolution and reporting trace. This is framework/platform
+//! agnostic so that language clients can integrate with their telemetry of
+//! choice.
+//!
+//! # A note on Time
+//!
+//! This struct uses a SystemTime internally for timing to give each event
+//! a sane global timestamp in the context of the rest of the system. This
+//! tends to use `CLOCK_REALTIME` instead of `CLOCK_MONOTONIC` on linux/unix
+//! with all of the timing drawbacks that implies.
+//!
+//! This is the same tradeoff that otel and tracing have to make:
+//! <https://github.com/open-telemetry/opentelemetry-rust/blob/2bf8175d071232eb3667171f2cd8f1eb9324fada/opentelemetry/src/lib.rs#L284>
+
+use std::{fmt::Display, net::SocketAddr, time::SystemTime};
 
 use smol_str::{SmolStr, ToSmolStr};
 
-#[derive(Clone, Debug)]
-pub(crate) struct Trace {
-    start: Instant,
-    phase: TracePhase,
-    events: Vec<TraceEvent>,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct TraceEvent {
-    pub(crate) phase: TracePhase,
-    pub(crate) kind: TraceEventKind,
-    pub(crate) at: Instant,
-    pub(crate) kv: Vec<TraceData>,
-}
-
-type TraceData = (&'static str, SmolStr);
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum TracePhase {
+pub enum TracePhase {
     RouteResolution,
     EndpointSelection(u8),
 }
 
+impl Display for TracePhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TracePhase::RouteResolution => write!(f, "RouteResolution"),
+            TracePhase::EndpointSelection(n) => write!(f, "EndpointSelection({n})"),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum TraceEventKind {
+pub enum EventKind {
     // RouteResolution
     LookupListener,
     LookupRoute,
@@ -40,21 +46,89 @@ pub(crate) enum TraceEventKind {
     LoadBalance,
 }
 
+impl Display for EventKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EventKind::LookupListener => write!(f, "LookupListener"),
+            EventKind::LookupRoute => write!(f, "LookupRoute"),
+            EventKind::MatchRoute => write!(f, "MatchRoute"),
+            EventKind::SelectCluster => write!(f, "SelectCluster"),
+            EventKind::HashRequest => write!(f, "HashRequest"),
+            EventKind::LookupCluster => write!(f, "LookupCluster"),
+            EventKind::LookupEndpoints => write!(f, "LookupEndpoints"),
+            EventKind::LookupDns => write!(f, "LookupDns"),
+            EventKind::LoadBalance => write!(f, "LoadBalance"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Event {
+    phase: TracePhase,
+    kind: EventKind,
+    time: SystemTime,
+    fields: Vec<TraceData>,
+}
+
+impl Event {
+    pub fn phase(&self) -> TracePhase {
+        self.phase
+    }
+
+    pub fn kind(&self) -> EventKind {
+        self.kind
+    }
+
+    pub fn time(&self) -> SystemTime {
+        self.time
+    }
+
+    pub fn fields(&self) -> impl Iterator<Item = (&str, &str)> + '_ {
+        self.fields
+            .iter()
+            .map(|data| (data.name, data.value.as_ref()))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Trace {
+    start: SystemTime,
+    phase: TracePhase,
+    events: Vec<Event>,
+}
+
+impl Trace {
+    pub fn start(&self) -> SystemTime {
+        self.start
+    }
+
+    pub fn events(&self) -> impl Iterator<Item = &Event> + '_ {
+        self.events.iter()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TraceData {
+    name: &'static str,
+    value: SmolStr,
+}
+
+impl TraceData {
+    fn new<T: ToSmolStr>(name: &'static str, value: T) -> Self {
+        Self {
+            name,
+            value: value.to_smolstr(),
+        }
+    }
+}
+
 impl Trace {
     pub(crate) fn new() -> Self {
         Trace {
-            start: Instant::now(),
+            start: SystemTime::now(),
             phase: TracePhase::RouteResolution,
             events: Vec::new(),
         }
-    }
-
-    pub(crate) fn events(&self) -> impl Iterator<Item = &TraceEvent> {
-        self.events.iter()
-    }
-
-    pub(crate) fn start(&self) -> Instant {
-        self.start
     }
 
     // Route Resolution builders
@@ -62,55 +136,55 @@ impl Trace {
     pub(crate) fn lookup_listener(&mut self, listener: String) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::LookupListener,
+        self.events.push(Event {
+            kind: EventKind::LookupListener,
             phase: TracePhase::RouteResolution,
-            at: Instant::now(),
-            kv: vec![("listener", listener.to_smolstr())],
+            time: SystemTime::now(),
+            fields: vec![TraceData::new("listener", listener)],
         })
     }
 
     pub(crate) fn lookup_route(&mut self, route: String) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::LookupRoute,
+        self.events.push(Event {
+            kind: EventKind::LookupRoute,
             phase: TracePhase::RouteResolution,
-            at: Instant::now(),
-            kv: vec![("route", route.to_smolstr())],
+            time: SystemTime::now(),
+            fields: vec![TraceData::new("route", route)],
         })
     }
 
     pub(crate) fn matched_route(&mut self) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::MatchRoute,
+        self.events.push(Event {
+            kind: EventKind::MatchRoute,
             phase: TracePhase::RouteResolution,
-            at: Instant::now(),
-            kv: vec![],
+            time: SystemTime::now(),
+            fields: vec![],
         })
     }
 
     pub(crate) fn select_cluster(&mut self) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
-        self.events.push(TraceEvent {
+        self.events.push(Event {
             phase: self.phase,
-            kind: TraceEventKind::SelectCluster,
-            at: Instant::now(),
-            kv: vec![],
+            kind: EventKind::SelectCluster,
+            time: SystemTime::now(),
+            fields: vec![],
         });
     }
 
     pub(crate) fn hash_request(&mut self, request_hash: u64) {
         debug_assert!(matches!(self.phase, TracePhase::RouteResolution));
 
-        self.events.push(TraceEvent {
+        self.events.push(Event {
             phase: self.phase,
-            kind: TraceEventKind::HashRequest,
-            at: Instant::now(),
-            kv: vec![("request-hash", request_hash.to_smolstr())],
+            kind: EventKind::HashRequest,
+            time: SystemTime::now(),
+            fields: vec![TraceData::new("request-hash", request_hash)],
         });
     }
 
@@ -125,54 +199,57 @@ impl Trace {
     }
 
     pub(crate) fn lookup_cluster(&mut self, cluster: String) {
-        self.events.push(TraceEvent {
+        self.events.push(Event {
             phase: self.phase,
-            kind: TraceEventKind::LookupCluster,
-            at: Instant::now(),
-            kv: vec![("cluster", cluster.to_smolstr())],
+            kind: EventKind::LookupCluster,
+            time: SystemTime::now(),
+            fields: vec![TraceData::new("cluster", cluster)],
         });
     }
 
     pub(crate) fn lookup_endpoints(&mut self, endpoints: String) {
-        self.events.push(TraceEvent {
+        self.events.push(Event {
             phase: self.phase,
-            kind: TraceEventKind::LookupEndpoints,
-            at: Instant::now(),
-            kv: vec![("endpoints", endpoints.to_smolstr())],
+            kind: EventKind::LookupEndpoints,
+            time: SystemTime::now(),
+            fields: vec![TraceData::new("endpoints", endpoints)],
         });
     }
 
     pub(crate) fn lookup_dns(&mut self, hostname: String) {
-        self.events.push(TraceEvent {
+        self.events.push(Event {
             phase: self.phase,
-            kind: TraceEventKind::LookupDns,
-            at: Instant::now(),
-            kv: vec![("hostname", hostname.to_smolstr())],
+            kind: EventKind::LookupDns,
+            time: SystemTime::now(),
+            fields: vec![TraceData::new("hostname", hostname)],
         });
     }
 
-    pub(crate) fn load_balance(
+    pub(crate) fn load_balance<T: ToSmolStr>(
         &mut self,
         lb_name: &'static str,
         addr: Option<&SocketAddr>,
-        extra: Vec<TraceData>,
+        extra: impl IntoIterator<Item = (&'static str, T)>,
     ) {
         debug_assert!(matches!(self.phase, TracePhase::EndpointSelection(_)));
 
-        let mut kv = Vec::with_capacity(extra.len() + 2);
-        kv.push(("type", lb_name.to_smolstr()));
-        kv.push((
+        let extra = extra.into_iter().map(|(k, v)| TraceData::new(k, v));
+        let (extra_len, _) = extra.size_hint();
+
+        let mut fields = Vec::with_capacity(2 + extra_len);
+        fields.push(TraceData::new("type", lb_name));
+        fields.push(TraceData::new(
             "addr",
             addr.map(|a| a.to_smolstr())
-                .unwrap_or_else(|| "-".to_smolstr()),
+                .unwrap_or_else(|| SmolStr::new_static("")),
         ));
-        kv.extend(extra);
+        fields.extend(extra);
 
-        self.events.push(TraceEvent {
-            kind: TraceEventKind::LoadBalance,
+        self.events.push(Event {
+            kind: EventKind::LoadBalance,
             phase: self.phase,
-            at: Instant::now(),
-            kv,
+            time: SystemTime::now(),
+            fields,
         });
     }
 }

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -224,7 +224,7 @@ impl AdsClient {
         };
 
         // TODO: how should we pick this number?
-        let (sub_tx, sub_rx) = mpsc::channel(10);
+        let (sub_tx, sub_rx) = mpsc::channel(16);
 
         let cache = Cache::default();
         let cache_reader = cache.reader();

--- a/crates/junction-core/src/xds/load_balancer.rs
+++ b/crates/junction-core/src/xds/load_balancer.rs
@@ -1,9 +1,8 @@
 use crate::{
     hash::thread_local_xxhash,
+    trace::Trace,
     xds::{clusters::LbPolicy, endpoints::EndpointGroup},
-    Trace,
 };
-use smol_str::ToSmolStr;
 use std::{
     net::SocketAddr,
     sync::{
@@ -75,7 +74,7 @@ impl RoundRobinLb {
         let idx = self.idx.fetch_add(1, Ordering::SeqCst) % endpoint_group.len();
         let addr = endpoint_group.nth(idx);
 
-        trace.load_balance("RoundRobin", addr, Vec::new());
+        trace.load_balance::<u64>("RoundRobin", addr, []);
 
         addr
     }
@@ -120,7 +119,7 @@ impl RingHashLb {
         let endpoint_idx = self.with_ring(endpoints, |r| r.pick(request_hash))?;
         let addr = endpoints.nth(endpoint_idx);
 
-        trace.load_balance("RingHash", addr, vec![("hash", request_hash.to_smolstr())]);
+        trace.load_balance("RingHash", addr, [("hash", request_hash)]);
 
         addr
     }

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -10,7 +10,7 @@ use pyo3::{
     wrap_pyfunction, Bound, Py, PyAny, PyResult, Python,
 };
 use serde::Serialize;
-use std::{net::IpAddr, str::FromStr};
+use std::{net::IpAddr, str::FromStr, time::SystemTime};
 use tracing_subscriber::EnvFilter;
 use xds_api::pb::google::protobuf;
 
@@ -74,9 +74,6 @@ mod env {
 /// An endpoint that an HTTP call can be made to. Includes the address that the
 /// request should resolve to along with the original request URI, the scheme to
 /// use, and the hostname to use for TLS if appropriate.
-//
-// TODO: add http method and shadowing. we can't switch method right now so
-// method is moot.
 #[derive(Clone, Debug)]
 #[pyclass]
 pub struct Endpoint {
@@ -123,8 +120,10 @@ impl Endpoint {
         self.inner.timeouts().clone().map(|t| t.into())
     }
 
-    fn print_trace(&self) {
-        self.inner.print_trace();
+    #[getter]
+    fn trace<'py>(&self) -> Trace {
+        let trace = self.inner.trace().clone();
+        trace.into()
     }
 }
 
@@ -134,10 +133,6 @@ impl From<junction_core::Endpoint> for Endpoint {
     }
 }
 
-//
-// FIXME: this works fine if you keep want to retrying the one address, but best
-// practices is to vary the addresses on a retry, which requires bigger changes
-//
 /// A policy that describes how a client should retry requests.
 #[derive(Clone, Debug)]
 #[pyclass]
@@ -257,6 +252,82 @@ impl From<junction_core::SearchConfig> for SearchConfig {
             search: value.search.into_iter().map(|s| s.to_string()).collect(),
         }
     }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[pyclass]
+pub struct Trace {
+    #[pyo3(get)]
+    start: f64,
+
+    #[pyo3(get)]
+    events: Vec<TraceEvent>,
+}
+
+#[pymethods]
+impl Trace {
+    fn __repr__(&self) -> String {
+        format!("{self:?}")
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let any = pythonize::pythonize(py, self)?;
+        Ok(any)
+    }
+}
+
+impl From<junction_core::trace::Trace> for Trace {
+    fn from(value: junction_core::trace::Trace) -> Self {
+        let trace = value.clone();
+        Self {
+            start: epoch_seconds(trace.start()),
+            events: trace.events().cloned().map(TraceEvent::from).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[pyclass]
+pub struct TraceEvent {
+    #[pyo3(get)]
+    kind: String,
+
+    #[pyo3(get)]
+    phase: String,
+
+    #[pyo3(get)]
+    time: f64,
+
+    #[pyo3(get)]
+    fields: Vec<(String, String)>,
+}
+
+#[pymethods]
+impl TraceEvent {
+    fn __repr__(&self) -> String {
+        format!("{self:?}")
+    }
+}
+
+impl From<junction_core::trace::Event> for TraceEvent {
+    fn from(value: junction_core::trace::Event) -> Self {
+        Self {
+            kind: value.kind().to_string(),
+            phase: value.phase().to_string(),
+            time: epoch_seconds(value.time()),
+            fields: value
+                .fields()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+}
+
+#[inline]
+fn epoch_seconds(t: SystemTime) -> f64 {
+    t.duration_since(SystemTime::UNIX_EPOCH)
+        .expect("timestamp before unix epoch")
+        .as_secs_f64()
 }
 
 /// Check route resolution.


### PR DESCRIPTION
Adds an actual public API for the internal traces the client generates. We're walking a bit of a fine line trying to expose data but hide internal representations in favor of `name()` and `time()` methods. `TracePhase` and `EventKind` enums are directly exposed, but I'm not actually sure that's a good idea.

Also includes types for exposing traces In the Python client so you can mess with them in the repl:

```python
>>> e = junction.resolve_http("http://nginx.default.svc.cluster.local")
>>> pprint(e.trace.events)
[
│   TraceEvent { kind: "LookupListener", phase: "RouteResolution", time: 1751588448.260102, fields: [("listener", "nginx.default.svc.cluster.local:80")] },
│   TraceEvent { kind: "MatchRoute", phase: "RouteResolution", time: 1751588448.260108, fields: [] },
│   TraceEvent { kind: "SelectCluster", phase: "RouteResolution", time: 1751588448.260108, fields: [] },
│   TraceEvent { kind: "HashRequest", phase: "RouteResolution", time: 1751588448.260162, fields: [("request-hash", "4170473710033342862")] },
│   TraceEvent { kind: "LookupCluster", phase: "EndpointSelection(0)", time: 1751588448.260399, fields: [("cluster", "nginx.default.svc.cluster.local:80")] },
│   TraceEvent { kind: "LookupEndpoints", phase: "EndpointSelection(0)", time: 1751588448.260751, fields: [("endpoints", "nginx.default.svc.cluster.local:80")] },
│   TraceEvent { kind: "LoadBalance", phase: "EndpointSelection(0)", time: 1751588448.260757, fields: [("type", "RoundRobin"), ("addr", "192.168.194.80:80")] }
]
```
