### PR TITLE
[xds] Dependency cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,7 @@ dependencies = [
  "pyo3-build-config 0.22.6",
  "pythonize",
  "serde",
- "serde_yml",
+ "serde_yaml",
  "tokio",
  "tracing-subscriber",
  "xds-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,12 +98,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,25 +415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-skiplist"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1065,7 +1040,6 @@ dependencies = [
  "junction-typeinfo",
  "k8s-openapi",
  "kube",
- "once_cell",
  "rand",
  "regex",
  "serde",
@@ -1092,9 +1066,7 @@ dependencies = [
 name = "junction-core"
 version = "0.3.2"
 dependencies = [
- "arc-swap",
  "bytes",
- "crossbeam-skiplist",
  "dashmap",
  "enum-map",
  "form_urlencoded",
@@ -1108,8 +1080,6 @@ dependencies = [
  "rand",
  "regex",
  "serde",
- "serde_json",
- "serde_yml",
  "smol_str",
  "thiserror 2.0.12",
  "tokio",
@@ -1127,10 +1097,8 @@ name = "junction-node"
 version = "0.3.2"
 dependencies = [
  "http 1.2.0",
- "junction-api",
  "junction-core",
  "neon",
- "once_cell",
  "tokio",
 ]
 
@@ -1146,7 +1114,6 @@ dependencies = [
  "pyo3-build-config 0.22.6",
  "pythonize",
  "serde",
- "serde_json",
  "serde_yml",
  "tokio",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,7 @@ license = "Apache-2.0"
 rust-version = "1.81"
 
 [workspace.dependencies]
-arc-swap = "1.7"
 bytes = "1.7"
-crossbeam-skiplist = "0.1"
 dashmap = "6.1"
 enum-map = "2.7"
 form_urlencoded = "1.1.1"
@@ -41,7 +39,6 @@ thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 xds-api = { version = "0.2", default-features = false }
-
 xxhash-rust = { version = "0.8.15", features = ["xxh64"] }
 
 junction-api = { version = "0.3.2", path = "crates/junction-api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.8"
 regex = "1.11.1"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
-serde_yml = "0.0.12"
+serde_yaml = "0.9"
 smol_str = "0.3"
 thiserror = "2.0"
 tracing = "0.1"

--- a/crates/junction-api/Cargo.toml
+++ b/crates/junction-api/Cargo.toml
@@ -18,7 +18,6 @@ serde = { workspace = true, default-features = false, features = ["derive"] }
 serde_json = { workspace = true }
 smol_str = { workspace = true }
 thiserror = { workspace = true }
-once_cell = { workspace = true }
 
 # typeinfo
 junction-typeinfo = { workspace = true, optional = true }

--- a/crates/junction-core/Cargo.toml
+++ b/crates/junction-core/Cargo.toml
@@ -17,9 +17,7 @@ categories = [
 rust-version.workspace = true
 
 [dependencies]
-arc-swap = { workspace = true }
 bytes = { workspace = true }
-crossbeam-skiplist = { workspace = true }
 dashmap = { workspace = true }
 enum-map = { workspace = true }
 form_urlencoded = { workspace = true }
@@ -32,8 +30,6 @@ prost = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
-serde_json = { workspace = true }
-serde_yml = { workspace = true }
 smol_str = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time", "macros"] }

--- a/junction-node/Cargo.toml
+++ b/junction-node/Cargo.toml
@@ -20,8 +20,6 @@ crate-type = ["cdylib"]
 [dependencies]
 http = { workspace = true }
 neon = { version = "1.0", default-features = false, features = ["napi-8"] }
-once_cell = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 junction-core = { workspace = true }
-junction-api = { workspace = true, features = ["kube_v1_29", "xds"] }

--- a/junction-python/Cargo.toml
+++ b/junction-python/Cargo.toml
@@ -21,7 +21,7 @@ junction-core = { workspace = true }
 junction-api = { workspace = true, features = ["kube_v1_29", "xds"] }
 once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_yml = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 xds-api = { workspace = true, features = ["pbjson"] }

--- a/junction-python/Cargo.toml
+++ b/junction-python/Cargo.toml
@@ -21,7 +21,6 @@ junction-core = { workspace = true }
 junction-api = { workspace = true, features = ["kube_v1_29", "xds"] }
 once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
 serde_yml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true }

--- a/junction-python/src/lib.rs
+++ b/junction-python/src/lib.rs
@@ -377,7 +377,7 @@ fn dump_kube_route(route: Bound<'_, PyAny>, namespace: String) -> PyResult<Strin
     let kube_route = route
         .to_gateway_httproute(&namespace)
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
-    Ok(serde_yml::to_string(&kube_route)
+    Ok(serde_yaml::to_string(&kube_route)
         .expect("Serialization failed. This is a bug in Junction, not your code."))
 }
 
@@ -395,7 +395,7 @@ fn dump_kube_backend(backend: Bound<'_, PyAny>) -> PyResult<String> {
     let backend: Backend = pythonize::depythonize_bound(backend)?;
     let patch = backend.to_service_patch();
 
-    Ok(serde_yml::to_string(&patch)
+    Ok(serde_yaml::to_string(&patch)
         .expect("Serialization failed. This is a bug in Junction, not your code."))
 }
 


### PR DESCRIPTION
There are two commits here:

9a8fca1d8aa937cf485305c515e3b36c9a251c73 removes unused dependencies, as reported by [cargo machete](https://github.com/bnjbvr/cargo-machete). There's nothing too exciting about that!

ec372a0203f02ec24cfebf04883f3c83afe3a65a is a little spicier - it moves us back to the (deprecated) `serde_yaml` from `serde_yml`. There's a lot of context in the kube-rs repo (https://github.com/kube-rs/kube/issues/1770) that I stumbled over last week, and it convinced me that we should adopt the same stance. 