### PR TITLE
junction-core: show NOT_FOUND status in CSDS

### DIFF
--- a/crates/junction-core/src/xds/csds.rs
+++ b/crates/junction-core/src/xds/csds.rs
@@ -106,8 +106,8 @@ impl ClientStatusDiscoveryService for Server {
 fn to_generic_config(config: XdsConfig) -> GenericXdsConfig {
     let client_status = match (&config.xds, &config.last_error) {
         (_, Some(_)) => ClientResourceStatus::Nacked,
-        (Some(_), None) => ClientResourceStatus::Acked,
-        _ => ClientResourceStatus::Unknown,
+        (Some(_), _) => ClientResourceStatus::Acked,
+        (None, _) => ClientResourceStatus::DoesNotExist,
     };
     let version_info = config.version.map(|v| v.to_string()).unwrap_or_default();
 


### PR DESCRIPTION
I was messing with client debuggability and noticed that we don't show NOT_FOUND statuses when a resource is NOT_FOUND. Let's do that.

Before:

```json
{
  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
  "name": "fake-does-not-exist:80",
}
```

After:

```json
{
  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
  "name": "fake-does-not-exist:80",
  "clientStatus": "DOES_NOT_EXIST"
}
```