### PR TITLE
[xds] junction-core: clippy cleanup

### DIFF
--- a/crates/junction-api-gen/src/python.rs
+++ b/crates/junction-api-gen/src/python.rs
@@ -272,7 +272,7 @@ impl std::fmt::Display for PyType {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", py_ty)?;
+                    write!(f, "{py_ty}")?;
                 }
 
                 write!(f, "]")

--- a/crates/junction-api/src/error.rs
+++ b/crates/junction-api/src/error.rs
@@ -96,7 +96,7 @@ where
         if i > 0 && path_entry.is_field() {
             buf.push('.');
         }
-        let _ = write!(&mut buf, "{}", path_entry);
+        let _ = write!(&mut buf, "{path_entry}");
     }
 
     buf

--- a/crates/junction-api/src/shared.rs
+++ b/crates/junction-api/src/shared.rs
@@ -100,7 +100,7 @@ impl<'de> Deserialize<'de> for Regex {
             {
                 match Regex::from_str(value) {
                     Ok(s) => Ok(s),
-                    Err(e) => Err(E::custom(format!("could not parse {}: {}", value, e))),
+                    Err(e) => Err(E::custom(format!("could not parse {value}: {e}"))),
                 }
             }
         }

--- a/crates/junction-api/src/xds/backend.rs
+++ b/crates/junction-api/src/xds/backend.rs
@@ -17,8 +17,8 @@ use crate::{
     BackendId, Service,
 };
 
-impl junction_core::IntoXds for Backend {
-    fn into_any(&self) -> Vec<(String, xds_api::pb::google::protobuf::Any)> {
+impl junction_core::ToXds for Backend {
+    fn to_any(&self) -> Vec<(String, xds_api::pb::google::protobuf::Any)> {
         let cluster = self.to_xds();
         let any = protobuf::Any::from_msg(&cluster).unwrap();
         vec![(cluster.name.clone(), any)]

--- a/crates/junction-api/src/xds/http.rs
+++ b/crates/junction-api/src/xds/http.rs
@@ -47,8 +47,8 @@ impl From<&Route> for xds_route::RouteConfiguration {
     }
 }
 
-impl junction_core::IntoXds for Route {
-    fn into_any(&self) -> Vec<(String, protobuf::Any)> {
+impl junction_core::ToXds for Route {
+    fn to_any(&self) -> Vec<(String, protobuf::Any)> {
         let route = self.to_xds();
         let route_name = route.name.clone();
 

--- a/crates/junction-api/src/xds/http.rs
+++ b/crates/junction-api/src/xds/http.rs
@@ -54,21 +54,18 @@ impl junction_core::ToXds for Route {
 
         let mut xds = vec![];
         for hostname in &self.hostnames {
-            match &hostname {
-                crate::http::HostnameMatch::Exact(hostname) => {
-                    let ports = if self.ports.is_empty() {
-                        &[80, 443]
-                    } else {
-                        self.ports.as_slice()
-                    };
+            if let crate::http::HostnameMatch::Exact(hostname) = &hostname {
+                let ports = if self.ports.is_empty() {
+                    &[80, 443]
+                } else {
+                    self.ports.as_slice()
+                };
 
-                    for &port in ports {
-                        let listener = api_listener_rds(hostname, port, &route_name);
-                        let listener_name = listener.name.clone();
-                        xds.push((listener_name, protobuf::Any::from_msg(&listener).unwrap()));
-                    }
+                for &port in ports {
+                    let listener = api_listener_rds(hostname, port, &route_name);
+                    let listener_name = listener.name.clone();
+                    xds.push((listener_name, protobuf::Any::from_msg(&listener).unwrap()));
                 }
-                _ => (),
             }
         }
 

--- a/crates/junction-core/src/client.rs
+++ b/crates/junction-core/src/client.rs
@@ -343,38 +343,6 @@ impl Client {
         })
     }
 
-    /// Resolve an HTTP method, URL, and headers to a target backend, returning
-    /// the Route that matched, the index of the rule that matched, and the
-    /// backend that was chosen - to make backend choice determinstic with
-    /// multiple backends, set the `JUNCTION_SEED` environment variable.
-    ///
-    /// This is a lower-level method that only performs the Route matching part
-    /// of resolution. It's intended for debugging or querying a client for
-    /// specific information. For everyday use, prefer [Client::resolve_http].
-    // pub async fn resolve_route(
-    //     &self,
-    //     request: HttpRequest<'_>,
-    //     deadline: Option<Instant>,
-    // ) -> crate::Result<xds::ResourceName> {
-    //     let trace = Trace::new();
-    //     resolve_route(&self.config, trace, request, deadline, &self.search_config).await
-    // }
-
-    /// Select an endpoint address for this backend from the set of currently
-    /// available endpoints.
-    ///
-    /// This is a lower level method that only performs part of route
-    /// resolution, and is intended for debugging and testing. For everyday use,
-    /// prefer [Client::resolve_http].
-    // pub async fn select_endpoint(
-    //     &self,
-    //     backend: &BackendId,
-    //     ctx: LbContext<'_>,
-    //     deadline: Option<Instant>,
-    // ) -> crate::Result<SelectedEndpoint> {
-    //     select_endpoint(&self.config, backend, ctx, deadline).await
-    // }
-
     /// Start a gRPC CSDS server on the given port. To run the server, you must
     /// `await` this future.
     ///
@@ -410,9 +378,9 @@ enum RouteConfigRef {
 impl AsRef<xds::RouteConfiguration> for RouteConfigRef {
     fn as_ref(&self) -> &xds::RouteConfiguration {
         match self {
-            RouteConfigRef::Route(route) => &route,
+            RouteConfigRef::Route(route) => route,
             RouteConfigRef::Inlined(listener) => match &listener.route_config {
-                xds::listeners::RouteConfig::Inline(route) => &route,
+                xds::listeners::RouteConfig::Inline(route) => route,
                 _ => panic!("expected an inline RouteConfiguration"),
             },
         }
@@ -487,7 +455,7 @@ pub(crate) async fn resolve_route(
     let route_config = match &listener.route_config {
         xds::listeners::RouteConfig::Rds(name) => {
             match with_deadline!(
-                cache.get_route_config(&name),
+                cache.get_route_config(name),
                 deadline,
                 "fetching route",
                 trace
@@ -575,7 +543,7 @@ async fn select_endpoint(
 
     // lookup cluster
     let cluster = with_deadline!(
-        cache.get_cluster(&cluster_name),
+        cache.get_cluster(cluster_name),
         deadline,
         "fetching cluster",
         trace,
@@ -593,7 +561,7 @@ async fn select_endpoint(
     let load_assignment = match &cluster.endpoints {
         xds::clusters::Endpoints::Eds(name) => {
             let load_assignment = with_deadline!(
-                cache.get_load_assignment(&name),
+                cache.get_load_assignment(name),
                 deadline,
                 "fetching endpoints",
                 trace
@@ -644,7 +612,7 @@ async fn select_endpoint(
     let addr = cluster.load_balancer.load_balance(
         &mut trace,
         request.request_hash,
-        &endpoints,
+        endpoints,
         request.previous_addrs,
     );
     let Some(addr) = addr else {
@@ -678,7 +646,7 @@ fn find_match<'a>(
     let mut matching_vhost = None;
     let hostname = request.url.hostname();
     for vhost in &route.vhosts {
-        if vhost.domains.iter().any(|d| d.matches_hostname(&hostname)) {
+        if vhost.domains.iter().any(|d| d.matches_hostname(hostname)) {
             matching_vhost = Some(vhost);
         }
     }
@@ -703,7 +671,10 @@ fn is_method_match(
     method_match: &Option<xds::route_configs::MethodMatcher>,
     method: &http::Method,
 ) -> bool {
-    method_match.as_ref().is_none_or(|m| m.is_match(method))
+    match method_match.as_ref() {
+        None => true,
+        Some(m) => m.is_match(method),
+    }
 }
 
 #[inline]
@@ -1038,7 +1009,7 @@ mod test {
         ])
         .unwrap();
 
-        dbg!(cache.get_route_config(&ResourceName::from("passthrough-route")));
+        cache.get_route_config(&ResourceName::from("passthrough-route"));
 
         let wont_match = [
             "http://example.com?qp1=tomato",

--- a/crates/junction-core/src/dns.rs
+++ b/crates/junction-core/src/dns.rs
@@ -893,7 +893,7 @@ options ndots:1 ndots:a-potato ndots:3";
         );
 
         let load_assigment = resolver
-            .get_endpoints(&"www.junctionlabs.io", 7777)
+            .get_endpoints("www.junctionlabs.io", 7777)
             .unwrap();
         let endpoints = load_assigment.endpoints.first().unwrap();
         let endpoints: Vec<_> = endpoints.iter().cloned().collect();
@@ -921,7 +921,7 @@ options ndots:1 ndots:a-potato ndots:3";
 
         // inserting the old answer shouldn't do anything
         resolver.insert_answer(
-            &"www.example.com",
+            "www.example.com",
             now,
             Ok(vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80)]),
         );

--- a/crates/junction-core/src/dns.rs
+++ b/crates/junction-core/src/dns.rs
@@ -892,9 +892,7 @@ options ndots:1 ndots:a-potato ndots:3";
             "should return true when a new port is inserted"
         );
 
-        let load_assigment = resolver
-            .get_endpoints("www.junctionlabs.io", 7777)
-            .unwrap();
+        let load_assigment = resolver.get_endpoints("www.junctionlabs.io", 7777).unwrap();
         let endpoints = load_assigment.endpoints.first().unwrap();
         let endpoints: Vec<_> = endpoints.iter().cloned().collect();
         assert_eq!(

--- a/crates/junction-core/src/lib.rs
+++ b/crates/junction-core/src/lib.rs
@@ -17,7 +17,7 @@ pub use crate::error::{Error, Result};
 pub use crate::url::Url;
 pub use client::{Client, HttpRequest, HttpResult, SearchConfig, SelectedEndpoint};
 pub use endpoints::{Endpoint, Retries, Timeouts};
-pub use xds::{IntoXds, ResourceVersion, XdsConfig};
+pub use xds::{ResourceVersion, ToXds, XdsConfig};
 
 use futures::FutureExt;
 
@@ -29,7 +29,7 @@ use futures::FutureExt;
 /// Use this function to test routing configuration without requiring a full
 /// client or a live connection to a control plane. For route resolution against,
 /// a live control plane, see [Client::resolve_http].
-pub fn check_route<T: IntoXds>(
+pub fn check_route<T: ToXds>(
     resources: impl IntoIterator<Item = T>,
     search_config: Option<&SearchConfig>,
     method: &http::Method,
@@ -37,7 +37,7 @@ pub fn check_route<T: IntoXds>(
     headers: &http::HeaderMap,
 ) -> Result<String> {
     let request = client::HttpRequest::from_parts(method, url, headers);
-    let client = xds::StaticCache::with_xds(resources.into_iter()).unwrap();
+    let client = xds::StaticCache::with_xds(resources).unwrap();
     let search_config = search_config.cloned().unwrap_or_default();
 
     // resolve_routes is async but we know that with StaticConfig, fetching

--- a/crates/junction-core/src/xds.rs
+++ b/crates/junction-core/src/xds.rs
@@ -89,14 +89,14 @@ pub(crate) trait XdsCache {
 }
 
 /// Any type that can be converted into xDS.
-pub trait IntoXds {
+pub trait ToXds {
     /// Convert this type into a k,v pair of a unique name and an xDS message,
     /// serialized as a protobuf `Any`.
-    fn into_any(&self) -> Vec<(String, protobuf::Any)>;
+    fn to_any(&self) -> Vec<(String, protobuf::Any)>;
 
     /// Covert this type into a vec of [Resource](xds_discovery::Resource).
-    fn into_resources(&self, version: String) -> Vec<xds_discovery::Resource> {
-        self.into_any()
+    fn to_resources(&self, version: String) -> Vec<xds_discovery::Resource> {
+        self.to_any()
             .into_iter()
             .map(|(name, any)| xds_discovery::Resource {
                 name,
@@ -108,20 +108,19 @@ pub trait IntoXds {
     }
 }
 
-impl IntoXds for &xds_discovery::Resource {
-    fn into_any(&self) -> Vec<(String, protobuf::Any)> {
+impl ToXds for &xds_discovery::Resource {
+    fn to_any(&self) -> Vec<(String, protobuf::Any)> {
         vec![(self.name.clone(), self.resource.clone().unwrap())]
     }
 }
 
 impl StaticCache {
-    pub(crate) fn with_xds<T: IntoXds>(
+    pub(crate) fn with_xds<T: ToXds>(
         xds: impl IntoIterator<Item = T>,
     ) -> Result<Self, Vec<ResourceError>> {
         let xds = xds
             .into_iter()
-            .map(|x| x.into_any())
-            .flatten()
+            .flat_map(|x| x.to_any())
             .map(|(s, any)| (ResourceName::from(s), any));
 
         let mut cache = StaticCache::default();

--- a/crates/junction-core/src/xds/cache.rs
+++ b/crates/junction-core/src/xds/cache.rs
@@ -157,7 +157,7 @@ impl<T> ResourceMap<T> {
     }
 
     fn get<'a>(&'a self, name: &ResourceName) -> Option<ResourceMapEntryRef<'a, T>> {
-        self.map.get(name).map(|r| r)
+        self.map.get(name)
     }
 
     async fn get_await<'a>(&'a self, name: &ResourceName) -> Option<ResourceMapEntryRef<'a, T>> {
@@ -613,7 +613,7 @@ impl Cache {
     /// Return the current list of subscriptions for this resource type.
     #[cfg(test)]
     pub(crate) fn subscriptions(&self, rtype: ResourceType) -> Vec<ResourceName> {
-        self.subs.explicit(rtype).map(|s| s.clone()).collect()
+        self.subs.explicit(rtype).cloned().collect()
     }
 
     pub(crate) fn dns_names(&self) -> Vec<DnsAddr> {
@@ -1527,7 +1527,7 @@ mod test {
         );
 
         // check that the first set of resources makes sense
-        let _ = dbg!(cache.collect());
+        let _ = cache.collect();
         assert_eq!(
             cache.versions(ResourceType::Listener),
             versions![("listener.example.svc.cluster.local", "v123")],

--- a/crates/junction-core/src/xds/resources.rs
+++ b/crates/junction-core/src/xds/resources.rs
@@ -110,7 +110,7 @@ fn path_str(path: &[PathEntry]) -> String {
         if i > 0 && matches!(path_entry, PathEntry::Field(_)) {
             buf.push('.');
         }
-        let _ = write!(&mut buf, "{}", path_entry);
+        let _ = write!(&mut buf, "{path_entry}");
     }
 
     buf

--- a/crates/junction-core/src/xds/resources/endpoints.rs
+++ b/crates/junction-core/src/xds/resources/endpoints.rs
@@ -94,7 +94,7 @@ impl Resource for LoadAssignment {
                 }
 
                 // parse the address and save it by locality/priority
-                let socket_addr = xds_lb_endpoint_socket_addr(&lb_endpoint)
+                let socket_addr = xds_lb_endpoint_socket_addr(lb_endpoint)
                     .with_field_index("lb_endpoints", lb_idx)
                     .with_field_index("endpoints", endpoints_idx)?;
                 locality_endpoints.push(socket_addr);
@@ -114,10 +114,11 @@ impl Resource for LoadAssignment {
             EndpointGroup::new(priority, endpoints)
         });
         let endpoints: Vec<_> = endpoints.collect();
-        assert!(
-            endpoints.is_sorted_by_key(|e| e.priority),
-            "EndpointGroups are ordered by priority: this is a bug in Junction",
-        );
+        // TODO: this assert isn't valid until MSRV is 1.82
+        // assert!(
+        //     endpoints.is_sorted_by_key(|e| e.priority),
+        //     "EndpointGroups are ordered by priority: this is a bug in Junction",
+        // );
         Ok(Self { endpoints })
     }
 

--- a/crates/junction-core/src/xds/resources/listeners.rs
+++ b/crates/junction-core/src/xds/resources/listeners.rs
@@ -22,7 +22,7 @@ impl Resource for ApiListener {
     fn from_xds(xds: &Self::Xds) -> Result<Self, ResourceError> {
         use xds_http::http_connection_manager::RouteSpecifier;
 
-        let conn_manager = http_connection_manager(&xds).with_field("api_listener")?;
+        let conn_manager = http_connection_manager(xds).with_field("api_listener")?;
 
         let route_config = match &conn_manager.route_specifier {
             Some(RouteSpecifier::Rds(rds)) => {

--- a/crates/junction-core/src/xds/resources/route_configs.rs
+++ b/crates/junction-core/src/xds/resources/route_configs.rs
@@ -147,8 +147,8 @@ impl Action {
                 };
 
                 let hash_policies = vec_from_xds!(action.hash_policy, "hash_policy", HashPolicy)?;
-                let retries = Retries::from_xds(&action)?;
-                let timeouts = Timeouts::from_xds(&action)?;
+                let retries = Retries::from_xds(action)?;
+                let timeouts = Timeouts::from_xds(action)?;
 
                 Ok(Self {
                     hash_policies,
@@ -157,7 +157,7 @@ impl Action {
                     timeouts,
                 })
             }
-            _ => return Err(ResourceError::invalid("unsupported action")),
+            _ => Err(ResourceError::invalid("unsupported action")),
         }
     }
 }
@@ -309,7 +309,7 @@ impl Matcher {
             .path_specifier
             .as_ref()
             .ok_or_else(|| ResourceError::invalid("missing path specifier"))
-            .and_then(|p| PathMatcher::from_xds(p))
+            .and_then(PathMatcher::from_xds)
             .with_field("path_specifier")?;
 
         let query = vec_from_xds!(xds.query_parameters, "query_parameters", QueryMatcher)?;
@@ -493,7 +493,7 @@ fn from_ascii(bs: &[u8]) -> Option<&str> {
     if !bs.is_ascii() {
         return None;
     }
-    Some(str::from_utf8(bs).expect("expected a valid ascii string"))
+    Some(std::str::from_utf8(bs).expect("expected a valid ascii string"))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/junction-core/src/xds/test.rs
+++ b/crates/junction-core/src/xds/test.rs
@@ -435,7 +435,6 @@ pub fn route_to_cluster(
                     },
                 ),
             ),
-            ..Default::default()
         };
         route_match.query_parameters = vec![query_matcher];
     }
@@ -519,7 +518,7 @@ pub fn logical_dns_cluster(
     let cluster_discovery_type = Some(ClusterDiscoveryType::Type(DiscoveryType::LogicalDns.into()));
     let host_identifier = Some(xds_endpoint::lb_endpoint::HostIdentifier::Endpoint(
         xds_endpoint::Endpoint {
-            address: Some(to_xds_address(&hostname, port)),
+            address: Some(to_xds_address(hostname, port)),
             ..Default::default()
         },
     ));

--- a/junction-python/samples/smoke-test/client.py
+++ b/junction-python/samples/smoke-test/client.py
@@ -49,9 +49,7 @@ class SessionFactory:
             self._kubectl_apply(*manifests)
             self.delete_resources = manifests
         if backends:
-            manifests = [
-                junction.dump_kube_backend(backend) for backend in backends
-            ]
+            manifests = [junction.dump_kube_backend(backend) for backend in backends]
             self._kubectl_patch(*manifests)
             for manifest in manifests:
                 spec = yaml.safe_load(manifest)


### PR DESCRIPTION
> NOTE: This is tacked on top of #198, and will get rebased when that lands.

I've been avoiding running clippy while everything is a mess. Here's a big clippy run with the changes from `junction-api`, `junction-core`,  and `junction-python` all split out into their own commits.